### PR TITLE
:sparkles: Enhanced pathfinding versatility

### DIFF
--- a/docs/algorithms/path_finding.rst
+++ b/docs/algorithms/path_finding.rst
@@ -84,6 +84,7 @@ Enumerate All Paths
 
 **Header:** ``fiction/algorithms/path_finding/enumerate_all_paths.hpp``
 
-.. doxygenstruct:: fiction::enumerate_all_clocking_paths_params
+.. doxygenstruct:: fiction::enumerate_all_paths_params
    :members:
+.. doxygenfunction:: fiction::enumerate_all_coordinate_paths
 .. doxygenfunction:: fiction::enumerate_all_clocking_paths

--- a/docs/algorithms/path_finding.rst
+++ b/docs/algorithms/path_finding.rst
@@ -86,5 +86,4 @@ Enumerate All Paths
 
 .. doxygenstruct:: fiction::enumerate_all_paths_params
    :members:
-.. doxygenfunction:: fiction::enumerate_all_coordinate_paths
-.. doxygenfunction:: fiction::enumerate_all_clocking_paths
+.. doxygenfunction:: fiction::enumerate_all_paths

--- a/include/fiction/algorithms/graph/generate_edge_intersection_graph.hpp
+++ b/include/fiction/algorithms/graph/generate_edge_intersection_graph.hpp
@@ -103,8 +103,8 @@ class generate_edge_intersection_graph_impl
                           if (!ps.path_limit.has_value())
                           {
                               // enumerate all paths for the current objective
-                              obj_paths = enumerate_all_clocking_paths<clk_path>(
-                                  obstruction_layout{layout}, {obj.source, obj.target}, {ps.crossings});
+                              obj_paths = enumerate_all_paths<clk_path>(obstruction_layout{layout},
+                                                                        {obj.source, obj.target}, {ps.crossings});
                           }
                           else
                           {

--- a/include/fiction/algorithms/path_finding/a_star.hpp
+++ b/include/fiction/algorithms/path_finding/a_star.hpp
@@ -370,12 +370,12 @@ class a_star_impl
  *
  * In certain cases it might be desirable to determine regular coordinate paths even if the layout implements a clocking
  * interface. This can be achieved by static-casting the layout to a coordinate layout when calling this function:
- * \code{.cpp}
+ * @code{.cpp}
  * using clk_lyt = clocked_layout<cartesian_layout<>>;
  * using path = layout_coordinate_path<cartesian_layout<>>;
  * clk_lyt layout = ...;
  * auto shortest_path = a_star<path>(static_cast<cartesian_layout<>>(layout), {source, target});
- * \endcode
+ * @endcode
  *
  * A* was introduced in \"A Formal Basis for the Heuristic Determination of Minimum Cost Paths\" by Peter E. Hart, Nils
  * J. Nilsson, and Bertram Raphael in IEEE Transactions on Systems Science and Cybernetics 1968, Volume 4, Issue 2.
@@ -405,7 +405,8 @@ template <typename Path, typename Lyt, typename Dist = uint64_t, typename Cost =
 }
 /**
  * A distance function that does not approximate but compute the actual minimum path length on the given layout via A*
- * traversal. Naturally, this function cannot be evaluated in \f$ O(1) \f$, but has the polynomial complexity of A*.
+ * traversal. Naturally, this function cannot be evaluated in \f$ \mathcal(O)(1) \f$, but has the polynomial complexity
+ * of A*.
  *
  * If no path between `source` and `target` exists in `layout`, the returned distance is
  * `std::numeric_limits<Dist>::infinity()` if that value is supported by `Dist`, or `std::numeric_limits<Dist>::max()`,

--- a/include/fiction/algorithms/path_finding/a_star.hpp
+++ b/include/fiction/algorithms/path_finding/a_star.hpp
@@ -58,7 +58,7 @@ class a_star_impl
      *
      * @return The shortest path in `layout` from `objective.source` to `objective.target`.
      */
-    Path run()
+    [[nodiscard]] Path run() noexcept
     {
         assert(!objective.source.is_dead() && !objective.target.is_dead() &&
                "Neither source nor target coordinate can be dead");
@@ -381,7 +381,7 @@ class a_star_impl
  *
  * This implementation is based on the pseudocode from https://en.wikipedia.org/wiki/A_star_search_algorithm.
  *
- * @tparam Path Path type to create.
+ * @tparam Path Type of the returned path.
  * @tparam Lyt Type of the layout to perform path finding on.
  * @tparam Dist Distance value type to be used in the heuristic estimation function.
  * @tparam Cost Cost value type to be used when determining moving cost between coordinates.

--- a/include/fiction/algorithms/path_finding/a_star.hpp
+++ b/include/fiction/algorithms/path_finding/a_star.hpp
@@ -353,11 +353,12 @@ class a_star_impl
 /**
  * The A* path finding algorithm for shortest loop-less paths between a given source and target coordinate in a layout.
  * This function automatically detects whether the given layout implements a clocking interface (see `clocked_layout`)
- * and respects the underlying information flow imposed by `layout`'s clocking scheme. A* is an extension of Dijkstra's
- * algorithm for shortest paths but offers better average complexity. It uses a heuristic distance function that
- * estimates the remaining costs towards the target in every step. Thus, this heuristic function should neither be
- * complex to calculate nor overestimating the remaining costs. Common heuristics to be used are the Manhattan and the
- * Euclidean distance functions. See `distance_functor` for implementations.
+ * and respects the underlying information flow imposed by `layout`'s clocking scheme.
+ *
+ * A* is an extension of Dijkstra's algorithm for shortest paths but offers better average complexity. It uses a
+ * heuristic distance function that estimates the remaining costs towards the target in every step. Thus, this heuristic
+ * function should neither be complex to calculate nor overestimating the remaining costs. Common heuristics to be used
+ * are the Manhattan and the Euclidean distance functions. See `distance_functor` for implementations.
  *
  * If the given layout implements the obstruction interface (see `obstruction_layout`), paths will not be routed via
  * obstructed coordinates and connections.

--- a/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
+++ b/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
@@ -221,12 +221,12 @@ class enumerate_all_paths_impl
  *
  * In certain cases it might be desirable to enumerate regular coordinate paths even if the layout implements a clocking
  * interface. This can be achieved by static-casting the layout to a coordinate layout when calling this function:
- * \code{.cpp}
+ * @code{.cpp}
  * using clk_lyt = clocked_layout<cartesian_layout<>>;
  * using path = layout_coordinate_path<cartesian_layout<>>;
  * clk_lyt layout = ...;
  * auto all_paths = enumerate_all_paths<path>(static_cast<cartesian_layout<>>(layout), {source, target});
- * \endcode
+ * @endcode
  *
  * @tparam Path Type of the returned individual paths.
  * @tparam Lyt Type of the layout to perform path finding on.

--- a/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
+++ b/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
@@ -42,7 +42,7 @@ class enumerate_all_paths_impl
      *
      * @return A collection of all unique paths in `layout` from `objective.source` to `objective.target`.
      */
-    [[nodiscard]] path_collection<Path> run()
+    [[nodiscard]] path_collection<Path> run() noexcept
     {
         assert(!objective.source.is_dead() && !objective.target.is_dead() &&
                "Neither source nor target coordinate can be dead");
@@ -225,7 +225,7 @@ class enumerate_all_paths_impl
  * using clk_lyt = clocked_layout<cartesian_layout<>>;
  * using path = layout_coordinate_path<cartesian_layout<>>;
  * clk_lyt layout = ...;
- * auto paths = enumerate_all_paths<path>(static_cast<cartesian_layout<>>(layout), {source, target});
+ * auto all_paths = enumerate_all_paths<path>(static_cast<cartesian_layout<>>(layout), {source, target});
  * \endcode
  *
  * @tparam Path Type of the returned individual paths.

--- a/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
+++ b/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
@@ -38,9 +38,9 @@ class enumerate_all_paths_impl
     {}
 
     /**
-     * Enumerate all possible paths in a layout that start at `source` and lead to `target`.
+     * Enumerate all possible paths in a layout that start at `objective.source` and lead to `objective.target`.
      *
-     * @return A collection of all unique paths in `layout` from `source` to `target`.
+     * @return A collection of all unique paths in `layout` from `objective.source` to `objective.target`.
      */
     [[nodiscard]] path_collection<Path> run()
     {
@@ -205,11 +205,11 @@ class enumerate_all_paths_impl
 }  // namespace detail
 
 /**
- * Enumerates all possible paths in a layout that start at coordinate `source` and lead to coordinate `target`. This
- * function automatically detects whether the given layout implements a clocking interface (see `clocked_layout`) and
- * respects the underlying information flow imposed by `layout`'s clocking scheme. This algorithm does neither generate
- * duplicate nor looping paths, even in a cyclic clocking scheme. That is, along each path, each coordinate can occur at
- * maximum once.
+ * Enumerates all possible paths in a layout that start at a given source coordinate and lead to given target
+ * coordinate. This function automatically detects whether the given layout implements a clocking interface (see
+ * `clocked_layout`) and respects the underlying information flow imposed by `layout`'s clocking scheme. This algorithm
+ * does neither generate duplicate nor looping paths, even in a cyclic clocking scheme. That is, along each path, each
+ * coordinate can occur at maximum once.
  *
  * If the given layout implements the obstruction interface (see `obstruction_layout`), paths will not be routed via
  * obstructed coordinates or connections.
@@ -233,7 +233,7 @@ class enumerate_all_paths_impl
  * @param layout The layout whose paths are to be enumerated.
  * @param objective Source-target coordinate pair.
  * @param params Parameters.
- * @return A collection of all unique paths in `layout` from `source` to `target`.
+ * @return A collection of all unique paths in `layout` from `objective.source` to `objective.target`.
  */
 template <typename Path, typename Lyt>
 [[nodiscard]] path_collection<Path> enumerate_all_paths(const Lyt& layout, const routing_objective<Lyt>& objective,

--- a/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
+++ b/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
@@ -14,9 +14,9 @@ namespace fiction
 {
 
 /**
- * Parameters for the algorithm that enumerates all paths in a clocked layout.
+ * Parameters for the algorithm that enumerates all paths in a layout.
  */
-struct enumerate_all_clocking_paths_params
+struct enumerate_all_paths_params
 {
     /**
      * Allow paths to cross over obstructed tiles if they are occupied by wire segments.
@@ -28,17 +28,21 @@ namespace detail
 {
 
 template <typename Path, typename Lyt>
-class enumerate_all_clocking_paths_impl
+class enumerate_all_paths_impl
 {
   public:
-    enumerate_all_clocking_paths_impl(const Lyt& lyt, const routing_objective<Lyt>& obj,
-                                      const enumerate_all_clocking_paths_params p) :
+    enumerate_all_paths_impl(const Lyt& lyt, const routing_objective<Lyt>& obj, const enumerate_all_paths_params p) :
             layout{lyt},
             objective{obj},
             ps{p}
     {}
 
-    [[nodiscard]] path_collection<Path> run()
+    /**
+     * Enumerate all possible coordinate paths in a layout that start at `source` and lead to `target`.
+     *
+     * @return A collection of all unique paths in `layout` from `source` to `target`.
+     */
+    [[nodiscard]] path_collection<Path> coordinate_paths()
     {
         assert(!objective.source.is_dead() && !objective.target.is_dead() &&
                "Neither source nor target coordinate can be dead");
@@ -46,37 +50,108 @@ class enumerate_all_clocking_paths_impl
         assert(layout.is_within_bounds(objective.source) && layout.is_within_bounds(objective.target) &&
                "Both source and target coordinate have to be within the layout bounds");
 
-        recursively_enumerate_all_paths(objective.source, objective.target, Path{});
+        recursively_enumerate_all_paths<path_level::COORDINATES>(objective.source, objective.target, Path{});
+
+        return collection;
+    }
+    /**
+     * Enumerate all possible clocking paths in a layout that start at `source` and lead to `target`.
+     *
+     * @return A collection of all unique paths in `layout` from `source` to `target`.
+     */
+    [[nodiscard]] path_collection<Path> clocking_paths()
+    {
+        assert(!objective.source.is_dead() && !objective.target.is_dead() &&
+               "Neither source nor target coordinate can be dead");
+
+        assert(layout.is_within_bounds(objective.source) && layout.is_within_bounds(objective.target) &&
+               "Both source and target coordinate have to be within the layout bounds");
+
+        recursively_enumerate_all_paths<path_level::CLOCKING>(objective.source, objective.target, Path{});
 
         return collection;
     }
 
   private:
+    /**
+     * The layout whose paths are to be enumerated.
+     */
     const Lyt& layout;
-
+    /**
+     * The source-target coordinate pair.
+     */
     const routing_objective<Lyt> objective;
-
-    enumerate_all_clocking_paths_params ps;
-
+    /**
+     * Routing parameters.
+     */
+    enumerate_all_paths_params ps;
+    /**
+     * Set of visited coordinates.
+     */
     phmap::flat_hash_set<coordinate<Lyt>> visited{};
-
+    /**
+     * Collection of all enumerated paths.
+     */
     path_collection<Path> collection{};
-
+    /**
+     * Abstraction levels on which paths can be enumerated.
+     */
+    enum class path_level
+    {
+        /**
+         * Enumerate paths on the coordinate level.
+         */
+        COORDINATES,
+        /**
+         * Enumerate paths on the clocking level.
+         */
+        CLOCKING
+        // more path levels go here
+    };
+    /**
+     * Mark a coordinate as visited.
+     *
+     * @param c Coordinate to mark as visited.
+     */
     void mark_visited(const coordinate<Lyt>& c) noexcept
     {
         visited.insert(c);
     }
-
+    /**
+     * Mark a coordinate as unvisited.
+     *
+     * @param c Coordinate to mark as unvisited.
+     */
     void mark_unvisited(const coordinate<Lyt>& c) noexcept
     {
         visited.erase(c);
     }
-
+    /**
+     * Check if a coordinate has been visited.
+     *
+     * @param c Coordinate to check.
+     * @return `true` if the coordinate has been visited, `false` otherwise.
+     */
     [[nodiscard]] bool is_visited(const coordinate<Lyt>& c) const noexcept
     {
         return visited.count(c) > 0;
     }
-
+    /**
+     * Recursively enumerate all paths from `src` to `tgt` in the given layout. This function is called recursively
+     * until the target coordinate is reached. Along each path, each coordinate can occur at maximum once. This function
+     * does not generate duplicate or looping paths. If the given layout implements the obstruction interface (see
+     * `obstruction_layout`), paths will not be routed via obstructed coordinates or connections. If the given layout is
+     * a gate-level layout and implements the obstruction interface (see `obstruction_layout`), paths may contain wire
+     * crossings if specified in the parameters. Wire crossings are only allowed over other wires and only if the
+     * crossing layer is not obstructed. Furthermore, it is ensured that crossings do not run along another wire but
+     * cross only in a single point (orthogonal crossings + knock-knees/double wires).
+     *
+     * @tparam PathLevel Abstraction level on which to enumerate paths.
+     * @param src Source coordinate.
+     * @param tgt Target coordinate.
+     * @param p Current path to extend.
+     */
+    template <path_level PathLevel>
     void recursively_enumerate_all_paths(const coordinate<Lyt>& src, const coordinate<Lyt>& tgt, Path p) noexcept
     {
         // mark source coordinate as visited and append it to the path
@@ -90,60 +165,70 @@ class enumerate_all_clocking_paths_impl
         }
         else  // destination is not reached yet
         {
-            // recurse for all outgoing clock zones
-            layout.foreach_outgoing_clocked_zone(
-                src,
-                [&, this](auto successor)  // make a copy
-                {
-                    // return to ground layer to avoid getting stuck in crossing layer
-                    successor = layout.below(successor);
+            const auto explore_successor = [&, this](auto successor)  // make a copy
+                noexcept
+            {
+                // return to ground layer to avoid getting stuck in crossing layer
+                successor = layout.below(successor);
 
-                    // check if successor is obstructed
-                    if constexpr (has_is_obstructed_coordinate_v<Lyt>)
+                // check if successor is obstructed
+                if constexpr (has_is_obstructed_coordinate_v<Lyt>)
+                {
+                    if (layout.is_obstructed_coordinate(successor) && successor != tgt)
                     {
-                        if (layout.is_obstructed_coordinate(successor) && successor != tgt)
+                        // if crossings are enabled, check if it is possible to switch to the crossing layer
+                        if (ps.crossings && is_crossable_wire(layout, src, successor))
                         {
-                            // if crossings are enabled, check if it is possible to switch to the crossing layer
-                            if (ps.crossings && is_crossable_wire(layout, src, successor))
+                            // if the crossing layer is not obstructed
+                            if (const auto above_successor = layout.above(successor);
+                                above_successor != successor && above_successor != tgt &&
+                                !layout.is_obstructed_coordinate(above_successor))
                             {
-                                // if the crossing layer is not obstructed
-                                if (const auto above_successor = layout.above(successor);
-                                    above_successor != successor && above_successor != tgt &&
-                                    !layout.is_obstructed_coordinate(above_successor))
-                                {
-                                    // allow exploring the crossing layer
-                                    successor = above_successor;
-                                }
-                                else
-                                {
-                                    return;  // skip the obstructed coordinate and keep looping
-                                }
+                                // allow exploring the crossing layer
+                                successor = above_successor;
                             }
                             else
                             {
                                 return;  // skip the obstructed coordinate and keep looping
                             }
                         }
-                    }
-
-                    // check if the connection to the successor is obstructed
-                    if constexpr (has_is_obstructed_connection_v<Lyt>)
-                    {
-                        if (layout.is_obstructed_connection(src, successor))
+                        else
                         {
-                            return;  // skip the obstructed connection and keep looping
+                            return;  // skip the obstructed coordinate and keep looping
                         }
                     }
+                }
 
-                    // if the successor has not yet been visited
-                    if (!is_visited(successor))
+                // check if the connection to the successor is obstructed
+                if constexpr (has_is_obstructed_connection_v<Lyt>)
+                {
+                    if (layout.is_obstructed_connection(src, successor))
                     {
-                        // recurse
-                        recursively_enumerate_all_paths(successor, tgt, p);
+                        return;  // skip the obstructed connection and keep looping
                     }
+                }
 
-                    return;  // keep looping
-                });
+                // if the successor has not yet been visited
+                if (!is_visited(successor))
+                {
+                    // recurse
+                    recursively_enumerate_all_paths<PathLevel>(successor, tgt, p);
+                }
+
+                return;  // keep looping
+            };
+
+            if constexpr (PathLevel == path_level::COORDINATES)
+            {
+                // recurse for all adjacent coordinates
+                layout.foreach_adjacent_coordinate(src, explore_successor);
+            }
+            else if constexpr (PathLevel == path_level::CLOCKING)
+            {
+                // recurse for all outgoing clock zones
+                layout.foreach_outgoing_clocked_zone(src, explore_successor);
+            }
+            // else if constexpr ...  // more path levels go here
         }
 
         // after recursion, remove current coordinate from path and mark it as unvisited to allow it in other paths
@@ -155,14 +240,44 @@ class enumerate_all_clocking_paths_impl
 }  // namespace detail
 
 /**
- * Enumerates all possible paths in a clocked layout that start at coordinate source and lead to coordinate target while
- * respecting the information flow imposed by the clocking scheme. This algorithm does neither generate duplicate nor
- * looping paths, even in a cyclic clocking scheme. That is, along each path, each coordinate can occur at maximum once.
+ * Enumerates all possible paths in a coordinate layout that start at coordinate `source` and lead to coordinate
+ * `target`. This algorithm does neither generate duplicate nor looping paths. That is, along each path, each coordinate
+ * can occur at maximum once.
  *
- * If the given layout implements the obstruction interface (see obstruction_layout), paths will not be routed via
- * obstructed coordinates and connections.
+ * If the given layout implements the obstruction interface (see `obstruction_layout`), paths will not be routed via
+ * obstructed coordinates or connections.
  *
- * If the given layout is a gate-level layout and implements the obstruction interface (see obstruction_layout), paths
+ * If the given layout is a gate-level layout and implements the obstruction interface (see `obstruction_layout`), paths
+ * may contain wire crossings if specified in the parameters. Wire crossings are only allowed over other wires and only
+ * if the crossing layer is not obstructed. Furthermore, it is ensured that crossings do not run along another wire but
+ * cross only in a single point (orthogonal crossings + knock-knees/double wires).
+ *
+ * @tparam Path Type of the returned individual paths.
+ * @tparam Lyt Type of the coordinate layout to perform path finding on.
+ * @param layout The coordinate layout whose paths are to be enumerated.
+ * @param objective Source-target coordinate pair.
+ * @param ps Parameters.
+ * @return A collection of all unique paths in `layout` from `source` to `target`.
+ */
+template <typename Path, typename Lyt>
+[[nodiscard]] path_collection<Path> enumerate_all_coordinate_paths(const Lyt&                    layout,
+                                                                   const routing_objective<Lyt>& objective,
+                                                                   enumerate_all_paths_params    params = {}) noexcept
+{
+    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
+
+    return detail::enumerate_all_paths_impl<Path, Lyt>{layout, objective, params}.coordinate_paths();
+}
+/**
+ * Enumerates all possible paths in a clocked layout that start at coordinate `source` and lead to coordinate `target`
+ * while respecting the information flow imposed by `layout`'s clocking scheme. This algorithm does neither generate
+ * duplicate nor looping paths, even in a cyclic clocking scheme. That is, along each path, each coordinate can occur at
+ * maximum once.
+ *
+ * If the given layout implements the obstruction interface (see `obstruction_layout`), paths will not be routed via
+ * obstructed coordinates or connections.
+ *
+ * If the given layout is a gate-level layout and implements the obstruction interface (see `obstruction_layout`), paths
  * may contain wire crossings if specified in the parameters. Wire crossings are only allowed over other wires and only
  * if the crossing layer is not obstructed. Furthermore, it is ensured that crossings do not run along another wire but
  * cross only in a single point (orthogonal crossings + knock-knees/double wires).
@@ -175,13 +290,13 @@ class enumerate_all_clocking_paths_impl
  * @return A collection of all unique paths in `layout` from `source` to `target`.
  */
 template <typename Path, typename Lyt>
-[[nodiscard]] path_collection<Path> enumerate_all_clocking_paths(const Lyt&                          layout,
-                                                                 const routing_objective<Lyt>&       objective,
-                                                                 enumerate_all_clocking_paths_params ps = {}) noexcept
+[[nodiscard]] path_collection<Path> enumerate_all_clocking_paths(const Lyt&                    layout,
+                                                                 const routing_objective<Lyt>& objective,
+                                                                 enumerate_all_paths_params    ps = {}) noexcept
 {
     static_assert(is_clocked_layout_v<Lyt>, "Lyt is not a clocked layout");
 
-    return detail::enumerate_all_clocking_paths_impl<Path, Lyt>{layout, objective, ps}.run();
+    return detail::enumerate_all_paths_impl<Path, Lyt>{layout, objective, ps}.clocking_paths();
 }
 
 }  // namespace fiction

--- a/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
+++ b/include/fiction/algorithms/path_finding/enumerate_all_paths.hpp
@@ -31,10 +31,10 @@ template <typename Path, typename Lyt>
 class enumerate_all_paths_impl
 {
   public:
-    enumerate_all_paths_impl(const Lyt& lyt, const routing_objective<Lyt>& obj, const enumerate_all_paths_params p) :
+    enumerate_all_paths_impl(const Lyt& lyt, const routing_objective<Lyt>& obj, const enumerate_all_paths_params& p) :
             layout{lyt},
             objective{obj},
-            ps{p}
+            params{p}
     {}
 
     /**
@@ -67,7 +67,7 @@ class enumerate_all_paths_impl
     /**
      * Routing parameters.
      */
-    enumerate_all_paths_params ps;
+    const enumerate_all_paths_params params;
     /**
      * Set of visited coordinates.
      */
@@ -143,7 +143,7 @@ class enumerate_all_paths_impl
                     if (layout.is_obstructed_coordinate(successor) && successor != tgt)
                     {
                         // if crossings are enabled, check if it is possible to switch to the crossing layer
-                        if (ps.crossings && is_crossable_wire(layout, src, successor))
+                        if (params.crossings && is_crossable_wire(layout, src, successor))
                         {
                             // if the crossing layer is not obstructed
                             if (const auto above_successor = layout.above(successor);
@@ -232,16 +232,16 @@ class enumerate_all_paths_impl
  * @tparam Lyt Type of the layout to perform path finding on.
  * @param layout The layout whose paths are to be enumerated.
  * @param objective Source-target coordinate pair.
- * @param ps Parameters.
+ * @param params Parameters.
  * @return A collection of all unique paths in `layout` from `source` to `target`.
  */
 template <typename Path, typename Lyt>
 [[nodiscard]] path_collection<Path> enumerate_all_paths(const Lyt& layout, const routing_objective<Lyt>& objective,
-                                                        enumerate_all_paths_params ps = {}) noexcept
+                                                        const enumerate_all_paths_params& params = {}) noexcept
 {
     static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
 
-    return detail::enumerate_all_paths_impl<Path, Lyt>{layout, objective, ps}.run();
+    return detail::enumerate_all_paths_impl<Path, Lyt>{layout, objective, params}.run();
 }
 
 }  // namespace fiction

--- a/include/fiction/algorithms/path_finding/jump_point_search.hpp
+++ b/include/fiction/algorithms/path_finding/jump_point_search.hpp
@@ -34,18 +34,18 @@ class jump_point_search_impl
     jump_point_search_impl(const Lyt& lyt, const routing_objective<Lyt>& obj,
                            const distance_functor<Lyt, Dist>& dist_fn) :
             layout{lyt},
-            source{obj.source},
-            target{obj.target},
+            objective{obj},
             distance{dist_fn}
     {
-        open_list.push(coordinate_f{source, 0});
+        open_list.push(coordinate_f{objective.source, 0});
     }
 
-    Path run()
+    [[nodiscard]] Path run() noexcept
     {
-        assert(!source.is_dead() && !target.is_dead() && "Neither source nor target coordinate can be dead");
+        assert(!objective.source.is_dead() && !objective.target.is_dead() &&
+               "Neither source nor target coordinate can be dead");
 
-        assert(layout.is_within_bounds(source) && layout.is_within_bounds(target) &&
+        assert(layout.is_within_bounds(objective.source) && layout.is_within_bounds(objective.target) &&
                "Both source and target coordinate have to be within the layout bounds");
 
         do {
@@ -53,7 +53,7 @@ class jump_point_search_impl
             const auto current = get_lowest_f_coord();
 
             // if coord is the target, a path has been found
-            if (current == target)
+            if (current == objective.target)
             {
                 return reconstruct_path();
             }
@@ -69,10 +69,17 @@ class jump_point_search_impl
     }
 
   private:
+    /**
+     * The layout in which the shortest path between `source` and `target` is to be found.
+     */
     const Lyt& layout;
-
-    const coordinate<Lyt> source, target;
-
+    /**
+     * The source-target coordinate pair.
+     */
+    const routing_objective<Lyt> objective;
+    /**
+     * The distance functor that implements the heuristic estimation function.
+     */
     const distance_functor<Lyt, Dist> distance;
 
     /**
@@ -80,8 +87,13 @@ class jump_point_search_impl
      */
     struct coordinate_f
     {
+        /**
+         * Coordinate.
+         */
         coordinate<Lyt> coord;
-
+        /**
+         * f-value of the coordinate.
+         */
         Dist f;
 
         /**
@@ -134,7 +146,7 @@ class jump_point_search_impl
      *
      * @return Coordinate with the lowest f-value from the open list.
      */
-    coordinate<Lyt> get_lowest_f_coord() noexcept
+    [[nodiscard]] coordinate<Lyt> get_lowest_f_coord() noexcept
     {
         const auto current = open_list.top().coord;
         open_list.pop();
@@ -148,86 +160,96 @@ class jump_point_search_impl
      */
     void expand(const coordinate<Lyt>& current) noexcept
     {
-        layout.foreach_outgoing_clocked_zone(
-            current,
-            [this, current](const auto& successor)
+        const auto explore_successor = [this, current](const auto& successor) noexcept
+        {
+            // check if the connection to the successor is obstructed
+            if constexpr (has_is_obstructed_connection_v<Lyt>)
             {
-                // check if the connection to the successor is obstructed
-                if constexpr (has_is_obstructed_connection_v<Lyt>)
+                if (layout.is_obstructed_connection(current, successor))
                 {
-                    if (layout.is_obstructed_connection(current, successor))
-                    {
-                        return;  // skip the obstructed connection and keep looping
-                    }
+                    return;  // skip the obstructed connection and keep looping
+                }
+            }
+
+            // check if successor is obstructed
+            if constexpr (has_is_obstructed_coordinate_v<Lyt>)
+            {
+                if (layout.is_obstructed_coordinate(successor) && successor != objective.target)
+                {
+                    return;  // skip the obstructed coordinate and keep looping
+                }
+            }
+
+            // compute the next jump point to prune the search space
+            if (const auto jump_point = jump(current, successor); jump_point.has_value())
+            {
+                if (is_visited(*jump_point))
+                {
+                    return;  // skip any jump point that is already in the closed list
                 }
 
-                // check if successor is obstructed
-                if constexpr (has_is_obstructed_coordinate_v<Lyt>)
+                // compute the g-value of current. Add the distance to the jump point as it might not be adjacent
+                const auto tentative_g = g(current) + distance(layout, *jump_point, current);
+
+                // f-value does not matter because the comparator compares only the coordinates
+                const auto it = open_list.find({*jump_point, 0});
+                if (it != open_list.end() && no_improvement(*jump_point, tentative_g))
                 {
-                    if (layout.is_obstructed_coordinate(successor) && successor != target)
-                    {
-                        return;  // skip the obstructed coordinate and keep looping
-                    }
+                    return;  // skip the coordinate if it does not offer improvement
                 }
 
-                // compute the next jump point to prune the search space
-                if (const auto jump_point = jump(current, successor); jump_point.has_value())
+                // track origin
+                came_from[*jump_point] = current;
+                set_g(*jump_point, tentative_g);
+
+                // compute new f-value
+                const auto f = tentative_g + distance(layout, *jump_point, objective.target);
+
+                // if successor is contained in the open list (frontier)
+                if (it != open_list.end())
                 {
-                    if (is_visited(*jump_point))
-                    {
-                        return;  // skip any jump point that is already in the closed list
-                    }
-
-                    // compute the g-value of current. Add the distance to the jump point as it might not be adjacent
-                    const auto tentative_g = g(current) + distance(layout, *jump_point, current);
-
-                    // f-value does not matter because the comparator compares only the coordinates
-                    const auto it = open_list.find({*jump_point, 0});
-                    if (it != open_list.end() && no_improvement(*jump_point, tentative_g))
-                    {
-                        return;  // skip the coordinate if it does not offer improvement
-                    }
-
-                    // track origin
-                    came_from[*jump_point] = current;
-                    set_g(*jump_point, tentative_g);
-
-                    // compute new f-value
-                    const auto f = tentative_g + distance(layout, *jump_point, target);
-
-                    // if successor is contained in the open list (frontier)
-                    if (it != open_list.end())
-                    {
-                        // update its f-value
-                        it->f = f;
-                    }
-                    else
-                    {
-                        // add successor to the open list
-                        open_list.push({*jump_point, f});
-                    }
+                    // update its f-value
+                    it->f = f;
                 }
+                else
+                {
+                    // add successor to the open list
+                    open_list.push({*jump_point, f});
+                }
+            }
 
-                return;  // keep looping
-            });
+            return;  // keep looping
+        };
+
+        if constexpr (is_clocked_layout_v<Lyt>)
+        {
+            // recurse for all outgoing clock zones
+            layout.foreach_outgoing_clocked_zone(current, explore_successor);
+        }
+        else
+        {
+            // recurse for all adjacent coordinates
+            layout.foreach_adjacent_coordinate(current, explore_successor);
+        }
     }
     /**
      * Compute the next jump point starting from successor with current as its parent. The vector (current, successor)
      * thus defines the direction in which to look for the jump point. A jump point has to be stepwise traversable from
-     * successor. That is, there must be a valid clocking path through non-obstructed tiles.
+     * successor. That is, there must be a valid path through non-obstructed tiles.
      *
      * @param current Parent coordinate.
      * @param successor Coordinate from which to look for the next jump point.
-     * @return The next jump point or std::nullopt if no such coordinate is available.
+     * @return The next jump point or `std::nullopt` if no such coordinate is available.
      */
-    std::optional<coordinate<Lyt>> jump(const coordinate<Lyt>& current, const coordinate<Lyt>& successor) const noexcept
+    [[nodiscard]] std::optional<coordinate<Lyt>> jump(const coordinate<Lyt>& current,
+                                                      const coordinate<Lyt>& successor) const noexcept
     {
         if (!is_traversable(current, successor))
         {
             return std::nullopt;
         }
 
-        if (successor == target)
+        if (successor == objective.target)
         {
             return successor;
         }
@@ -263,22 +285,32 @@ class jump_point_search_impl
     }
     /**
      * Checks if coordinate c2 is directly reachable from coordinate c1. That is if the coordinates are not identical,
-     * if the clocking checks out, and if there is no obstacle in the way.
+     * if they are adjacent or if the clocking checks out, and if there is no obstacle in the way.
      *
      * @param c1 Start coordinate.
      * @param c2 Goal coordinate.
      * @return `true` iff c2 is directly reachable from c1.
      */
-    bool is_traversable(const coordinate<Lyt>& c1, const coordinate<Lyt>& c2) const noexcept
+    [[nodiscard]] bool is_traversable(const coordinate<Lyt>& c1, const coordinate<Lyt>& c2) const noexcept
     {
         if (c1 == c2)
         {
             return false;
         }
 
-        if (!layout.is_outgoing_clocked(c1, c2))
+        if constexpr (is_clocked_layout_v<Lyt>)
         {
-            return false;
+            if (!layout.is_outgoing_clocked(c1, c2))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (!layout.is_adjacent_of(c1, c2))
+            {
+                return false;
+            }
         }
 
         if constexpr (has_is_obstructed_connection_v<Lyt>)
@@ -291,7 +323,7 @@ class jump_point_search_impl
 
         if constexpr (has_is_obstructed_coordinate_v<Lyt>)
         {
-            if (layout.is_obstructed_coordinate(c2) && c2 != target)
+            if (layout.is_obstructed_coordinate(c2) && c2 != objective.target)
             {
                 return false;
             }
@@ -305,7 +337,7 @@ class jump_point_search_impl
      * @param c Coordinate to check.
      * @return `true` iff c has already been visited.
      */
-    bool is_visited(const coordinate<Lyt>& c) const noexcept
+    [[nodiscard]] bool is_visited(const coordinate<Lyt>& c) const noexcept
     {
         return closed_list.count(c) > 0;
     }
@@ -315,7 +347,7 @@ class jump_point_search_impl
      * @param c Coordinate whose g-value is desired.
      * @return g-value of coordinate c or 0 if no value has been stored.
      */
-    Dist g(const coordinate<Lyt>& c) const noexcept
+    [[nodiscard]] Dist g(const coordinate<Lyt>& c) const noexcept
     {
         if (const auto it = g_values.find(c); it != g_values.cend())
         {
@@ -342,7 +374,7 @@ class jump_point_search_impl
      * @param g_val g-value to compare to c's.
      * @return `true` iff the given g-value does not mean an improvement for the given coordinate.
      */
-    bool no_improvement(const coordinate<Lyt>& c, const Dist g_val) noexcept
+    [[nodiscard]] bool no_improvement(const coordinate<Lyt>& c, const Dist g_val) noexcept
     {
         return g_val >= g(c);
     }
@@ -351,17 +383,17 @@ class jump_point_search_impl
      *
      * @return The shortest path connecting source and target.
      */
-    Path reconstruct_path() const noexcept
+    [[nodiscard]] Path reconstruct_path() const noexcept
     {
         Path path{};
 
         // iterate backwards over the found connections and add them to the path
-        for (auto current = target; current != source; current = came_from.at(current))
+        for (auto current = objective.target; current != objective.source; current = came_from.at(current))
         {
             path.push_back(current);
         }
         // finally, add the source coordinate
-        path.push_back(source);
+        path.push_back(objective.source);
         // and reverse the path to bring it in proper order
         std::reverse(std::begin(path), std::end(path));
 
@@ -373,7 +405,7 @@ class jump_point_search_impl
      * @param p Incomplete path with jump gaps.
      * @return Completed interpolated path.
      */
-    Path fill_in_jumps(const Path& p) const noexcept
+    [[nodiscard]] Path fill_in_jumps(const Path& p) const noexcept
     {
         Path expanded{};
 
@@ -406,7 +438,7 @@ class jump_point_search_impl
      * @param c2 Goal coordinate.
      * @return A straight path between c1 and c2.
      */
-    Path interpolate(coordinate<Lyt> c1, coordinate<Lyt> c2) const noexcept
+    [[nodiscard]] Path interpolate(coordinate<Lyt> c1, coordinate<Lyt> c2) const noexcept
     {
         Path line{};
 
@@ -452,16 +484,28 @@ class jump_point_search_impl
 }  // namespace detail
 
 /**
- * The Jump Point Search (JPS) path finding algorithm for shortest loopless paths between a given source and target
- * coordinate in a clocked layout. JPS was proposed as an optimization of A* for shortest paths and offers better
- * average complexity on uniform-cost grids that allow diagonal connections. It uses a heuristic distance function that
- * estimates the remaining costs towards the target in every step. Thus, this heuristic function should neither be
- * complex to calculate nor overestimating the remaining costs. Common heuristics to be used are the Manhattan and the
- * Euclidean distance functions. See distance_functor for implementations. Since JPS assumes a unit-cost grid, the use
- * of cost functions together with JPS is not possible.
+ * The Jump Point Search (JPS) path finding algorithm for shortest loop-less paths between a given source and target
+ * coordinate in a Cartesian layout. This function automatically detects whether the given layout implements a clocking
+ * interface (see `clocked_layout`) and respects the underlying information flow imposed by `layout`'s clocking scheme.
  *
- * If the given layout implements the obstruction interface (see obstruction_layout), paths will not be routed via
+ * JPS was proposed as an optimization of A* for shortest paths and offers better average complexity on uniform-cost
+ * grids that allow diagonal connections. It uses a heuristic distance function that estimates the remaining costs
+ * towards the target in every step. Thus, this heuristic function should neither be complex to calculate nor
+ * overestimating the remaining costs. Common heuristics to be used are the Manhattan and the Euclidean distance
+ * functions. See `distance_functor` for implementations. Since JPS assumes a unit-cost grid, the use of cost functions
+ * together with JPS is not possible.
+ *
+ * If the given layout implements the obstruction interface (see `obstruction_layout`), paths will not be routed via
  * obstructed coordinates and connections.
+ *
+ * In certain cases it might be desirable to determine regular coordinate paths even if the layout implements a clocking
+ * interface. This can be achieved by static-casting the layout to a coordinate layout when calling this function:
+ * \code{.cpp}
+ * using clk_lyt = clocked_layout<cartesian_layout<>>;
+ * using path = layout_coordinate_path<cartesian_layout<>>;
+ * clk_lyt layout = ...;
+ * auto shortest_path = jump_point_search<path>(static_cast<cartesian_layout<>>(layout), {source, target});
+ * \endcode
  *
  * JPS was introduced in \"Online Graph Pruning for Pathfinding on Grid Maps\" by Daniel Harabor and Alban Grastien in
  * AAAI 2011.
@@ -471,18 +515,17 @@ class jump_point_search_impl
  * @note The original JPS highly relies on diagonal paths in the grid which are not possible in most Cartesian
  * grid-based FCN technologies. Therefore, this implementation disallows diagonal paths. Consequently, and due to
  * non-uniform clocking schemes, JPS might perform worse than A* in terms of runtime. It is recommended to use A* (see
- * a_star).
+ * `a_star`).
  *
  * @note JPS does not support wire crossings.
  *
- * @tparam Path Path type to create.
- * @tparam Lyt Clocked layout type.
+ * @tparam Path Type of the returned path.
+ * @tparam Lyt Type of the layout to perform path finding on.
  * @tparam Dist Distance value type to be used in the heuristic estimation function.
- * @param layout The clocked layout in which the shortest path between `source` and `target` is to be found.
+ * @param layout The layout in which the shortest path between a source and target is to be found.
  * @param objective Source-target coordinate pair.
  * @param dist_fn A distance functor that implements the desired heuristic estimation function.
- * @param ps Parameters.
- * @return The shortest loopless path in `layout` from `source` to `target`.
+ * @return The shortest loop-less path in `layout` from `objective.source` to `objective.target`.
  */
 template <typename Path, typename Lyt, typename Dist = uint64_t>
 [[nodiscard]] Path
@@ -490,7 +533,6 @@ jump_point_search(const Lyt& layout, const routing_objective<Lyt>& objective,
                   const distance_functor<Lyt, Dist>& dist_fn = manhattan_distance_functor<Lyt, Dist>()) noexcept
 {
     static_assert(is_cartesian_layout_v<Lyt>, "Lyt is not a Cartesian layout");
-    static_assert(is_clocked_layout_v<Lyt>, "Lyt is not a clocked layout");
 
     return detail::jump_point_search_impl<Path, Lyt, Dist>{layout, objective, dist_fn}.run();
 }

--- a/include/fiction/algorithms/path_finding/jump_point_search.hpp
+++ b/include/fiction/algorithms/path_finding/jump_point_search.hpp
@@ -500,12 +500,12 @@ class jump_point_search_impl
  *
  * In certain cases it might be desirable to determine regular coordinate paths even if the layout implements a clocking
  * interface. This can be achieved by static-casting the layout to a coordinate layout when calling this function:
- * \code{.cpp}
+ * @code{.cpp}
  * using clk_lyt = clocked_layout<cartesian_layout<>>;
  * using path = layout_coordinate_path<cartesian_layout<>>;
  * clk_lyt layout = ...;
  * auto shortest_path = jump_point_search<path>(static_cast<cartesian_layout<>>(layout), {source, target});
- * \endcode
+ * @endcode
  *
  * JPS was introduced in \"Online Graph Pruning for Pathfinding on Grid Maps\" by Daniel Harabor and Alban Grastien in
  * AAAI 2011.

--- a/include/fiction/algorithms/path_finding/k_shortest_paths.hpp
+++ b/include/fiction/algorithms/path_finding/k_shortest_paths.hpp
@@ -245,12 +245,12 @@ class yen_k_shortest_paths_impl
  *
  * In certain cases it might be desirable to enumerate regular coordinate paths even if the layout implements a clocking
  * interface. This can be achieved by static-casting the layout to a coordinate layout when calling this function:
- * \code{.cpp}
+ * @code{.cpp}
  * using clk_lyt = clocked_layout<cartesian_layout<>>;
  * using path = layout_coordinate_path<cartesian_layout<>>;
  * clk_lyt layout = ...;
  * auto k_paths = yen_k_shortest_paths<path>(static_cast<cartesian_layout<>>(layout), {source, target}, k);
- * \endcode
+ * @endcode
  *
  * The algorithm was originally described in \"An algorithm for finding shortest routes from all source nodes to a given
  * destination in general networks\" by Jin Y. Yen in Quarterly of Applied Mathematics, 1970.

--- a/include/fiction/algorithms/physical_design/orthogonal.hpp
+++ b/include/fiction/algorithms/physical_design/orthogonal.hpp
@@ -628,8 +628,8 @@ class orthogonal_impl
  * network directly used instead of relabeling the edges according to its DFS tree, ordering the vertices using
  * topological sorting instead of DFS, and adding an extra placement rule for nodes without predecessors.
  *
- * The algorithm works in polynomial time \f$ O(3|N| + |L|) \f$ where \f$ |N| \f$ is the number of nodes in the given
- * network and \f$ |L| \f$ is the resulting layout size given by \f$ x \cdot y \f$, which approaches \f$
+ * The algorithm works in polynomial time \f$ \mathcal(O)(3|N| + |L|) \f$ where \f$ |N| \f$ is the number of nodes in
+ * the given network and \f$ |L| \f$ is the resulting layout size given by \f$ x \cdot y \f$, which approaches \f$
  * (\frac{|N|}{2})^2 \f$ asymptotically.
  *
  * May throw a high_degree_fanin_exception if `ntk` contains any node with a fan-in larger than 2.

--- a/include/fiction/algorithms/properties/critical_path_length_and_throughput.hpp
+++ b/include/fiction/algorithms/properties/critical_path_length_and_throughput.hpp
@@ -154,7 +154,8 @@ class critical_path_length_and_throughput_impl
  * Field-coupled Nanotechnologies\" by M. Walter, R. Wille, F. Sill Torres, and R. Drechsler published by Springer
  * Nature in 2022.
  *
- * The complexity of this function is \f$ O(|T|) \f$ where \f$ T \f$ is the set of all occupied tiles in `lyt`.
+ * The complexity of this function is \f$ \mathcal(O)(|T|) \f$ where \f$ T \f$ is the set of all occupied tiles in
+ * `lyt`.
  *
  * @tparam Lyt Gate-level layout type.
  * @param lyt The gate-level layout whose CP and TP are desired.

--- a/test/algorithms/path_finding/a_star.cpp
+++ b/test/algorithms/path_finding/a_star.cpp
@@ -20,7 +20,7 @@
 
 using namespace fiction;
 
-TEST_CASE("A* on 2x2 clocked layouts", "[A*]")
+TEST_CASE("A* on 2x2 layouts", "[A*]")
 {
     using lyt        = cartesian_layout<offset::ucoord_t>;
     using coord_path = layout_coordinate_path<lyt>;
@@ -133,7 +133,7 @@ TEST_CASE("A* on 2x2 clocked layouts", "[A*]")
     }
 }
 
-TEST_CASE("A* on 4x4 clocked layouts", "[A*]")
+TEST_CASE("A* on 4x4 layouts", "[A*]")
 {
     using lyt        = cartesian_layout<offset::ucoord_t>;
     using coord_path = layout_coordinate_path<lyt>;
@@ -484,7 +484,7 @@ TEST_CASE("A* on 4x4 gate-level layouts with connection obstruction", "[A*]")
     }
 }
 
-TEST_CASE("A* on 10x10 clocked layouts with varying distance functions", "[A*]")
+TEST_CASE("A* on 10x10 layouts with varying distance functions", "[A*]")
 {
     using lyt        = cartesian_layout<offset::ucoord_t>;
     using clk_lyt    = clocked_layout<lyt>;
@@ -586,7 +586,7 @@ TEST_CASE("A* on 10x10 clocked layouts with varying distance functions", "[A*]")
     }
 }
 
-TEST_CASE("A* on 4x4 clocked layouts with varying cost functions", "[A*]")
+TEST_CASE("A* on 4x4 layouts with varying cost functions", "[A*]")
 {
     using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
     using coord_path = layout_coordinate_path<clk_lyt>;

--- a/test/algorithms/path_finding/a_star.cpp
+++ b/test/algorithms/path_finding/a_star.cpp
@@ -22,12 +22,12 @@ using namespace fiction;
 
 TEST_CASE("A* on 2x2 clocked layouts", "[A*]")
 {
-    using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using coord_path = layout_coordinate_path<clk_lyt>;
+    using lyt        = cartesian_layout<offset::ucoord_t>;
+    using coord_path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{1, 1}};
 
         SECTION("(0,0) to (1,1)")  // path of length 3
         {
@@ -36,18 +36,22 @@ TEST_CASE("A* on 2x2 clocked layouts", "[A*]")
 
             CHECK(path.size() == 3);
             CHECK(dist == 2);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{1, 1});
+            CHECK(path.source() == coordinate<lyt>{0, 0});
+            CHECK(path.target() == coordinate<lyt>{1, 1});
             // path could either go east-south or south-east
-            CHECK((path[1] == coordinate<clk_lyt>{1, 0} || path[1] == coordinate<clk_lyt>{0, 1}));
+            CHECK((path[1] == coordinate<lyt>{1, 0} || path[1] == coordinate<lyt>{0, 1}));
         }
-        SECTION("(1,1) to (0,0)")  // no valid paths
+        SECTION("(1,1) to (0,0)")  // path of length 3
         {
             const auto path = a_star<coord_path>(layout, {{1, 1}, {0, 0}});
             const auto dist = a_star_distance(layout, {1, 1}, {0, 0});
 
-            CHECK(path.empty());
-            CHECK(dist == std::numeric_limits<uint64_t>::max());
+            CHECK(path.size() == 3);
+            CHECK(dist == 2);
+            CHECK(path.source() == coordinate<lyt>{1, 1});
+            CHECK(path.target() == coordinate<lyt>{0, 0});
+            // path could either go west-north or north-west
+            CHECK((path[1] == coordinate<lyt>{1, 0} || path[1] == coordinate<lyt>{0, 1}));
         }
         SECTION("(0,0) to (0,0)")  // source and target are identical
         {
@@ -56,47 +60,87 @@ TEST_CASE("A* on 2x2 clocked layouts", "[A*]")
 
             CHECK(path.size() == 1);
             CHECK(dist == 0);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            CHECK(path.source() == coordinate<lyt>{0, 0});
+            CHECK(path.target() == coordinate<lyt>{0, 0});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("(0,0) to (0,1)")  // path of length 4
+        SECTION("2DDWave")
         {
-            const auto path = a_star<coord_path>(layout, {{0, 0}, {0, 1}});
-            const auto dist = a_star_distance(layout, {0, 0}, {0, 1});
+            const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
 
-            CHECK(path.size() == 4);
-            CHECK(dist == 3);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{0, 1});
-            CHECK(path[1] == coordinate<clk_lyt>{1, 0});
-            CHECK(path[2] == coordinate<clk_lyt>{1, 1});
+            SECTION("(0,0) to (1,1)")  // path of length 3
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {1, 1}});
+                const auto dist = a_star_distance(layout, {0, 0}, {1, 1});
+
+                CHECK(path.size() == 3);
+                CHECK(dist == 2);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{1, 1});
+                // path could either go east-south or south-east
+                CHECK((path[1] == coordinate<clk_lyt>{1, 0} || path[1] == coordinate<clk_lyt>{0, 1}));
+            }
+            SECTION("(1,1) to (0,0)")  // no valid paths
+            {
+                const auto path = a_star<coord_path>(layout, {{1, 1}, {0, 0}});
+                const auto dist = a_star_distance(layout, {1, 1}, {0, 0});
+
+                CHECK(path.empty());
+                CHECK(dist == std::numeric_limits<uint64_t>::max());
+            }
+            SECTION("(0,0) to (0,0)")  // source and target are identical
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {0, 0}});
+                const auto dist = a_star_distance(layout, {0, 0}, {0, 0});
+
+                CHECK(path.size() == 1);
+                CHECK(dist == 0);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            }
         }
-        SECTION("(0,0) to (0,0)")  // source and target are identical
+        SECTION("USE")
         {
-            const auto path = a_star<coord_path>(layout, {{0, 0}, {0, 0}});
-            const auto dist = a_star_distance(layout, {0, 0}, {0, 0});
+            const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
 
-            CHECK(path.size() == 1);
-            CHECK(dist == 0);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            SECTION("(0,0) to (0,1)")  // path of length 4
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {0, 1}});
+                const auto dist = a_star_distance(layout, {0, 0}, {0, 1});
+
+                CHECK(path.size() == 4);
+                CHECK(dist == 3);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{0, 1});
+                CHECK(path[1] == coordinate<clk_lyt>{1, 0});
+                CHECK(path[2] == coordinate<clk_lyt>{1, 1});
+            }
+            SECTION("(0,0) to (0,0)")  // source and target are identical
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {0, 0}});
+                const auto dist = a_star_distance(layout, {0, 0}, {0, 0});
+
+                CHECK(path.size() == 1);
+                CHECK(dist == 0);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            }
         }
     }
 }
 
 TEST_CASE("A* on 4x4 clocked layouts", "[A*]")
 {
-    using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using coord_path = layout_coordinate_path<clk_lyt>;
+    using lyt        = cartesian_layout<offset::ucoord_t>;
+    using coord_path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{3, 3}};
 
         SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
         {
@@ -105,23 +149,43 @@ TEST_CASE("A* on 4x4 clocked layouts", "[A*]")
 
             CHECK(path.size() == 7);
             CHECK(dist == 6);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            CHECK(path.source() == coordinate<lyt>{0, 0});
+            CHECK(path.target() == coordinate<lyt>{3, 3});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+        SECTION("2DDWave")
         {
-            const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}});
-            const auto dist = a_star_distance(layout, {0, 0}, {3, 3});
+            const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
 
-            CHECK(path.size() == 7);
-            CHECK(dist == 6);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}});
+                const auto dist = a_star_distance(layout, {0, 0}, {3, 3});
+
+                CHECK(path.size() == 7);
+                CHECK(dist == 6);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            }
+        }
+        SECTION("USE")
+        {
+            const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+
+            SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}});
+                const auto dist = a_star_distance(layout, {0, 0}, {3, 3});
+
+                CHECK(path.size() == 7);
+                CHECK(dist == 6);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            }
         }
     }
 }
@@ -132,19 +196,19 @@ TEST_CASE("A* on 4x4 gate-level layouts with coordinate obstruction", "[A*]")
     using obst_lyt   = obstruction_layout<gate_lyt>;
     using coord_path = layout_coordinate_path<obst_lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
+        const gate_lyt layout{{3, 3}};
 
         SECTION("(0,0) to (3,3) with coordinate obstruction")  // path of length 7
         {
-            obstruction_layout obstr_lyt{layout};
+            obstruction_layout obstr_lyt{static_cast<cartesian_layout<>>(layout)};
 
             // create some PIs as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});
-            obstr_lyt.create_pi("obstruction", {3, 1});
-            obstr_lyt.create_pi("obstruction", {1, 2});
-            obstr_lyt.create_pi("obstruction", {2, 2});
+            obstr_lyt.obstruct_coordinate({3, 0});
+            obstr_lyt.obstruct_coordinate({3, 1});
+            obstr_lyt.obstruct_coordinate({1, 2});
+            obstr_lyt.obstruct_coordinate({2, 2});
             // effectively blocking (3,2) as well
 
             const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
@@ -161,29 +225,61 @@ TEST_CASE("A* on 4x4 gate-level layouts with coordinate obstruction", "[A*]")
             CHECK(path[5] == coordinate<gate_lyt>{2, 3});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
-
-        SECTION("(0,0) to (3,3) with coordinate obstruction")  // path of length 7
+        SECTION("2DDWave")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
 
-            // create a PI as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with coordinate obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
-            const auto dist = a_star_distance(obstr_lyt, {0, 0}, {3, 3});
+                // create some PIs as obstruction
+                obstr_lyt.create_pi("obstruction", {3, 0});
+                obstr_lyt.create_pi("obstruction", {3, 1});
+                obstr_lyt.create_pi("obstruction", {1, 2});
+                obstr_lyt.create_pi("obstruction", {2, 2});
+                // effectively blocking (3,2) as well
 
-            CHECK(path.size() == 7);
-            CHECK(dist == 6);
-            CHECK(path.source() == coordinate<gate_lyt>{0, 0});
-            CHECK(path.target() == coordinate<gate_lyt>{3, 3});
-            CHECK(path[1] == coordinate<gate_lyt>{1, 0});
-            CHECK(path[2] == coordinate<gate_lyt>{1, 1});
-            CHECK(path[3] == coordinate<gate_lyt>{1, 2});
-            CHECK(path[4] == coordinate<gate_lyt>{2, 2});
-            CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+                const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+                const auto dist = a_star_distance(obstr_lyt, {0, 0}, {3, 3});
+
+                CHECK(path.size() == 7);
+                CHECK(dist == 6);
+                CHECK(path.source() == coordinate<gate_lyt>{0, 0});
+                CHECK(path.target() == coordinate<gate_lyt>{3, 3});
+                CHECK(path[1] == coordinate<gate_lyt>{0, 1});
+                CHECK(path[2] == coordinate<gate_lyt>{0, 2});
+                CHECK(path[3] == coordinate<gate_lyt>{0, 3});
+                CHECK(path[4] == coordinate<gate_lyt>{1, 3});
+                CHECK(path[5] == coordinate<gate_lyt>{2, 3});
+            }
+        }
+        SECTION("USE")
+        {
+            const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
+
+            SECTION("(0,0) to (3,3) with coordinate obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                // create a PI as obstruction
+                obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
+
+                const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+                const auto dist = a_star_distance(obstr_lyt, {0, 0}, {3, 3});
+
+                CHECK(path.size() == 7);
+                CHECK(dist == 6);
+                CHECK(path.source() == coordinate<gate_lyt>{0, 0});
+                CHECK(path.target() == coordinate<gate_lyt>{3, 3});
+                CHECK(path[1] == coordinate<gate_lyt>{1, 0});
+                CHECK(path[2] == coordinate<gate_lyt>{1, 1});
+                CHECK(path[3] == coordinate<gate_lyt>{1, 2});
+                CHECK(path[4] == coordinate<gate_lyt>{2, 2});
+                CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+            }
         }
     }
 }
@@ -308,13 +404,13 @@ TEST_CASE("A* on 4x4 gate-level layouts with connection obstruction", "[A*]")
     using gate_lyt   = gate_level_layout<clocked_layout<cartesian_layout<offset::ucoord_t>>>;
     using coord_path = layout_coordinate_path<gate_lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
+        const gate_lyt layout{{3, 3}};
 
         SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
         {
-            obstruction_layout obstr_lyt{layout};
+            obstruction_layout obstr_lyt{static_cast<cartesian_layout<>>(layout)};
 
             // create some connection obstructions
             obstr_lyt.obstruct_connection({0, 0}, {1, 0});
@@ -334,93 +430,157 @@ TEST_CASE("A* on 4x4 gate-level layouts with connection obstruction", "[A*]")
             CHECK(path[5] == coordinate<gate_lyt>{2, 3});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
-
-        SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+        SECTION("2DDWave")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
 
-            // create a PI as obstruction
-            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+                // create some connection obstructions
+                obstr_lyt.obstruct_connection({0, 0}, {1, 0});
+                obstr_lyt.obstruct_connection({0, 1}, {1, 1});
+                obstr_lyt.obstruct_connection({0, 2}, {1, 2});
+                // leaving only one valid path via (0,4)
 
-            CHECK(path.size() == 7);
-            CHECK(path.source() == coordinate<gate_lyt>{0, 0});
-            CHECK(path.target() == coordinate<gate_lyt>{3, 3});
-            CHECK(path[1] == coordinate<gate_lyt>{1, 0});
-            CHECK(path[2] == coordinate<gate_lyt>{1, 1});
-            CHECK(path[3] == coordinate<gate_lyt>{1, 2});
-            CHECK(path[4] == coordinate<gate_lyt>{2, 2});
-            CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+                const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<gate_lyt>{0, 0});
+                CHECK(path.target() == coordinate<gate_lyt>{3, 3});
+                CHECK(path[1] == coordinate<gate_lyt>{0, 1});
+                CHECK(path[2] == coordinate<gate_lyt>{0, 2});
+                CHECK(path[3] == coordinate<gate_lyt>{0, 3});
+                CHECK(path[4] == coordinate<gate_lyt>{1, 3});
+                CHECK(path[5] == coordinate<gate_lyt>{2, 3});
+            }
+        }
+        SECTION("USE")
+        {
+            const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
+
+            SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                // create a PI as obstruction
+                obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+
+                const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<gate_lyt>{0, 0});
+                CHECK(path.target() == coordinate<gate_lyt>{3, 3});
+                CHECK(path[1] == coordinate<gate_lyt>{1, 0});
+                CHECK(path[2] == coordinate<gate_lyt>{1, 1});
+                CHECK(path[3] == coordinate<gate_lyt>{1, 2});
+                CHECK(path[4] == coordinate<gate_lyt>{2, 2});
+                CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+            }
         }
     }
 }
 
 TEST_CASE("A* on 10x10 clocked layouts with varying distance functions", "[A*]")
 {
-    using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using coord_path = layout_coordinate_path<clk_lyt>;
+    using lyt        = cartesian_layout<offset::ucoord_t>;
+    using clk_lyt    = clocked_layout<lyt>;
+    using coord_path = layout_coordinate_path<lyt>;
 
     SECTION("Manhattan distance")
     {
-        SECTION("RES")
+        SECTION("coordinate paths")
         {
-            const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
+            const lyt layout{{9, 9}};
 
             SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
             {
-                const auto path =
-                    a_star<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<clk_lyt>());
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<lyt>());
 
                 CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                CHECK(path.source() == coordinate<lyt>{0, 0});
+                CHECK(path.target() == coordinate<lyt>{9, 9});
             }
         }
-        SECTION("ESP")
+        SECTION("clocking paths")
         {
-            const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
-
-            SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+            SECTION("RES")
             {
-                const auto path = a_star<coord_path>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<clk_lyt>());
+                const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
 
-                CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path =
+                        a_star<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
+            }
+            SECTION("ESP")
+            {
+                const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
+
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path =
+                        a_star<coord_path>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
             }
         }
     }
     SECTION("Euclidean distance")
     {
-        SECTION("RES")
+        SECTION("coordinate paths")
         {
-            const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
+            const lyt layout{{9, 9}};
 
             SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
             {
-                const auto path =
-                    a_star<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<clk_lyt>());
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<lyt>());
 
                 CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                CHECK(path.source() == coordinate<lyt>{0, 0});
+                CHECK(path.target() == coordinate<lyt>{9, 9});
             }
         }
-        SECTION("ESP")
+        SECTION("clocking paths")
         {
-            const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
-
-            SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+            SECTION("RES")
             {
-                const auto path = a_star<coord_path>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<clk_lyt>());
+                const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
 
-                CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path =
+                        a_star<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
+            }
+            SECTION("ESP")
+            {
+                const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
+
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path =
+                        a_star<coord_path>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
             }
         }
     }
@@ -455,33 +615,51 @@ TEST_CASE("A* on 4x4 clocked layouts with varying cost functions", "[A*]")
 
 TEST_CASE("A* path finding with the A* distance functor (don't do this!)", "[A*]")
 {
-    using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using coord_path = layout_coordinate_path<clk_lyt>;
+    using lyt        = cartesian_layout<offset::ucoord_t>;
+    using coord_path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{3, 3}};
 
         SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
         {
-            const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}}, a_star_distance_functor<clk_lyt>());
+            const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}}, a_star_distance_functor<lyt>());
 
             CHECK(path.size() == 7);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            CHECK(path.source() == coordinate<lyt>{0, 0});
+            CHECK(path.target() == coordinate<lyt>{3, 3});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+        SECTION("2DDWave")
         {
-            const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}}, a_star_distance_functor<clk_lyt>());
+            const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
 
-            CHECK(path.size() == 7);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}}, a_star_distance_functor<clk_lyt>());
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            }
+        }
+        SECTION("USE")
+        {
+            const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+
+            SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+            {
+                const auto path = a_star<coord_path>(layout, {{0, 0}, {3, 3}}, a_star_distance_functor<clk_lyt>());
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            }
         }
     }
 }

--- a/test/algorithms/path_finding/distance.cpp
+++ b/test/algorithms/path_finding/distance.cpp
@@ -319,44 +319,141 @@ TEST_CASE("A* distance", "[distance]")
 {
     SECTION("Unsigned Cartesian layout")
     {
-        using clk_lyt = clocked_layout<cartesian_layout<offset::ucoord_t>>;
+        using lyt = cartesian_layout<offset::ucoord_t>;
 
-        SECTION("2DDWave")
+        SECTION("coordinate path distance")
         {
-            const clk_lyt layout{{9, 4, 1}, twoddwave_clocking<clk_lyt>()};
+            const lyt layout{{9, 4, 1}};
 
             SECTION("Default distance type (uint64_t)")
             {
-                CHECK(a_star_distance<clk_lyt>(layout, {0, 0}, {0, 0}) == 0);
-                CHECK(a_star_distance<clk_lyt>(layout, {1, 1}, {1, 1}) == 0);
-                CHECK(a_star_distance<clk_lyt>(layout, {0, 0}, {0, 1}) == 1);
-                CHECK(a_star_distance<clk_lyt>(layout, {0, 0}, {1, 1}) == 2);
-                CHECK(a_star_distance<clk_lyt>(layout, {9, 1}, {6, 2}) == std::numeric_limits<uint64_t>::max());
-                CHECK(a_star_distance<clk_lyt>(layout, {6, 2}, {0, 4}) == std::numeric_limits<uint64_t>::max());
-                CHECK(a_star_distance<clk_lyt>(layout, {0, 4}, {9, 1}) == std::numeric_limits<uint64_t>::max());
+                CHECK(a_star_distance<lyt>(layout, {0, 0}, {0, 0}) == 0);
+                CHECK(a_star_distance<lyt>(layout, {1, 1}, {1, 1}) == 0);
+                CHECK(a_star_distance<lyt>(layout, {0, 0}, {0, 1}) == 1);
+                CHECK(a_star_distance<lyt>(layout, {0, 0}, {1, 1}) == 2);
+                CHECK(a_star_distance<lyt>(layout, {9, 1}, {6, 2}) == 4);
+                CHECK(a_star_distance<lyt>(layout, {6, 2}, {0, 4}) == 8);
+                CHECK(a_star_distance<lyt>(layout, {0, 4}, {9, 1}) == 12);
 
-                // A* is not meant for routing in the z-layer
-                CHECK(a_star_distance<clk_lyt>(layout, {6, 2, 1}, {0, 4, 0}) == std::numeric_limits<uint64_t>::max());
-                CHECK(a_star_distance<clk_lyt>(layout, {6, 2, 0}, {0, 4, 1}) == std::numeric_limits<uint64_t>::max());
-                CHECK(a_star_distance<clk_lyt>(layout, {0, 4, 1}, {9, 1, 1}) == std::numeric_limits<uint64_t>::max());
+                // A* is not meant for routing to the z-layer
+                CHECK(a_star_distance<lyt>(layout, {6, 2, 0}, {0, 4, 1}) == std::numeric_limits<uint64_t>::max());
+                CHECK(a_star_distance<lyt>(layout, {0, 4, 1}, {9, 1, 1}) == std::numeric_limits<uint64_t>::max());
             }
-            SECTION("Floating-point distance type (double)")
+        }
+        SECTION("clocking path distance")
+        {
+            using clk_lyt = clocked_layout<lyt>;
+
+            SECTION("2DDWave")
             {
-                using namespace Catch::Matchers;
+                const clk_lyt layout{{9, 4, 1}, twoddwave_clocking<clk_lyt>()};
 
-                CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {0, 0}, {0, 0})), WithinAbs(0.0, 0.00001));
-                CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {1, 1}, {1, 1})), WithinAbs(0.0, 0.00001));
-                CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {0, 0}, {0, 1})), WithinAbs(1.0, 0.00001));
-                CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {0, 0}, {1, 1})), WithinAbs(2.0, 0.00001));
+                SECTION("Default distance type (uint64_t)")
+                {
+                    CHECK(a_star_distance<clk_lyt>(layout, {0, 0}, {0, 0}) == 0);
+                    CHECK(a_star_distance<clk_lyt>(layout, {1, 1}, {1, 1}) == 0);
+                    CHECK(a_star_distance<clk_lyt>(layout, {0, 0}, {0, 1}) == 1);
+                    CHECK(a_star_distance<clk_lyt>(layout, {0, 0}, {1, 1}) == 2);
+                    CHECK(a_star_distance<clk_lyt>(layout, {9, 1}, {6, 2}) == std::numeric_limits<uint64_t>::max());
+                    CHECK(a_star_distance<clk_lyt>(layout, {6, 2}, {0, 4}) == std::numeric_limits<uint64_t>::max());
+                    CHECK(a_star_distance<clk_lyt>(layout, {0, 4}, {9, 1}) == std::numeric_limits<uint64_t>::max());
 
-                CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {9, 1}, {6, 2})));
-                CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {6, 2}, {0, 4})));
-                CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {0, 4}, {9, 1})));
+                    // A* is not meant for routing to the z-layer
+                    CHECK(a_star_distance<clk_lyt>(layout, {6, 2, 0}, {0, 4, 1}) ==
+                          std::numeric_limits<uint64_t>::max());
+                    CHECK(a_star_distance<clk_lyt>(layout, {0, 4, 1}, {9, 1, 1}) ==
+                          std::numeric_limits<uint64_t>::max());
+                }
+                SECTION("Floating-point distance type (double)")
+                {
+                    using namespace Catch::Matchers;
 
-                // A* is not meant for routing in the z-layer
-                CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {6, 2, 1}, {0, 4, 0})));
-                CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {6, 2, 0}, {0, 4, 1})));
-                CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {0, 4, 1}, {9, 1, 1})));
+                    CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {0, 0}, {0, 0})), WithinAbs(0.0, 0.00001));
+                    CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {1, 1}, {1, 1})), WithinAbs(0.0, 0.00001));
+                    CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {0, 0}, {0, 1})), WithinAbs(1.0, 0.00001));
+                    CHECK_THAT((a_star_distance<clk_lyt, double>(layout, {0, 0}, {1, 1})), WithinAbs(2.0, 0.00001));
+
+                    CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {9, 1}, {6, 2})));
+                    CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {6, 2}, {0, 4})));
+                    CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {0, 4}, {9, 1})));
+
+                    // A* is not meant for routing in the z-layer
+                    CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {6, 2, 1}, {0, 4, 0})));
+                    CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {6, 2, 0}, {0, 4, 1})));
+                    CHECK(std::isinf(a_star_distance<clk_lyt, double>(layout, {0, 4, 1}, {9, 1, 1})));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("a_star distance functor", "[distance]")
+{
+    SECTION("Unsigned Cartesian layout")
+    {
+        using lyt = cartesian_layout<offset::ucoord_t>;
+
+        SECTION("coordinate path distance")
+        {
+            const lyt layout{{9, 4, 1}};
+
+            const a_star_distance_functor<lyt> distance{};
+
+            CHECK(distance(layout, {0, 0}, {0, 0}) == 0);
+            CHECK(distance(layout, {1, 1}, {1, 1}) == 0);
+            CHECK(distance(layout, {0, 0}, {0, 1}) == 1);
+            CHECK(distance(layout, {0, 0}, {1, 1}) == 2);
+            CHECK(distance(layout, {9, 1}, {6, 2}) == 4);
+            CHECK(distance(layout, {6, 2}, {0, 4}) == 8);
+            CHECK(distance(layout, {0, 4}, {9, 1}) == 12);
+
+            // A* is not meant for routing to the z-layer
+            CHECK(distance(layout, {6, 2, 0}, {0, 4, 1}) == std::numeric_limits<uint64_t>::max());
+            CHECK(distance(layout, {0, 4, 1}, {9, 1, 1}) == std::numeric_limits<uint64_t>::max());
+        }
+        SECTION("clocking path distance")
+        {
+            using clk_lyt = clocked_layout<lyt>;
+
+            SECTION("2DDWave")
+            {
+                const clk_lyt layout{{9, 4, 1}, twoddwave_clocking<clk_lyt>()};
+
+                SECTION("Default distance type (uint64_t)")
+                {
+                    const a_star_distance_functor<clk_lyt> distance{};
+
+                    CHECK(distance(layout, {0, 0}, {0, 0}) == 0);
+                    CHECK(distance(layout, {1, 1}, {1, 1}) == 0);
+                    CHECK(distance(layout, {0, 0}, {0, 1}) == 1);
+                    CHECK(distance(layout, {0, 0}, {1, 1}) == 2);
+                    CHECK(distance(layout, {9, 1}, {6, 2}) == std::numeric_limits<uint64_t>::max());
+                    CHECK(distance(layout, {6, 2}, {0, 4}) == std::numeric_limits<uint64_t>::max());
+                    CHECK(distance(layout, {0, 4}, {9, 1}) == std::numeric_limits<uint64_t>::max());
+
+                    // A* is not meant for routing to the z-layer
+                    CHECK(distance(layout, {6, 2, 0}, {0, 4, 1}) == std::numeric_limits<uint64_t>::max());
+                    CHECK(distance(layout, {0, 4, 1}, {9, 1, 1}) == std::numeric_limits<uint64_t>::max());
+                }
+                SECTION("Floating-point distance type (double)")
+                {
+                    using namespace Catch::Matchers;
+
+                    const a_star_distance_functor<clk_lyt, double> distance{};
+
+                    CHECK_THAT(distance(layout, {0, 0}, {0, 0}), WithinAbs(0.0, 0.00001));
+                    CHECK_THAT(distance(layout, {1, 1}, {1, 1}), WithinAbs(0.0, 0.00001));
+                    CHECK_THAT(distance(layout, {0, 0}, {0, 1}), WithinAbs(1.0, 0.00001));
+                    CHECK_THAT(distance(layout, {0, 0}, {1, 1}), WithinAbs(2.0, 0.00001));
+
+                    CHECK(std::isinf(distance(layout, {9, 1}, {6, 2})));
+                    CHECK(std::isinf(distance(layout, {6, 2}, {0, 4})));
+                    CHECK(std::isinf(distance(layout, {0, 4}, {9, 1})));
+
+                    // A* is not meant for routing to the z-layer
+                    CHECK(std::isinf(distance(layout, {6, 2, 0}, {0, 4, 1})));
+                    CHECK(std::isinf(distance(layout, {0, 4, 1}, {9, 1, 1})));
+                }
             }
         }
     }
@@ -392,55 +489,4 @@ TEST_CASE("SiDB nanometer distance", "[distance]")
     CHECK(sidb_nanometer_distance(layout, {0, 2, 1}, {-5, 1, 0}) ==
           std::hypot(sidb_simulation_parameters{}.lat_a * 0.5,
                      sidb_simulation_parameters{}.lat_b * 0.1 + sidb_simulation_parameters{}.lat_c * 0.1));
-}
-
-TEST_CASE("a_star distance functor", "[distance]")
-{
-    SECTION("Unsigned Cartesian layout")
-    {
-        using clk_lyt = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-
-        SECTION("2DDWave")
-        {
-            const clk_lyt layout{{9, 4, 1}, twoddwave_clocking<clk_lyt>()};
-
-            SECTION("Default distance type (uint64_t)")
-            {
-                const a_star_distance_functor<clk_lyt> distance{};
-
-                CHECK(distance(layout, {0, 0}, {0, 0}) == 0);
-                CHECK(distance(layout, {1, 1}, {1, 1}) == 0);
-                CHECK(distance(layout, {0, 0}, {0, 1}) == 1);
-                CHECK(distance(layout, {0, 0}, {1, 1}) == 2);
-                CHECK(distance(layout, {9, 1}, {6, 2}) == std::numeric_limits<uint64_t>::max());
-                CHECK(distance(layout, {6, 2}, {0, 4}) == std::numeric_limits<uint64_t>::max());
-                CHECK(distance(layout, {0, 4}, {9, 1}) == std::numeric_limits<uint64_t>::max());
-
-                // A* is not meant for routing in the z-layer
-                CHECK(distance(layout, {6, 2, 1}, {0, 4, 0}) == std::numeric_limits<uint64_t>::max());
-                CHECK(distance(layout, {6, 2, 0}, {0, 4, 1}) == std::numeric_limits<uint64_t>::max());
-                CHECK(distance(layout, {0, 4, 1}, {9, 1, 1}) == std::numeric_limits<uint64_t>::max());
-            }
-            SECTION("Floating-point distance type (double)")
-            {
-                using namespace Catch::Matchers;
-
-                const a_star_distance_functor<clk_lyt, double> distance{};
-
-                CHECK_THAT(distance(layout, {0, 0}, {0, 0}), WithinAbs(0.0, 0.00001));
-                CHECK_THAT(distance(layout, {1, 1}, {1, 1}), WithinAbs(0.0, 0.00001));
-                CHECK_THAT(distance(layout, {0, 0}, {0, 1}), WithinAbs(1.0, 0.00001));
-                CHECK_THAT(distance(layout, {0, 0}, {1, 1}), WithinAbs(2.0, 0.00001));
-
-                CHECK(std::isinf(distance(layout, {9, 1}, {6, 2})));
-                CHECK(std::isinf(distance(layout, {6, 2}, {0, 4})));
-                CHECK(std::isinf(distance(layout, {0, 4}, {9, 1})));
-
-                // A* is not meant for routing in the z-layer
-                CHECK(std::isinf(distance(layout, {6, 2, 1}, {0, 4, 0})));
-                CHECK(std::isinf(distance(layout, {6, 2, 0}, {0, 4, 1})));
-                CHECK(std::isinf(distance(layout, {0, 4, 1}, {9, 1, 1})));
-            }
-        }
-    }
 }

--- a/test/algorithms/path_finding/enumerate_all_paths.cpp
+++ b/test/algorithms/path_finding/enumerate_all_paths.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
 
         SECTION("(0,0) to (1,1)")  // two valid paths
         {
-            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{0, 0}, {1, 1}});
+            const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {1, 1}});
 
             CHECK(collection.size() == 2);
             CHECK(collection.contains({{{0, 0}, {0, 1}, {1, 1}}}));
@@ -33,7 +33,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
         }
         SECTION("(1,1) to (0,0)")  // two valid paths
         {
-            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{1, 1}, {0, 0}});
+            const auto collection = enumerate_all_paths<path>(layout, {{1, 1}, {0, 0}});
 
             CHECK(collection.size() == 2);
             CHECK(collection.contains({{{1, 1}, {0, 1}, {0, 0}}}));
@@ -41,7 +41,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
         }
         SECTION("(0,0) to (0,0)")  // source and target are identical
         {
-            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{0, 0}, {0, 0}});
+            const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {0, 0}});
 
             CHECK(collection.size() == 1);
             CHECK(collection.contains({{{0, 0}}}));
@@ -59,7 +59,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
 
             SECTION("(0,0) to (1,1)")  // two valid paths
             {
-                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {1, 1}});
+                const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {1, 1}});
 
                 CHECK(collection.size() == 2);
                 CHECK(collection.contains({{{0, 0}, {0, 1}, {1, 1}}}));
@@ -67,7 +67,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
             }
             SECTION("(1,1) to (0,0)")  // no valid paths
             {
-                const auto collection = enumerate_all_clocking_paths<path>(layout, {{1, 1}, {0, 0}});
+                const auto collection = enumerate_all_paths<path>(layout, {{1, 1}, {0, 0}});
 
                 CHECK(collection.empty());
                 CHECK(!collection.contains({{{0, 0}, {0, 1}, {1, 1}}}));
@@ -75,7 +75,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
             }
             SECTION("(0,0) to (0,0)")  // source and target are identical
             {
-                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 0}});
+                const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {0, 0}});
 
                 CHECK(collection.size() == 1);
                 CHECK(collection.contains({{{0, 0}}}));
@@ -89,7 +89,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
 
             SECTION("(0,0) to (0,1)")  // one valid path
             {
-                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 1}});
+                const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {0, 1}});
 
                 CHECK(collection.size() == 1);
                 CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
@@ -98,7 +98,7 @@ TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
             }
             SECTION("(0,0) to (0,0)")  // source and target are identical
             {
-                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 0}});
+                const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {0, 0}});
 
                 CHECK(collection.size() == 1);
                 CHECK(collection.contains({{{0, 0}}}));
@@ -120,7 +120,7 @@ TEST_CASE("Enumerate all paths on 4x4 layouts", "[enumerate-all-paths]")
 
         SECTION("(0,0) to (3,3) without obstruction")  // 184 valid paths
         {
-            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{0, 0}, {3, 3}});
+            const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {3, 3}});
 
             CHECK(collection.size() == 184);
         }
@@ -135,7 +135,7 @@ TEST_CASE("Enumerate all paths on 4x4 layouts", "[enumerate-all-paths]")
 
             SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
             {
-                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {3, 3}});
+                const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {3, 3}});
 
                 CHECK(collection.size() == 20);
             }
@@ -146,7 +146,7 @@ TEST_CASE("Enumerate all paths on 4x4 layouts", "[enumerate-all-paths]")
 
             SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
             {
-                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {3, 3}});
+                const auto collection = enumerate_all_paths<path>(layout, {{0, 0}, {3, 3}});
 
                 CHECK(collection.size() == 4);
             }
@@ -165,12 +165,12 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with coordinate obstruc
 
         SECTION("(0,0) to (3,3) with coordinate obstruction")  // 108 valid paths
         {
-            obstruction_layout obstr_lyt{layout};
+            obstruction_layout obstr_lyt{static_cast<cartesian_layout<>>(layout)};
 
-            // create a PI as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 75 paths
+            // mark coordinate as obstructed
+            obstr_lyt.obstruct_coordinate({3, 0});  // blocks 75 paths
 
-            const auto collection = enumerate_all_coordinate_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+            const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
             CHECK(collection.size() == 108);
         }
@@ -188,7 +188,7 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with coordinate obstruc
                 // create a PI as obstruction
                 obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 1 path
 
-                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+                const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
                 CHECK(collection.size() == 19);
             }
@@ -204,7 +204,7 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with coordinate obstruc
                 // create a PI as obstruction
                 obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
 
-                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+                const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
                 CHECK(collection.size() == 1);
             }
@@ -237,7 +237,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
                     const auto w  = obstr_lyt.create_buf(pi, {1, 1});  // obstruction that can be crossed over
                     obstr_lyt.create_po(w, "obstruction PO", {1, 2});  // obstructs 1 coordinate
 
-                    const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {2, 2}}, params);
+                    const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {2, 2}}, params);
 
                     CHECK(collection.size() == 1);
                     CHECK(collection.contains({{{0, 0}, {0, 1}, {1, 1, 1}, {2, 1}, {2, 2}}}));
@@ -256,7 +256,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
                     const auto w  = obstr_lyt.create_buf(pi, {1, 1});  // obstruction that can be crossed over
                     obstr_lyt.create_po(w, "obstruction PO", {0, 1});  // obstructs 1 coordinate
 
-                    const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {2, 2}}, params);
+                    const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {2, 2}}, params);
 
                     CHECK(collection.size() == 1);
                     CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1, 1}, {1, 2}, {2, 2}}}));
@@ -287,7 +287,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
                     const auto w22 = obstr_lyt.create_buf(w21, {2, 2});  // obstruction that can be crossed over
                     obstr_lyt.create_po(w22, "obstruction PO", {2, 3});  // obstructs 1 coordinate
 
-                    const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}}, params);
+                    const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 3}}, params);
 
                     CHECK(collection.size() == 2);
                     CHECK(collection.contains({{{0, 0}, {0, 1}, {1, 1, 1}, {2, 1, 1}, {3, 1}, {3, 2}, {3, 3}}}));
@@ -317,7 +317,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
                     const auto w2  = obstr_lyt.create_buf(pi2, {2, 1});  // obstruction that can be crossed over
                     obstr_lyt.create_po(w2, "obstruction PO", {3, 1});   // obstructs 1 coordinate
 
-                    const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 2}}, params);
+                    const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 2}}, params);
 
                     CHECK(collection.size() == 1);
                     CHECK(collection.contains({{{0, 0}, {0, 1}, {1, 1, 1}, {2, 1, 1}, {2, 2}, {3, 2}}}));
@@ -338,12 +338,12 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with connection obstruc
 
         SECTION("(0,0) to (3,3) with connection obstruction")  // 108 valid paths
         {
-            obstruction_layout obstr_lyt{layout};
+            obstruction_layout obstr_lyt{static_cast<cartesian_layout<>>(layout)};
 
             // create a connection obstruction
             obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 75 paths
 
-            const auto collection = enumerate_all_coordinate_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+            const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
             CHECK(collection.size() == 108);
         }
@@ -361,7 +361,7 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with connection obstruc
                 // create a connection obstruction
                 obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 1 path
 
-                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+                const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
                 CHECK(collection.size() == 19);
             }
@@ -377,7 +377,7 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with connection obstruc
                 // create a PI as obstruction
                 obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
 
-                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+                const auto collection = enumerate_all_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
                 CHECK(collection.size() == 1);
             }

--- a/test/algorithms/path_finding/enumerate_all_paths.cpp
+++ b/test/algorithms/path_finding/enumerate_all_paths.cpp
@@ -14,91 +14,142 @@
 
 using namespace fiction;
 
-TEST_CASE("Enumerate all paths on 2x2 clocked layouts", "[enumerate-all-paths]")
+TEST_CASE("Enumerate all paths on 2x2 layouts", "[enumerate-all-paths]")
 {
-    using clk_lyt = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using path    = layout_coordinate_path<clk_lyt>;
+    using lyt  = cartesian_layout<offset::ucoord_t>;
+    using path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{1, 1}};
 
         SECTION("(0,0) to (1,1)")  // two valid paths
         {
-            const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {1, 1}});
+            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{0, 0}, {1, 1}});
 
             CHECK(collection.size() == 2);
             CHECK(collection.contains({{{0, 0}, {0, 1}, {1, 1}}}));
             CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}}}));
         }
-        SECTION("(1,1) to (0,0)")  // no valid paths
+        SECTION("(1,1) to (0,0)")  // two valid paths
         {
-            const auto collection = enumerate_all_clocking_paths<path>(layout, {{1, 1}, {0, 0}});
+            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{1, 1}, {0, 0}});
 
-            CHECK(collection.empty());
-            CHECK(!collection.contains({{{0, 0}, {0, 1}, {1, 1}}}));
-            CHECK(!collection.contains({{{0, 0}, {1, 0}, {1, 1}}}));
+            CHECK(collection.size() == 2);
+            CHECK(collection.contains({{{1, 1}, {0, 1}, {0, 0}}}));
+            CHECK(collection.contains({{{1, 1}, {1, 0}, {0, 0}}}));
         }
         SECTION("(0,0) to (0,0)")  // source and target are identical
         {
-            const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 0}});
+            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{0, 0}, {0, 0}});
 
             CHECK(collection.size() == 1);
             CHECK(collection.contains({{{0, 0}}}));
-            CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
-            CHECK(collection[0].target() == coordinate<clk_lyt>{0, 0});
+            CHECK(collection[0].source() == coordinate<lyt>{0, 0});
+            CHECK(collection[0].target() == coordinate<lyt>{0, 0});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("(0,0) to (0,1)")  // one valid path
+        SECTION("2DDWave")
         {
-            const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 1}});
+            const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
 
-            CHECK(collection.size() == 1);
-            CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
-            CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
-            CHECK(collection[0].target() == coordinate<clk_lyt>{0, 1});
+            SECTION("(0,0) to (1,1)")  // two valid paths
+            {
+                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {1, 1}});
+
+                CHECK(collection.size() == 2);
+                CHECK(collection.contains({{{0, 0}, {0, 1}, {1, 1}}}));
+                CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}}}));
+            }
+            SECTION("(1,1) to (0,0)")  // no valid paths
+            {
+                const auto collection = enumerate_all_clocking_paths<path>(layout, {{1, 1}, {0, 0}});
+
+                CHECK(collection.empty());
+                CHECK(!collection.contains({{{0, 0}, {0, 1}, {1, 1}}}));
+                CHECK(!collection.contains({{{0, 0}, {1, 0}, {1, 1}}}));
+            }
+            SECTION("(0,0) to (0,0)")  // source and target are identical
+            {
+                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 0}});
+
+                CHECK(collection.size() == 1);
+                CHECK(collection.contains({{{0, 0}}}));
+                CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
+                CHECK(collection[0].target() == coordinate<clk_lyt>{0, 0});
+            }
         }
-        SECTION("(0,0) to (0,0)")  // source and target are identical
+        SECTION("USE")
         {
-            const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 0}});
+            const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
 
-            CHECK(collection.size() == 1);
-            CHECK(collection.contains({{{0, 0}}}));
-            CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
-            CHECK(collection[0].target() == coordinate<clk_lyt>{0, 0});
+            SECTION("(0,0) to (0,1)")  // one valid path
+            {
+                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 1}});
+
+                CHECK(collection.size() == 1);
+                CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
+                CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
+                CHECK(collection[0].target() == coordinate<clk_lyt>{0, 1});
+            }
+            SECTION("(0,0) to (0,0)")  // source and target are identical
+            {
+                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {0, 0}});
+
+                CHECK(collection.size() == 1);
+                CHECK(collection.contains({{{0, 0}}}));
+                CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
+                CHECK(collection[0].target() == coordinate<clk_lyt>{0, 0});
+            }
         }
     }
 }
 
-TEST_CASE("Enumerate all paths on 4x4 clocked layouts", "[enumerate-all-paths]")
+TEST_CASE("Enumerate all paths on 4x4 layouts", "[enumerate-all-paths]")
 {
-    using clk_lyt = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using path    = layout_coordinate_path<clk_lyt>;
+    using lyt  = cartesian_layout<offset::ucoord_t>;
+    using path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{3, 3}};
 
-        SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+        SECTION("(0,0) to (3,3) without obstruction")  // 184 valid paths
         {
-            const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {3, 3}});
+            const auto collection = enumerate_all_coordinate_paths<path>(layout, {{0, 0}, {3, 3}});
 
-            CHECK(collection.size() == 20);
+            CHECK(collection.size() == 184);
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+        SECTION("2DDWave")
         {
-            const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {3, 3}});
+            const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
 
-            CHECK(collection.size() == 4);
+            SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+            {
+                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {3, 3}});
+
+                CHECK(collection.size() == 20);
+            }
+        }
+        SECTION("USE")
+        {
+            const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+
+            SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+            {
+                const auto collection = enumerate_all_clocking_paths<path>(layout, {{0, 0}, {3, 3}});
+
+                CHECK(collection.size() == 4);
+            }
         }
     }
 }
@@ -108,36 +159,55 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with coordinate obstruc
     using gate_lyt = gate_level_layout<clocked_layout<cartesian_layout<offset::ucoord_t>>>;
     using path     = layout_coordinate_path<gate_lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
+        const gate_lyt layout{{3, 3}};
 
-        SECTION("(0,0) to (3,3) with coordinate obstruction")  // 19 valid paths
+        SECTION("(0,0) to (3,3) with coordinate obstruction")  // 108 valid paths
         {
             obstruction_layout obstr_lyt{layout};
 
             // create a PI as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 1 path
+            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 75 paths
 
-            const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+            const auto collection = enumerate_all_coordinate_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
-            CHECK(collection.size() == 19);
+            CHECK(collection.size() == 108);
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
-
-        SECTION("(0,0) to (3,3) with coordinate obstruction")  // 1 valid path
+        SECTION("2DDWave")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
 
-            // create a PI as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with coordinate obstruction")  // 19 valid paths
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+                // create a PI as obstruction
+                obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 1 path
 
-            CHECK(collection.size() == 1);
+                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+
+                CHECK(collection.size() == 19);
+            }
+        }
+        SECTION("USE")
+        {
+            const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
+
+            SECTION("(0,0) to (3,3) with coordinate obstruction")  // 1 valid path
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                // create a PI as obstruction
+                obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
+
+                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+
+                CHECK(collection.size() == 1);
+            }
         }
     }
 }
@@ -148,7 +218,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
     using path     = layout_coordinate_path<gate_lyt>;
 
     // enable crossings
-    const enumerate_all_clocking_paths_params params{true};
+    const enumerate_all_paths_params params{true};
 
     SECTION("Single crossing")
     {
@@ -262,36 +332,55 @@ TEST_CASE("Enumerate all paths on 4x4 gate-level layouts with connection obstruc
     using gate_lyt = gate_level_layout<clocked_layout<cartesian_layout<offset::ucoord_t>>>;
     using path     = layout_coordinate_path<gate_lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
+        const gate_lyt layout{{3, 3}};
 
-        SECTION("(0,0) to (3,3) with connection obstruction")  // 19 valid paths
+        SECTION("(0,0) to (3,3) with connection obstruction")  // 108 valid paths
         {
             obstruction_layout obstr_lyt{layout};
 
             // create a connection obstruction
-            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 1 path
+            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 75 paths
 
-            const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+            const auto collection = enumerate_all_coordinate_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
 
-            CHECK(collection.size() == 19);
+            CHECK(collection.size() == 108);
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
-
-        SECTION("(0,0) to (3,3) with connection obstruction")  // 1 valid path
+        SECTION("2DDWave")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
 
-            // create a PI as obstruction
-            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with connection obstruction")  // 19 valid paths
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+                // create a connection obstruction
+                obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 1 path
 
-            CHECK(collection.size() == 1);
+                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+
+                CHECK(collection.size() == 19);
+            }
+        }
+        SECTION("USE")
+        {
+            const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
+
+            SECTION("(0,0) to (3,3) with connection obstruction")  // 1 valid path
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                // create a PI as obstruction
+                obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+
+                const auto collection = enumerate_all_clocking_paths<path>(obstr_lyt, {{0, 0}, {3, 3}});
+
+                CHECK(collection.size() == 1);
+            }
         }
     }
 }

--- a/test/algorithms/path_finding/jump_point_search.cpp
+++ b/test/algorithms/path_finding/jump_point_search.cpp
@@ -17,94 +17,150 @@
 
 using namespace fiction;
 
-TEST_CASE("JPS on 2x2 clocked layouts", "[JPS]")
+TEST_CASE("JPS on 2x2 layouts", "[JPS]")
 {
-    using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using coord_path = layout_coordinate_path<clk_lyt>;
+    using lyt        = cartesian_layout<offset::ucoord_t>;
+    using coord_path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{1, 1}};
 
         SECTION("(0,0) to (1,1)")  // path of length 3
         {
             const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {1, 1}});
 
             CHECK(path.size() == 3);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{1, 1});
+            CHECK(path.source() == coordinate<lyt>{0, 0});
+            CHECK(path.target() == coordinate<lyt>{1, 1});
             // path could either go east-south or south-east
-            CHECK((path[1] == coordinate<clk_lyt>{1, 0} || path[1] == coordinate<clk_lyt>{0, 1}));
+            CHECK((path[1] == coordinate<lyt>{1, 0} || path[1] == coordinate<lyt>{0, 1}));
         }
-        SECTION("(1,1) to (0,0)")  // no valid paths
+        SECTION("(1,1) to (0,0)")  // path of length 3
         {
             const auto path = jump_point_search<coord_path>(layout, {{1, 1}, {0, 0}});
 
-            CHECK(path.empty());
+            CHECK(path.size() == 3);
+            CHECK(path.source() == coordinate<lyt>{1, 1});
+            CHECK(path.target() == coordinate<lyt>{0, 0});
+            // path could either go west-north or north-west
+            CHECK((path[1] == coordinate<lyt>{1, 0} || path[1] == coordinate<lyt>{0, 1}));
         }
         SECTION("(0,0) to (0,0)")  // source and target are identical
         {
             const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {0, 0}});
 
             CHECK(path.size() == 1);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            CHECK(path.source() == coordinate<lyt>{0, 0});
+            CHECK(path.target() == coordinate<lyt>{0, 0});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("(0,0) to (0,1)")  // path of length 4
+        SECTION("2DDWave")
         {
-            const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {0, 1}});
+            const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
 
-            CHECK(path.size() == 4);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{0, 1});
-            CHECK(path[1] == coordinate<clk_lyt>{1, 0});
-            CHECK(path[2] == coordinate<clk_lyt>{1, 1});
+            SECTION("(0,0) to (1,1)")  // path of length 3
+            {
+                const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {1, 1}});
+
+                CHECK(path.size() == 3);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{1, 1});
+                // path could either go east-south or south-east
+                CHECK((path[1] == coordinate<clk_lyt>{1, 0} || path[1] == coordinate<clk_lyt>{0, 1}));
+            }
+            SECTION("(1,1) to (0,0)")  // no valid paths
+            {
+                const auto path = jump_point_search<coord_path>(layout, {{1, 1}, {0, 0}});
+
+                CHECK(path.empty());
+            }
+            SECTION("(0,0) to (0,0)")  // source and target are identical
+            {
+                const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {0, 0}});
+
+                CHECK(path.size() == 1);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            }
         }
-        SECTION("(0,0) to (0,0)")  // source and target are identical
+        SECTION("USE")
         {
-            const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {0, 0}});
+            const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
 
-            CHECK(path.size() == 1);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            SECTION("(0,0) to (0,1)")  // path of length 4
+            {
+                const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {0, 1}});
+
+                CHECK(path.size() == 4);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{0, 1});
+                CHECK(path[1] == coordinate<clk_lyt>{1, 0});
+                CHECK(path[2] == coordinate<clk_lyt>{1, 1});
+            }
+            SECTION("(0,0) to (0,0)")  // source and target are identical
+            {
+                const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {0, 0}});
+
+                CHECK(path.size() == 1);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{0, 0});
+            }
         }
     }
 }
 
-TEST_CASE("JPS on 4x4 clocked layouts", "[JPS]")
+TEST_CASE("JPS on 4x4 layouts", "[JPS]")
 {
-    using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using coord_path = layout_coordinate_path<clk_lyt>;
+    using lyt        = cartesian_layout<offset::ucoord_t>;
+    using coord_path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{3, 3}};
 
         SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
         {
             const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {3, 3}});
 
             CHECK(path.size() == 7);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            CHECK(path.source() == coordinate<lyt>{0, 0});
+            CHECK(path.target() == coordinate<lyt>{3, 3});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+        SECTION("2DDWave")
         {
-            const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {3, 3}});
+            const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
 
-            CHECK(path.size() == 7);
-            CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-            CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+            {
+                const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {3, 3}});
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            }
+        }
+        SECTION("USE")
+        {
+            const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+
+            SECTION("(0,0) to (3,3) without obstruction")  // path of length 7
+            {
+                const auto path = jump_point_search<coord_path>(layout, {{0, 0}, {3, 3}});
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                CHECK(path.target() == coordinate<clk_lyt>{3, 3});
+            }
         }
     }
 }
@@ -171,13 +227,13 @@ TEST_CASE("JPS on 4x4 gate-level layouts with connection obstruction", "[JPS]")
     using gate_lyt   = gate_level_layout<clocked_layout<cartesian_layout<offset::ucoord_t>>>;
     using coord_path = layout_coordinate_path<gate_lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
+        const gate_lyt layout{{3, 3}};
 
         SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
         {
-            obstruction_layout obstr_lyt{layout};
+            obstruction_layout obstr_lyt{static_cast<cartesian_layout<>>(layout)};
 
             // create some connection obstructions
             obstr_lyt.obstruct_connection({0, 0}, {1, 0});
@@ -197,95 +253,159 @@ TEST_CASE("JPS on 4x4 gate-level layouts with connection obstruction", "[JPS]")
             CHECK(path[5] == coordinate<gate_lyt>{2, 3});
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
-
-        SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+        SECTION("2DDWave")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
 
-            // create a PI as obstruction
-            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto path = jump_point_search<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+                // create some connection obstructions
+                obstr_lyt.obstruct_connection({0, 0}, {1, 0});
+                obstr_lyt.obstruct_connection({0, 1}, {1, 1});
+                obstr_lyt.obstruct_connection({0, 2}, {1, 2});
+                // leaving only one valid path via (0,4)
 
-            CHECK(path.size() == 7);
-            CHECK(path.source() == coordinate<gate_lyt>{0, 0});
-            CHECK(path.target() == coordinate<gate_lyt>{3, 3});
-            CHECK(path[1] == coordinate<gate_lyt>{1, 0});
-            CHECK(path[2] == coordinate<gate_lyt>{1, 1});
-            CHECK(path[3] == coordinate<gate_lyt>{1, 2});
-            CHECK(path[4] == coordinate<gate_lyt>{2, 2});
-            CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+                const auto path = jump_point_search<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<gate_lyt>{0, 0});
+                CHECK(path.target() == coordinate<gate_lyt>{3, 3});
+                CHECK(path[1] == coordinate<gate_lyt>{0, 1});
+                CHECK(path[2] == coordinate<gate_lyt>{0, 2});
+                CHECK(path[3] == coordinate<gate_lyt>{0, 3});
+                CHECK(path[4] == coordinate<gate_lyt>{1, 3});
+                CHECK(path[5] == coordinate<gate_lyt>{2, 3});
+            }
+        }
+        SECTION("USE")
+        {
+            const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
+
+            SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                // create a PI as obstruction
+                obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+
+                const auto path = jump_point_search<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
+
+                CHECK(path.size() == 7);
+                CHECK(path.source() == coordinate<gate_lyt>{0, 0});
+                CHECK(path.target() == coordinate<gate_lyt>{3, 3});
+                CHECK(path[1] == coordinate<gate_lyt>{1, 0});
+                CHECK(path[2] == coordinate<gate_lyt>{1, 1});
+                CHECK(path[3] == coordinate<gate_lyt>{1, 2});
+                CHECK(path[4] == coordinate<gate_lyt>{2, 2});
+                CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+            }
         }
     }
 }
 
-TEST_CASE("JPS on 10x10 clocked layouts with varying distance functions", "[JPS]")
+TEST_CASE("JPS on 10x10 layouts with varying distance functions", "[JPS]")
 {
-    using clk_lyt    = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using coord_path = layout_coordinate_path<clk_lyt>;
+    using lyt        = cartesian_layout<offset::ucoord_t>;
+    using clk_lyt    = clocked_layout<lyt>;
+    using coord_path = layout_coordinate_path<lyt>;
 
-    SECTION("Manhattan")
+    SECTION("Manhattan distance")
     {
-        SECTION("RES")
+        SECTION("coordinate paths")
         {
-            const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
-
-            SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
-            {
-                const auto path = jump_point_search<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}},
-                                                                         manhattan_distance_functor<clk_lyt>());
-
-                CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
-            }
-        }
-        SECTION("ESR")
-        {
-            const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
+            const lyt layout{{9, 9}};
 
             SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
             {
                 const auto path =
-                    jump_point_search<coord_path>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<clk_lyt>());
+                    jump_point_search<coord_path>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<lyt>());
 
                 CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                CHECK(path.source() == coordinate<lyt>{0, 0});
+                CHECK(path.target() == coordinate<lyt>{9, 9});
+            }
+        }
+        SECTION("clocking paths")
+        {
+            SECTION("RES")
+            {
+                const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
+
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path = jump_point_search<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}},
+                                                                             manhattan_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
+            }
+            SECTION("ESP")
+            {
+                const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
+
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path =
+                        jump_point_search<coord_path>(layout, {{0, 0}, {9, 9}}, manhattan_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
             }
         }
     }
-    SECTION("Euclidean")
+    SECTION("Euclidean distance")
     {
-        SECTION("RES")
+        SECTION("coordinate paths")
         {
-            const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
-
-            SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
-            {
-                const auto path = jump_point_search<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}},
-                                                                         euclidean_distance_functor<clk_lyt>());
-
-                CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
-            }
-        }
-        SECTION("ESR")
-        {
-            const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
+            const lyt layout{{9, 9}};
 
             SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
             {
                 const auto path =
-                    jump_point_search<coord_path>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<clk_lyt>());
+                    jump_point_search<coord_path>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<lyt>());
 
                 CHECK(path.size() == 19);
-                CHECK(path.source() == coordinate<clk_lyt>{0, 0});
-                CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                CHECK(path.source() == coordinate<lyt>{0, 0});
+                CHECK(path.target() == coordinate<lyt>{9, 9});
+            }
+        }
+        SECTION("clocking paths")
+        {
+            SECTION("RES")
+            {
+                const clk_lyt layout{{9, 9}, res_clocking<clk_lyt>()};
+
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path = jump_point_search<coord_path, clk_lyt>(layout, {{0, 0}, {9, 9}},
+                                                                             euclidean_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
+            }
+            SECTION("ESP")
+            {
+                const clk_lyt layout{{9, 9}, esr_clocking<clk_lyt>()};
+
+                SECTION("(0,0) to (9,9) without obstruction")  // path of length 19
+                {
+                    const auto path =
+                        jump_point_search<coord_path>(layout, {{0, 0}, {9, 9}}, euclidean_distance_functor<clk_lyt>());
+
+                    CHECK(path.size() == 19);
+                    CHECK(path.source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(path.target() == coordinate<clk_lyt>{9, 9});
+                }
             }
         }
     }

--- a/test/algorithms/path_finding/k_shortest_paths.cpp
+++ b/test/algorithms/path_finding/k_shortest_paths.cpp
@@ -14,14 +14,14 @@
 
 using namespace fiction;
 
-TEST_CASE("Yen's algorithm on 2x2 clocked layouts", "[k-shortest-paths]")
+TEST_CASE("Yen's algorithm on 2x2 layouts", "[k-shortest-paths]")
 {
-    using clk_lyt = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using path    = layout_coordinate_path<clk_lyt>;
+    using lyt  = cartesian_layout<>;
+    using path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{1, 1}};
 
         SECTION("k = 1")
         {
@@ -32,14 +32,16 @@ TEST_CASE("Yen's algorithm on 2x2 clocked layouts", "[k-shortest-paths]")
                 const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {1, 1}}, k);
 
                 CHECK(collection.size() == 1);
-                CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
-                CHECK(collection[0].target() == coordinate<clk_lyt>{1, 1});
+                CHECK(collection[0].source() == coordinate<lyt>{0, 0});
+                CHECK(collection[0].target() == coordinate<lyt>{1, 1});
             }
-            SECTION("(1,1) to (0,0)")  // no valid paths
+            SECTION("(1,1) to (0,0)")  // two valid paths
             {
                 const auto collection = yen_k_shortest_paths<path>(layout, {{1, 1}, {0, 0}}, k);
 
-                CHECK(collection.empty());
+                CHECK(collection.size() == 1);
+                CHECK(collection[0].source() == coordinate<lyt>{1, 1});
+                CHECK(collection[0].target() == coordinate<lyt>{0, 0});
             }
             SECTION("(0,0) to (0,0)")  // source and target are identical
             {
@@ -65,7 +67,9 @@ TEST_CASE("Yen's algorithm on 2x2 clocked layouts", "[k-shortest-paths]")
             {
                 const auto collection = yen_k_shortest_paths<path>(layout, {{1, 1}, {0, 0}}, k);
 
-                CHECK(collection.empty());
+                CHECK(collection.size() == 2);
+                CHECK(collection.contains({{1, 1}, {1, 0}, {0, 0}}));
+                CHECK(collection.contains({{1, 1}, {0, 1}, {0, 0}}));
             }
             SECTION("(0,0) to (0,0)")  // source and target are identical
             {
@@ -91,7 +95,9 @@ TEST_CASE("Yen's algorithm on 2x2 clocked layouts", "[k-shortest-paths]")
             {
                 const auto collection = yen_k_shortest_paths<path>(layout, {{1, 1}, {0, 0}}, k);
 
-                CHECK(collection.empty());
+                CHECK(collection.size() == 2);
+                CHECK(collection.contains({{1, 1}, {1, 0}, {0, 0}}));
+                CHECK(collection.contains({{1, 1}, {0, 1}, {0, 0}}));
             }
             SECTION("(0,0) to (0,0)")  // source and target are identical
             {
@@ -102,84 +108,172 @@ TEST_CASE("Yen's algorithm on 2x2 clocked layouts", "[k-shortest-paths]")
             }
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("k = 1")
+        SECTION("2DDWave")
         {
-            constexpr const auto k = 1;
+            const clk_lyt layout{{1, 1}, twoddwave_clocking<clk_lyt>()};
 
-            SECTION("(0,0) to (0,1)")  // one valid path
+            SECTION("k = 1")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 1}}, k);
+                constexpr const auto k = 1;
 
-                CHECK(collection.size() == 1);
-                CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
+                SECTION("(0,0) to (1,1)")  // two valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {1, 1}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection[0].source() == coordinate<clk_lyt>{0, 0});
+                    CHECK(collection[0].target() == coordinate<clk_lyt>{1, 1});
+                }
+                SECTION("(1,1) to (0,0)")  // no valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{1, 1}, {0, 0}}, k);
+
+                    CHECK(collection.empty());
+                }
+                SECTION("(0,0) to (0,0)")  // source and target are identical
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}}}));
+                }
             }
-            SECTION("(0,0) to (0,0)")  // source and target are identical
+            SECTION("k = 2")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+                constexpr const auto k = 2;
 
-                CHECK(collection.size() == 1);
-                CHECK(collection.contains({{{0, 0}}}));
+                SECTION("(0,0) to (1,1)")  // two valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {1, 1}}, k);
+
+                    CHECK(collection.size() == 2);
+                    CHECK(collection.contains({{0, 0}, {1, 0}, {1, 1}}));
+                    CHECK(collection.contains({{0, 0}, {0, 1}, {1, 1}}));
+                }
+                SECTION("(1,1) to (0,0)")  // no valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{1, 1}, {0, 0}}, k);
+
+                    CHECK(collection.empty());
+                }
+                SECTION("(0,0) to (0,0)")  // source and target are identical
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}}}));
+                }
+            }
+            SECTION("k = 3")
+            {
+                constexpr const auto k = 3;
+
+                SECTION("(0,0) to (1,1)")  // two valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {1, 1}}, k);
+
+                    CHECK(collection.size() == 2);
+                    CHECK(collection.contains({{0, 0}, {1, 0}, {1, 1}}));
+                    CHECK(collection.contains({{0, 0}, {0, 1}, {1, 1}}));
+                }
+                SECTION("(1,1) to (0,0)")  // no valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{1, 1}, {0, 0}}, k);
+
+                    CHECK(collection.empty());
+                }
+                SECTION("(0,0) to (0,0)")  // source and target are identical
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}}}));
+                }
             }
         }
-        SECTION("k = 2")
+        SECTION("USE")
         {
-            constexpr const auto k = 2;
+            const clk_lyt layout{{1, 1}, use_clocking<clk_lyt>()};
 
-            SECTION("(0,0) to (0,1)")  // one valid path
+            SECTION("k = 1")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 1}}, k);
+                constexpr const auto k = 1;
 
-                CHECK(collection.size() == 1);
-                CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
+                SECTION("(0,0) to (0,1)")  // one valid path
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 1}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
+                }
+                SECTION("(0,0) to (0,0)")  // source and target are identical
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}}}));
+                }
             }
-            SECTION("(0,0) to (0,0)")  // source and target are identical
+            SECTION("k = 2")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+                constexpr const auto k = 2;
 
-                CHECK(collection.size() == 1);
-                CHECK(collection.contains({{{0, 0}}}));
+                SECTION("(0,0) to (0,1)")  // one valid path
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 1}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
+                }
+                SECTION("(0,0) to (0,0)")  // source and target are identical
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}}}));
+                }
             }
-        }
-        SECTION("k = 3")
-        {
-            constexpr const auto k = 3;
-
-            SECTION("(0,0) to (0,1)")  // one valid path
+            SECTION("k = 3")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 1}}, k);
+                constexpr const auto k = 3;
 
-                CHECK(collection.size() == 1);
-                CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
-            }
-            SECTION("(0,0) to (0,0)")  // source and target are identical
-            {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+                SECTION("(0,0) to (0,1)")  // one valid path
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 1}}, k);
 
-                CHECK(collection.size() == 1);
-                CHECK(collection.contains({{{0, 0}}}));
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}, {1, 0}, {1, 1}, {0, 1}}}));
+                }
+                SECTION("(0,0) to (0,0)")  // source and target are identical
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {0, 0}}, k);
+
+                    CHECK(collection.size() == 1);
+                    CHECK(collection.contains({{{0, 0}}}));
+                }
             }
         }
     }
 }
 
-TEST_CASE("Yen's algorithm on 4x4 clocked layouts", "[k-shortest-paths]")
+TEST_CASE("Yen's algorithm on 4x4 layouts", "[k-shortest-paths]")
 {
-    using clk_lyt = clocked_layout<cartesian_layout<offset::ucoord_t>>;
-    using path    = layout_coordinate_path<clk_lyt>;
+    using lyt  = cartesian_layout<>;
+    using path = layout_coordinate_path<lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
+        const lyt layout{{3, 3}};
 
         SECTION("k = 1")
         {
             constexpr const auto k = 1;
 
-            SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+            SECTION("(0,0) to (3,3) without obstruction")  // 184 valid paths
             {
                 const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
 
@@ -190,7 +284,7 @@ TEST_CASE("Yen's algorithm on 4x4 clocked layouts", "[k-shortest-paths]")
         {
             constexpr const auto k = 5;
 
-            SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+            SECTION("(0,0) to (3,3) without obstruction")  // 184 valid paths
             {
                 const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
 
@@ -201,7 +295,7 @@ TEST_CASE("Yen's algorithm on 4x4 clocked layouts", "[k-shortest-paths]")
         {
             constexpr const auto k = 10;
 
-            SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+            SECTION("(0,0) to (3,3) without obstruction")  // 184 valid paths
             {
                 const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
 
@@ -212,7 +306,7 @@ TEST_CASE("Yen's algorithm on 4x4 clocked layouts", "[k-shortest-paths]")
         {
             constexpr const auto k = 20;
 
-            SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+            SECTION("(0,0) to (3,3) without obstruction")  // 184 valid paths
             {
                 const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
 
@@ -220,52 +314,106 @@ TEST_CASE("Yen's algorithm on 4x4 clocked layouts", "[k-shortest-paths]")
             }
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
+        using clk_lyt = clocked_layout<lyt>;
 
-        SECTION("k = 1")
+        SECTION("2DDWave")
         {
-            constexpr const auto k = 1;
+            const clk_lyt layout{{3, 3}, twoddwave_clocking<clk_lyt>()};
 
-            SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+            SECTION("k = 1")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+                constexpr const auto k = 1;
 
-                CHECK(collection.size() == k);
+                SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
+            }
+            SECTION("k = 5")
+            {
+                constexpr const auto k = 5;
+
+                SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
+            }
+            SECTION("k = 10")
+            {
+                constexpr const auto k = 10;
+
+                SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
+            }
+            SECTION("k = 20")
+            {
+                constexpr const auto k = 20;
+
+                SECTION("(0,0) to (3,3) without obstruction")  // 20 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
             }
         }
-        SECTION("k = 2")
+        SECTION("USE")
         {
-            constexpr const auto k = 2;
+            const clk_lyt layout{{3, 3}, use_clocking<clk_lyt>()};
 
-            SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+            SECTION("k = 1")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+                constexpr const auto k = 1;
 
-                CHECK(collection.size() == k);
+                SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
             }
-        }
-        SECTION("k = 3")
-        {
-            constexpr const auto k = 3;
-
-            SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+            SECTION("k = 2")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+                constexpr const auto k = 2;
 
-                CHECK(collection.size() == k);
+                SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
             }
-        }
-        SECTION("k = 4")
-        {
-            constexpr const auto k = 4;
-
-            SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+            SECTION("k = 3")
             {
-                const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+                constexpr const auto k = 3;
 
-                CHECK(collection.size() == k);
+                SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
+            }
+            SECTION("k = 4")
+            {
+                constexpr const auto k = 4;
+
+                SECTION("(0,0) to (3,3) without obstruction")  // 4 valid paths
+                {
+                    const auto collection = yen_k_shortest_paths<path>(layout, {{0, 0}, {3, 3}}, k);
+
+                    CHECK(collection.size() == k);
+                }
             }
         }
     }
@@ -276,36 +424,13 @@ TEST_CASE("Yen's algorithm on 4x4 gate-level layouts with coordinate obstruction
     using gate_lyt   = gate_level_layout<clocked_layout<cartesian_layout<offset::ucoord_t>>>;
     using coord_path = layout_coordinate_path<gate_lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
+        const gate_lyt layout{{3, 3}};
 
-        SECTION("(0,0) to (3,3) with coordinate obstruction via PIs")  // path of length 7
-        {
-            obstruction_layout obstr_lyt{layout};
-
-            // create some PIs as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});
-            obstr_lyt.create_pi("obstruction", {3, 1});
-            obstr_lyt.create_pi("obstruction", {1, 2});
-            obstr_lyt.create_pi("obstruction", {2, 2});
-            // effectively blocking (3,2) as well
-
-            const auto collection =
-                yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
-
-            REQUIRE(collection.size() == 1);
-            const auto& path = collection[0];
-            REQUIRE(path.size() == 7);
-            CHECK(path[1] == coordinate<gate_lyt>{0, 1});
-            CHECK(path[2] == coordinate<gate_lyt>{0, 2});
-            CHECK(path[3] == coordinate<gate_lyt>{0, 3});
-            CHECK(path[4] == coordinate<gate_lyt>{1, 3});
-            CHECK(path[5] == coordinate<gate_lyt>{2, 3});
-        }
         SECTION("(0,0) to (3,3) with coordinate obstruction via declaration")  // path of length 7
         {
-            obstruction_layout obstr_lyt{layout};
+            obstruction_layout obstr_lyt{static_cast<cartesian_layout<>>(layout)};
 
             // create some PIs as obstruction
             obstr_lyt.obstruct_coordinate({3, 0});
@@ -314,8 +439,7 @@ TEST_CASE("Yen's algorithm on 4x4 gate-level layouts with coordinate obstruction
             obstr_lyt.obstruct_coordinate({2, 2});
             // effectively blocking (3,2) as well
 
-            const auto collection =
-                yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+            const auto collection = yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);
 
             REQUIRE(collection.size() == 1);
             const auto& path = collection[0];
@@ -333,50 +457,110 @@ TEST_CASE("Yen's algorithm on 4x4 gate-level layouts with coordinate obstruction
             CHECK(obstr_lyt.is_obstructed_coordinate({2, 2}));
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
-
-        SECTION("(0,0) to (3,3) with coordinate obstruction via PIs")  // path of length 7
+        SECTION("2DDWave")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
 
-            // create a PI as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with coordinate obstruction via PIs")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto collection =
-                yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+                // create some PIs as obstruction
+                obstr_lyt.create_pi("obstruction", {3, 0});
+                obstr_lyt.create_pi("obstruction", {3, 1});
+                obstr_lyt.create_pi("obstruction", {1, 2});
+                obstr_lyt.create_pi("obstruction", {2, 2});
+                // effectively blocking (3,2) as well
 
-            REQUIRE(collection.size() == 1);
-            const auto& path = collection[0];
-            REQUIRE(path.size() == 7);
-            CHECK(path[1] == coordinate<gate_lyt>{1, 0});
-            CHECK(path[2] == coordinate<gate_lyt>{1, 1});
-            CHECK(path[3] == coordinate<gate_lyt>{1, 2});
-            CHECK(path[4] == coordinate<gate_lyt>{2, 2});
-            CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+                const auto collection =
+                    yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+
+                REQUIRE(collection.size() == 1);
+                const auto& path = collection[0];
+                REQUIRE(path.size() == 7);
+                CHECK(path[1] == coordinate<gate_lyt>{0, 1});
+                CHECK(path[2] == coordinate<gate_lyt>{0, 2});
+                CHECK(path[3] == coordinate<gate_lyt>{0, 3});
+                CHECK(path[4] == coordinate<gate_lyt>{1, 3});
+                CHECK(path[5] == coordinate<gate_lyt>{2, 3});
+            }
+            SECTION("(0,0) to (3,3) with coordinate obstruction via declaration")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                // create some PIs as obstruction
+                obstr_lyt.obstruct_coordinate({3, 0});
+                obstr_lyt.obstruct_coordinate({3, 1});
+                obstr_lyt.obstruct_coordinate({1, 2});
+                obstr_lyt.obstruct_coordinate({2, 2});
+                // effectively blocking (3,2) as well
+
+                const auto collection =
+                    yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+
+                REQUIRE(collection.size() == 1);
+                const auto& path = collection[0];
+                REQUIRE(path.size() == 7);
+                CHECK(path[1] == coordinate<gate_lyt>{0, 1});
+                CHECK(path[2] == coordinate<gate_lyt>{0, 2});
+                CHECK(path[3] == coordinate<gate_lyt>{0, 3});
+                CHECK(path[4] == coordinate<gate_lyt>{1, 3});
+                CHECK(path[5] == coordinate<gate_lyt>{2, 3});
+
+                // coordinates should still be obstructed
+                CHECK(obstr_lyt.is_obstructed_coordinate({3, 0}));
+                CHECK(obstr_lyt.is_obstructed_coordinate({3, 1}));
+                CHECK(obstr_lyt.is_obstructed_coordinate({1, 2}));
+                CHECK(obstr_lyt.is_obstructed_coordinate({2, 2}));
+            }
         }
-        SECTION("(0,0) to (3,3) with coordinate obstruction via declaration")  // path of length 7
+        SECTION("USE")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
 
-            // create a PI as obstruction
-            obstr_lyt.obstruct_coordinate({3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with coordinate obstruction via PIs")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto collection =
-                yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+                // create a PI as obstruction
+                obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
 
-            REQUIRE(collection.size() == 1);
-            const auto& path = collection[0];
-            REQUIRE(path.size() == 7);
-            CHECK(path[1] == coordinate<gate_lyt>{1, 0});
-            CHECK(path[2] == coordinate<gate_lyt>{1, 1});
-            CHECK(path[3] == coordinate<gate_lyt>{1, 2});
-            CHECK(path[4] == coordinate<gate_lyt>{2, 2});
-            CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+                const auto collection =
+                    yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
 
-            // coordinates should still be obstructed
-            CHECK(obstr_lyt.is_obstructed_coordinate({3, 0}));
+                REQUIRE(collection.size() == 1);
+                const auto& path = collection[0];
+                REQUIRE(path.size() == 7);
+                CHECK(path[1] == coordinate<gate_lyt>{1, 0});
+                CHECK(path[2] == coordinate<gate_lyt>{1, 1});
+                CHECK(path[3] == coordinate<gate_lyt>{1, 2});
+                CHECK(path[4] == coordinate<gate_lyt>{2, 2});
+                CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+            }
+            SECTION("(0,0) to (3,3) with coordinate obstruction via declaration")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                // create a PI as obstruction
+                obstr_lyt.obstruct_coordinate({3, 0});  // blocks 3 paths
+
+                const auto collection =
+                    yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+
+                REQUIRE(collection.size() == 1);
+                const auto& path = collection[0];
+                REQUIRE(path.size() == 7);
+                CHECK(path[1] == coordinate<gate_lyt>{1, 0});
+                CHECK(path[2] == coordinate<gate_lyt>{1, 1});
+                CHECK(path[3] == coordinate<gate_lyt>{1, 2});
+                CHECK(path[4] == coordinate<gate_lyt>{2, 2});
+                CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+
+                // coordinates should still be obstructed
+                CHECK(obstr_lyt.is_obstructed_coordinate({3, 0}));
+            }
         }
     }
 }
@@ -507,13 +691,13 @@ TEST_CASE("Yen's algorithm on 4x4 gate-level layouts with connection obstruction
     using gate_lyt   = gate_level_layout<clocked_layout<cartesian_layout<offset::ucoord_t>>>;
     using coord_path = layout_coordinate_path<gate_lyt>;
 
-    SECTION("2DDWave")
+    SECTION("coordinate paths")
     {
-        const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
+        const gate_lyt layout{{3, 3}};
 
         SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
         {
-            obstruction_layout obstr_lyt{layout};
+            obstruction_layout obstr_lyt{static_cast<cartesian_layout<>>(layout)};
 
             // create some connection obstructions
             obstr_lyt.obstruct_connection({0, 0}, {1, 0});
@@ -521,8 +705,7 @@ TEST_CASE("Yen's algorithm on 4x4 gate-level layouts with connection obstruction
             obstr_lyt.obstruct_connection({0, 2}, {1, 2});
             // leaving only one valid path via (0,4)
 
-            const auto collection =
-                yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+            const auto collection = yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);
 
             REQUIRE(collection.size() == 1);
             const auto& path = collection[0];
@@ -539,30 +722,65 @@ TEST_CASE("Yen's algorithm on 4x4 gate-level layouts with connection obstruction
             CHECK(obstr_lyt.is_obstructed_connection({0, 2}, {1, 2}));
         }
     }
-    SECTION("USE")
+    SECTION("clocking paths")
     {
-        const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
-
-        SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+        SECTION("2DDWave")
         {
-            obstruction_layout obstr_lyt{layout};
+            const gate_lyt layout{{3, 3}, twoddwave_clocking<gate_lyt>()};
 
-            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+            SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
 
-            const auto collection =
-                yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+                // create some connection obstructions
+                obstr_lyt.obstruct_connection({0, 0}, {1, 0});
+                obstr_lyt.obstruct_connection({0, 1}, {1, 1});
+                obstr_lyt.obstruct_connection({0, 2}, {1, 2});
+                // leaving only one valid path via (0,4)
 
-            REQUIRE(collection.size() == 1);
-            const auto& path = collection[0];
-            REQUIRE(path.size() == 7);
-            CHECK(path[1] == coordinate<gate_lyt>{1, 0});
-            CHECK(path[2] == coordinate<gate_lyt>{1, 1});
-            CHECK(path[3] == coordinate<gate_lyt>{1, 2});
-            CHECK(path[4] == coordinate<gate_lyt>{2, 2});
-            CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+                const auto collection =
+                    yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
 
-            // connections should still be obstructed
-            CHECK(obstr_lyt.is_obstructed_connection({2, 0}, {3, 0}));
+                REQUIRE(collection.size() == 1);
+                const auto& path = collection[0];
+                REQUIRE(path.size() == 7);
+                CHECK(path[1] == coordinate<gate_lyt>{0, 1});
+                CHECK(path[2] == coordinate<gate_lyt>{0, 2});
+                CHECK(path[3] == coordinate<gate_lyt>{0, 3});
+                CHECK(path[4] == coordinate<gate_lyt>{1, 3});
+                CHECK(path[5] == coordinate<gate_lyt>{2, 3});
+
+                // connections should still be obstructed
+                CHECK(obstr_lyt.is_obstructed_connection({0, 0}, {1, 0}));
+                CHECK(obstr_lyt.is_obstructed_connection({0, 1}, {1, 1}));
+                CHECK(obstr_lyt.is_obstructed_connection({0, 2}, {1, 2}));
+            }
+        }
+        SECTION("USE")
+        {
+            const gate_lyt layout{{3, 3}, use_clocking<gate_lyt>()};
+
+            SECTION("(0,0) to (3,3) with connection obstruction")  // path of length 7
+            {
+                obstruction_layout obstr_lyt{layout};
+
+                obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+
+                const auto collection =
+                    yen_k_shortest_paths<coord_path>(obstr_lyt, {{0, 0}, {3, 3}}, 1);  // only one path possible
+
+                REQUIRE(collection.size() == 1);
+                const auto& path = collection[0];
+                REQUIRE(path.size() == 7);
+                CHECK(path[1] == coordinate<gate_lyt>{1, 0});
+                CHECK(path[2] == coordinate<gate_lyt>{1, 1});
+                CHECK(path[3] == coordinate<gate_lyt>{1, 2});
+                CHECK(path[4] == coordinate<gate_lyt>{2, 2});
+                CHECK(path[5] == coordinate<gate_lyt>{3, 2});
+
+                // connections should still be obstructed
+                CHECK(obstr_lyt.is_obstructed_connection({2, 0}, {3, 0}));
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This PR increases the versatility of all path-finding algorithms by enabling them on different layout abstractions. Initially, path-finding was intended to be used exclusively in routing. Thus, it made sense to enforce clocked layouts as underlying data structures. However, it became evident that pathfinding can be applied more versatilely than anticipated initially. Therefore, this PR enables all path-finding algorithms on coordinate layouts as well. They automatically detect the most strict level of abstraction that a given layout implements and perform routing on that level. Alternatively, they can always be downcasted for the function call to strip a higher abstraction level if so desired.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
