### PR TITLE
:bug: Fix `equivalence_checking` on `obstruction_layout` objects

### DIFF
--- a/include/fiction/layouts/obstruction_layout.hpp
+++ b/include/fiction/layouts/obstruction_layout.hpp
@@ -56,7 +56,7 @@ class obstruction_layout<Lyt, false> : public Lyt
     /**
      * Standard constructor for empty layouts.
      */
-    obstruction_layout() : Lyt(), strg{std::make_shared<obstruction_layout_storage>()}
+    obstruction_layout() : Lyt(), obstr_strg{std::make_shared<obstruction_layout_storage>()}
     {
         static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
     }
@@ -65,7 +65,7 @@ class obstruction_layout<Lyt, false> : public Lyt
      *
      * @param lyt Existing layout that is to be extended by an obstruction interface.
      */
-    explicit obstruction_layout(const Lyt& lyt) : Lyt(lyt), strg{std::make_shared<obstruction_layout_storage>()}
+    explicit obstruction_layout(const Lyt& lyt) : Lyt(lyt), obstr_strg{std::make_shared<obstruction_layout_storage>()}
     {
         static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
     }
@@ -76,7 +76,7 @@ class obstruction_layout<Lyt, false> : public Lyt
      */
     void obstruct_coordinate(const typename Lyt::coordinate& c) noexcept
     {
-        strg->obstructed_coordinates.insert(c);
+        obstr_strg->obstructed_coordinates.insert(c);
     }
     /**
      * Marks the connection from coordinate `src` to coordinate `tgt` as obstructed.
@@ -88,7 +88,7 @@ class obstruction_layout<Lyt, false> : public Lyt
      */
     void obstruct_connection(const typename Lyt::coordinate& src, const typename Lyt::coordinate& tgt) noexcept
     {
-        strg->obstructed_connections.insert({src, tgt});
+        obstr_strg->obstructed_connections.insert({src, tgt});
     }
     /**
      * Clears the obstruction status of the given coordinate `c` if the obstruction was manually marked via
@@ -98,7 +98,7 @@ class obstruction_layout<Lyt, false> : public Lyt
      */
     void clear_obstructed_coordinate(const typename Lyt::coordinate& c) noexcept
     {
-        strg->obstructed_coordinates.erase(c);
+        obstr_strg->obstructed_coordinates.erase(c);
     }
     /**
      * Clears the obstruction status of the connection from coordinate `src` to coordinate `tgt` if the obstruction was
@@ -109,21 +109,21 @@ class obstruction_layout<Lyt, false> : public Lyt
      */
     void clear_obstructed_connection(const typename Lyt::coordinate& src, const typename Lyt::coordinate& tgt) noexcept
     {
-        strg->obstructed_connections.erase({src, tgt});
+        obstr_strg->obstructed_connections.erase({src, tgt});
     }
     /**
      * Clears all obstructed coordinates that were manually marked via `obstruct_coordinate`.
      */
     void clear_obstructed_coordinates() noexcept
     {
-        strg->obstructed_coordinates.clear();
+        obstr_strg->obstructed_coordinates.clear();
     }
     /**
      * Clears all obstructed connections that were manually marked via `obstruct_connection`.
      */
     void clear_obstructed_connections() noexcept
     {
-        strg->obstructed_connections.clear();
+        obstr_strg->obstructed_connections.clear();
     }
     /**
      * Checks if the given coordinate is obstructed of some sort.
@@ -133,7 +133,7 @@ class obstruction_layout<Lyt, false> : public Lyt
      */
     [[nodiscard]] bool is_obstructed_coordinate(const typename Lyt::coordinate& c) const noexcept
     {
-        if (strg->obstructed_coordinates.count(c) > 0)
+        if (obstr_strg->obstructed_coordinates.count(c) > 0)
         {
             return true;
         }
@@ -160,7 +160,7 @@ class obstruction_layout<Lyt, false> : public Lyt
     [[nodiscard]] bool is_obstructed_connection(const typename Lyt::coordinate& src,
                                                 const typename Lyt::coordinate& tgt) const noexcept
     {
-        if (strg->obstructed_connections.count({src, tgt}) > 0)
+        if (obstr_strg->obstructed_connections.count({src, tgt}) > 0)
         {
             return true;
         }
@@ -176,7 +176,7 @@ class obstruction_layout<Lyt, false> : public Lyt
     }
 
   private:
-    storage strg;
+    storage obstr_strg;
 };
 
 template <class T>

--- a/test/algorithms/verification/equivalence_checking.cpp
+++ b/test/algorithms/verification/equivalence_checking.cpp
@@ -8,6 +8,7 @@
 #include "utils/blueprints/network_blueprints.hpp"
 
 #include <fiction/algorithms/verification/equivalence_checking.hpp>
+#include <fiction/layouts/obstruction_layout.hpp>
 #include <fiction/networks/technology_network.hpp>
 #include <fiction/types.hpp>
 
@@ -92,6 +93,16 @@ TEST_CASE("Network-layout equivalence", "[equiv]")
                                blueprints::and_or_gate_layout<hex_even_row_gate_clk_lyt>());
         check_for_strong_equiv(blueprints::and_or_network<fiction::technology_network>(),
                                blueprints::and_or_gate_layout<hex_odd_row_gate_clk_lyt>());
+    }
+    SECTION("Obstruction layout")
+    {
+        const auto lyt       = blueprints::and_or_gate_layout<cart_gate_clk_lyt>();
+        const auto obstr_lyt = obstruction_layout{lyt};
+
+        check_for_strong_equiv(blueprints::and_or_network<mockturtle::aig_network>(), obstr_lyt);
+        check_for_strong_equiv(blueprints::and_or_network<mockturtle::mig_network>(), obstr_lyt);
+        check_for_strong_equiv(blueprints::and_or_network<mockturtle::xag_network>(), obstr_lyt);
+        check_for_strong_equiv(blueprints::and_or_network<fiction::technology_network>(), obstr_lyt);
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes unintended behavior, namely that `equivalence_checking` and `gate_level_drvs` could not be executed on `obstruction_layout` objections.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
