### PR TITLE
:memo: Fixed remaining fragments from the move to `cda-tum` and adjusted the tracking of publications

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,9 +11,9 @@ body:
         **Thank you for wanting to report a bug for this project!**
 
         ⚠
-        Verify first that your issue is not [already reported on GitHub](https://github.com/marcelwa/fiction/search?q=is%3Aissue&type=issues).
+        Verify first that your issue is not [already reported on GitHub](https://github.com/cda-tum/fiction/search?q=is%3Aissue&type=issues).
 
-        If you are having general questions, please consider [starting a discussion](https://github.com/marcelwa/fiction/discussions).
+        If you are having general questions, please consider [starting a discussion](https://github.com/cda-tum/fiction/discussions).
   - type: markdown
     attributes:
       value: >-

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -11,7 +11,7 @@ body:
         **Thank you for wanting to suggest a feature for this project!**
 
         ⚠
-        Verify first that your idea is not [already requested on GitHub](https://github.com/marcelwa/fiction/search?q=is%3Aissue&type=issues).
+        Verify first that your idea is not [already requested on GitHub](https://github.com/cda-tum/fiction/search?q=is%3Aissue&type=issues).
 
   - type: textarea
     attributes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y install \
 RUN pip3 install z3-solver==4.10.0
 
 # Clone fiction's repository including submodules
-RUN git clone --recursive https://github.com/marcelwa/fiction.git
+RUN git clone --recursive https://github.com/cda-tum/fiction.git
 
 # Build fiction
 RUN cmake -S fiction -B fiction/build \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 </p>
 
 This code base provides a framework for **fi**eld-**c**oupled **t**echnology-**i**ndependent **o**pen **n**anocomputing
-developed as part of the _Munich Nanotech Toolkit_ (_MNT_) by the [Chair for Design Automation](https://www.cda.cit.tum.de/)
+developed as part of the _Munich Nanotech Toolkit_ (_MNT_) by
+the [Chair for Design Automation](https://www.cda.cit.tum.de/)
 at the [Technical University of Munich](https://www.tum.de/). It is written in C++17 using the
 [EPFL Logic Synthesis Libraries](https://github.com/lsils/lstools-showcase). Thereby, *fiction*
 focuses on the logic synthesis, placement, routing, clocking, and verification of emerging nanotechnologies. As a
@@ -297,3 +298,23 @@ Cell-level layouts:
 - Number of cells
 - Bounding box
 - Area usage in nm²
+
+# Reference
+
+In case you are using *fiction* in your work, we would be thankful if you referred to it by citing the following
+publication:
+
+```bibtex
+@misc{fiction,
+      author = {Walter, Marcel and Wille, Robert and Sill Torres, Frank and Gro{\ss}e, Daniel and Drechsler, Rolf},
+      title = {{fiction: An Open Source Framework for the Design of Field-coupled Nanocomputing Circuits}},
+      archivePrefix = {arXiv},
+      eprint = {1905.02477},
+      note = {arXiv:1905.02477},
+      year = {2019},
+      month = {May}
+}
+```
+
+Additionally, many algorithms implemented in *fiction* have been published individually. For a full list of publications
+based upon *fiction*, please refer to the [documentation](https://fiction.readthedocs.io/en/latest/publications.html).

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,7 +6,7 @@ We value contributions from people with all levels of experience.
 In particular if this is your first pull request, not everything has to be perfect.
 We will guide you through the process.
 
-We use GitHub to `host code <https://github.com/marcelwa/fiction>`_, to `track issues and feature requests <https://github.com/marcelwa/fiction/issues>`_, as well as accept `pull requests <https://github.com/marcelwa/fiction/pulls>`_.
+We use GitHub to `host code <https://github.com/cda-tum/fiction>`_, to `track issues and feature requests <https://github.com/cda-tum/fiction/issues>`_, as well as accept `pull requests <https://github.com/cda-tum/fiction/pulls>`_.
 See https://docs.github.com/en/get-started/quickstart for a general introduction to working with GitHub and contributing to projects.
 
 Types of Contributions
@@ -15,25 +15,25 @@ Types of Contributions
 You can contribute in several ways:
 
 - 🐛 Report Bugs
-    Report bugs at https://github.com/marcelwa/fiction/issues using the *🐛 Bug report* issue template. Please make sure to fill out all relevant information in the respective issue form.
+    Report bugs at https://github.com/cda-tum/fiction/issues using the *🐛 Bug report* issue template. Please make sure to fill out all relevant information in the respective issue form.
 
 - 🐛 Fix Bugs
-    Look through the `GitHub Issues <https://github.com/marcelwa/fiction/issues>`_ for bugs. Anything tagged with "bug" is open to whoever wants to try and fix it.
+    Look through the `GitHub Issues <https://github.com/cda-tum/fiction/issues>`_ for bugs. Anything tagged with "bug" is open to whoever wants to try and fix it.
 
 - ✨ Propose New Features
-    Propose new features at https://github.com/marcelwa/fiction/issues using the *✨ Feature request* issue template. Please make sure to fill out all relevant information in the respective issue form.
+    Propose new features at https://github.com/cda-tum/fiction/issues using the *✨ Feature request* issue template. Please make sure to fill out all relevant information in the respective issue form.
 
 - ✨ Implement New Features
-    Look through the `GitHub Issues <https://github.com/marcelwa/fiction/issues>`_ for features. Anything tagged with "enhancement" is open to whoever wants to implement it. We highly appreciate external contributions to the project.
+    Look through the `GitHub Issues <https://github.com/cda-tum/fiction/issues>`_ for features. Anything tagged with "enhancement" is open to whoever wants to implement it. We highly appreciate external contributions to the project.
 
 - ✔️ Write Tests
-    We can always use more tests to ensure that the code base is robust and stable. If you want to help out, you can start by looking through the `CodeCov report <https://app.codecov.io/gh/marcelwa/fiction>`_ to find out where we missed covering lines.
+    We can always use more tests to ensure that the code base is robust and stable. If you want to help out, you can start by looking through the `CodeCov report <https://app.codecov.io/gh/cda-tum/fiction>`_ to find out where we missed covering lines.
 
 - 📝 Write Documentation
     *fiction* could always use some more `documentation <https://fiction.readthedocs.io/en/latest/>`_, and we appreciate any help with that.
 
-🎉 Getting Started
-##################
+First Contributions
+###################
 
 Ready to contribute? Check out the `documentation <https://fiction.readthedocs.io/en/latest/>`_ to set up *fiction* for local development and learn about the style guidelines and conventions used throughout the project.
 

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -24,96 +24,109 @@ If you use *fiction* in your work, we would appreciate if you cited
       month = {May}
     }
 
-Furthermore, if you use any of the design automation algorithms :ref:`exact <exact>`, :ref:`ortho <ortho>`,
-:ref:`onepass <onepass>`, :ref:`equiv <equiv>`, :ref:`color routing <color_routing>`, :ref:`QuickSim <quicksim>`,
-:ref:`critical temperature simulation <critical_temperature>`, or :ref:`hexagonalization <hexagonalization>`
-please consider citing their respective papers as well:
+Furthermore, if you use any of the design automation algorithms, please consider citing their respective papers as well.
 
-.. code-block:: tex
+* :ref:`Exact physical design <exact>` (``exact``):
 
-    @inproceedings{walter2018exact,
-      title={{An Exact Method for Design Exploration of Quantum-dot Cellular Automata}},
-      author={Walter, Marcel and Wille, Robert and Gro{\ss}e, Daniel and Sill Torres, Frank and Drechsler, Rolf},
-      booktitle={Design, Automation and Test in Europe Conference \& Exhibition},
-      pages = {503--508},
-      year={2018}
-    }
+    .. code-block:: tex
 
-.. code-block:: tex
+        @inproceedings{walter2018exact,
+          title={{An Exact Method for Design Exploration of Quantum-dot Cellular Automata}},
+          author={Walter, Marcel and Wille, Robert and Gro{\ss}e, Daniel and Sill Torres, Frank and Drechsler, Rolf},
+          booktitle={Design, Automation and Test in Europe Conference \& Exhibition},
+          pages = {503--508},
+          year={2018}
+        }
 
-    @inproceedings{walter2019ortho,
-      title={{Scalable Design for Field-coupled Nanocomputing Circuits}},
-      author={Walter, Marcel and Wille, Robert and Sill Torres, Frank and Gro{\ss}e, Daniel and Drechsler, Rolf},
-      booktitle={Asia and South Pacific Design Automation Conference},
-      pages={197--202},
-      year={2019},
-      publisher={ACM New York, NY, USA}
-    }
+* :ref:`Scalable physical design <ortho>` (``ortho``):
 
-.. code-block:: tex
+    .. code-block:: tex
 
-    @inproceedings{walter2021onepass,
-      title={{One-pass Synthesis for Field-coupled Nanocomputing Technologies}},
-      author={Walter, Marcel and Haaswijk, W. and Wille, Robert and Sill Torres, Frank and Drechsler, Rolf},
-      booktitle={Asia and South Pacific Design Automation Conference},
-      pages={574--580},
-      year={2021},
-      publisher={ACM New York, NY, USA}
-    }
+        @inproceedings{walter2019ortho,
+          title={{Scalable Design for Field-coupled Nanocomputing Circuits}},
+          author={Walter, Marcel and Wille, Robert and Sill Torres, Frank and Gro{\ss}e, Daniel and Drechsler, Rolf},
+          booktitle={Asia and South Pacific Design Automation Conference},
+          pages={197--202},
+          year={2019},
+          publisher={ACM New York, NY, USA}
+        }
 
-.. code-block:: tex
+* :ref:`One-pass synthesis <onepass>` (``onepass``):
 
-    @inproceedings{walter2020equiv,
-      title={{Verification for Field-coupled Nanocomputing Circuits}},
-      author={Walter, Marcel and Wille, Robert and Sill Torres, Frank and D. Gro{\ss}e and Drechsler, Rolf},
-      booktitle={Design Automation Conference},
-      year={2020}
-    }
+    .. code-block:: tex
 
-.. code-block:: tex
+        @inproceedings{walter2021onepass,
+          title={{One-pass Synthesis for Field-coupled Nanocomputing Technologies}},
+          author={Walter, Marcel and Haaswijk, W. and Wille, Robert and Sill Torres, Frank and Drechsler, Rolf},
+          booktitle={Asia and South Pacific Design Automation Conference},
+          pages={574--580},
+          year={2021},
+          publisher={ACM New York, NY, USA}
+        }
 
-    @inproceedings{walter2022colorrouting,
-      title={{Efficient Multi-Path Signal Routing for Field-coupled Nanotechnologies}},
-      author={Walter, Marcel and Wille, Robert},
-      booktitle={International Symposium on Nanoscale Architectures},
-      year={2022}
-    }
+* :ref:`Equivalence checking <equiv>` (``equiv``):
 
-.. code-block:: tex
+    .. code-block:: tex
 
-    @inproceedings{drewniok2023quicksimIEEE,
-      title={{\emph{QuickSim}: Efficient \emph{and} Accurate Physical Simulation of Silicon Dangling Bond Logic}},
-      author={Drewniok, Jan and Walter, Marcel and Ng, Samuel Sze Hang and Walus, Konrad and Wille, Robert},
-      booktitle={IEEE International Conference on Nanotechnology (IEEE-NANO)},
-      year={2023}
-    }
+        @inproceedings{walter2020equiv,
+          title={{Verification for Field-coupled Nanocomputing Circuits}},
+          author={Walter, Marcel and Wille, Robert and Sill Torres, Frank and D. Gro{\ss}e and Drechsler, Rolf},
+          booktitle={Design Automation Conference},
+          year={2020}
+        }
 
-.. code-block:: tex
+* :ref:`Multi-path routing <color_routing>` (``color_routing``):
 
-    @inproceedings{drewniok2023temperatureIEEE,
-      title={{Temperature Behavior of Silicon Dangling Bond Logic}},
-      author={Drewniok, Jan and Walter, Marcel and Wille, Robert},
-      booktitle={IEEE International Conference on Nanotechnology (IEEE-NANO)},
-      year={2023}
-    }
+    .. code-block:: tex
 
-.. code-block:: tex
+        @inproceedings{walter2022colorrouting,
+          title={{Efficient Multi-Path Signal Routing for Field-coupled Nanotechnologies}},
+          author={Walter, Marcel and Wille, Robert},
+          booktitle={International Symposium on Nanoscale Architectures},
+          year={2022}
+        }
 
-    @inproceedings{hofmann2023hexagonalization,
-      title={{Scalable Physical Design for Silicon Dangling Bond Logic: How a 45\textdegree~Turn Prevents the Reinvention of the Wheel}},
-      author={Hofmann, Simon and Walter, Marcel and Wille, Robert},
-      booktitle={IEEE International Conference on Nanotechnology (IEEE-NANO)},
-      year={2023}
-    }
+* :ref:`QuickSim <quicksim>` (``quicksim``):
 
-The same holds for the :ref:`Bestagon <bestagon>` gate library:
+    .. code-block:: tex
 
-.. code-block:: tex
+        @inproceedings{drewniok2023quicksimIEEE,
+          title={{\emph{QuickSim}: Efficient \emph{and} Accurate Physical Simulation of Silicon Dangling Bond Logic}},
+          author={Drewniok, Jan and Walter, Marcel and Ng, Samuel Sze Hang and Walus, Konrad and Wille, Robert},
+          booktitle={IEEE International Conference on Nanotechnology (IEEE NANO)},
+          year={2023}
+        }
 
-    @inproceedings{walter2022hexagons,
-      title={{Hexagons are the Bestagons: Design Automation for Silicon Dangling Bond Logic}},
-      author={Walter, Marcel and Ng, Samuel Sze Hang and Walus, Konrad and Wille, Robert},
-      booktitle={Design Automation Conference},
-      pages = {739--744},
-      year={2022}
-    }
+* :ref:`Critical temperature simulation <critical_temperature>` (``critical_temperature``):
+
+    .. code-block:: tex
+
+        @inproceedings{drewniok2023temperatureIEEE,
+          title={{Temperature Behavior of Silicon Dangling Bond Logic}},
+          author={Drewniok, Jan and Walter, Marcel and Wille, Robert},
+          booktitle={IEEE International Conference on Nanotechnology (IEEE NANO)},
+          year={2023}
+        }
+
+* :ref:`Mapping Cartesian to hexagonal layouts <hexagonalization>` (``hexagonalization``):
+
+    .. code-block:: tex
+
+        @inproceedings{hofmann2023hexagonalization,
+          title={{Scalable Physical Design for Silicon Dangling Bond Logic: How a 45\textdegree~Turn Prevents the Reinvention of the Wheel}},
+          author={Hofmann, Simon and Walter, Marcel and Wille, Robert},
+          booktitle={IEEE International Conference on Nanotechnology (IEEE NANO)},
+          year={2023}
+        }
+
+* :ref:`SiDB Bestagon library <bestagon>`:
+
+    .. code-block:: tex
+
+        @inproceedings{walter2022hexagons,
+          title={{Hexagons are the Bestagons: Design Automation for Silicon Dangling Bond Logic}},
+          author={Walter, Marcel and Ng, Samuel Sze Hang and Walus, Konrad and Wille, Robert},
+          booktitle={Design Automation Conference},
+          pages = {739--744},
+          year={2022}
+        }

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,12 +1,12 @@
 Support
 =======
 
-If you are stuck with a problem using *fiction* or are having questions, please do get in touch at our `Issues <https://github.com/marcelwa/fiction/issues>`_ or `Discussions <https://github.com/marcelwa/fiction/discussions>`_. We'd love to help.
+If you are stuck with a problem using *fiction* or are having questions, please do get in touch at our `Issues <https://github.com/cda-tum/fiction/issues>`_ or `Discussions <https://github.com/cda-tum/fiction/discussions>`_. We'd love to help.
 
 You can save time by following this procedure when reporting a problem:
 
 - Do try to solve the problem on your own first. Make sure to consult the `Documentation <https://fiction.readthedocs.io/en/latest/>`_.
-- Search through past `Issues <https://github.com/marcelwa/fiction/issues>`_ to see if someone else already had the same problem.
+- Search through past `Issues <https://github.com/cda-tum/fiction/issues>`_ to see if someone else already had the same problem.
 - Before filing a bug report, try to create a minimal working example (MWE) that reproduces the problem. It's much easier to identify the cause for the problem if a handful of lines suffice to show that something isn't working.
 
 You can also always reach us at `fcn.cda@xcit.tum.de <mailto:fcn.cda@xcit.tum.de>`_.

--- a/include/fiction/algorithms/physical_design/hexagonalization.hpp
+++ b/include/fiction/algorithms/physical_design/hexagonalization.hpp
@@ -51,7 +51,7 @@ template <typename CartLyt, typename HexLyt>
 /**
  * Transforms a 2DDWave-clocked Cartesian layout into a hexagonal even row clocked layout suitable for SiDBs by
  * remapping all gates and wires as originally proposed in \"Scalable Physical Design for Silicon Dangling Bond Logic:
- * How a 45° Turn Prevents the Reinvention of the Wheel\" by S. Hofmann, M. Walter, and R. Wille in IEEE Nano 2023.
+ * How a 45° Turn Prevents the Reinvention of the Wheel\" by S. Hofmann, M. Walter, and R. Wille in IEEE NANO 2023.
  *
  * @param Lyt Gate-level layout that is 2DDWave-clocked.
  *

--- a/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
+++ b/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
@@ -447,7 +447,7 @@ class critical_temperature_impl
 /**
  *
  * This algorithm performs temperature-aware SiDB simulation as proposed in \"Temperature Behavior of Silicon Dangling
- * Bond Logic\" by J. Drewniok, M. Walter, and R. Wille in IEEE-NANO 2023. It comes in two flavors: gate-based and
+ * Bond Logic\" by J. Drewniok, M. Walter, and R. Wille in IEEE NANO 2023. It comes in two flavors: gate-based and
  * non-gate based, which can be specified using the `critical_temperature_mode` parameter.
  *
  * For gate-based simulation, the Critical Temperature is defined as follows: The temperature at which the excited

--- a/include/fiction/algorithms/simulation/sidb/quicksim.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quicksim.hpp
@@ -51,7 +51,7 @@ struct quicksim_params
 
 /**
  * The *QuickSim* algorithm which was proposed in \"QuickSim: Efficient and Accurate Physical Simulation of Silicon
- * Dangling Bond Logic\" by J. Drewniok, M. Walter, S. S. H. Ng, K. Walus, and R. Wille in IEEE-NANO 2023 is an
+ * Dangling Bond Logic\" by J. Drewniok, M. Walter, S. S. H. Ng, K. Walus, and R. Wille in IEEE NANO 2023 is an
  * electrostatic ground state simulation algorithm for SiDB layouts. It determines physically valid charge
  * configurations (with minimal energy) of a given (already initialized) charge distribution layout. Depending on the
  * simulation parameters, the ground state is found with a certain probability after one run.

--- a/include/fiction/utils/version_info.hpp.in
+++ b/include/fiction/utils/version_info.hpp.in
@@ -15,7 +15,7 @@ inline constexpr const char* FICTION_VERSION = "@CMAKE_PROJECT_NAME@ v@PROJECT_V
 /**
  * Repository string.
  */
-inline constexpr const char* FICTION_REPO = "https://github.com/marcelwa/fiction";
+inline constexpr const char* FICTION_REPO = "https://github.com/cda-tum/fiction";
 /**
  * Compiled at the stored date.
  */


### PR DESCRIPTION
## Description

The move to @cda-tum left behind some inconsistencies in *fiction*'s documentation. This PR attempts to fix them while also restructuring the tracking of publications and their respective bibTeX files.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
