### PR TITLE
:art: Fix minor oversights by using `static constexpr` and `noexcept`

### DIFF
--- a/include/fiction/layouts/clocking_scheme.hpp
+++ b/include/fiction/layouts/clocking_scheme.hpp
@@ -221,7 +221,7 @@ static auto columnar_clocking(const num_clks& n = num_clks::FOUR) noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function columnar_3_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 3u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 3u> cutout{
             {{{0, 1, 2}}, {{0, 1, 2}}, {{0, 1, 2}}}};
 
         return cutout[cz.y % 3ul][cz.x % 3ul];
@@ -230,7 +230,7 @@ static auto columnar_clocking(const num_clks& n = num_clks::FOUR) noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function columnar_4_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
             {{{0, 1, 2, 3}}, {{0, 1, 2, 3}}, {{0, 1, 2, 3}}, {{0, 1, 2, 3}}}};
 
         return cutout[cz.y % 4ul][cz.x % 4ul];
@@ -268,7 +268,7 @@ static auto row_clocking(const num_clks& n = num_clks::FOUR) noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function row_3_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 3u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 3u> cutout{
             {{{0, 0, 0}}, {{1, 1, 1}}, {{2, 2, 2}}}};
 
         return cutout[cz.y % 3ul][cz.x % 3ul];
@@ -277,7 +277,7 @@ static auto row_clocking(const num_clks& n = num_clks::FOUR) noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function row_4_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
             {{{0, 0, 0, 0}}, {{1, 1, 1, 1}}, {{2, 2, 2, 2}}, {{3, 3, 3, 3}}}};
 
         return cutout[cz.y % 4ul][cz.x % 4ul];
@@ -314,7 +314,7 @@ static auto twoddwave_clocking(const num_clks& n = num_clks::FOUR) noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function twoddwave_3_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 3u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 3u> cutout{
             {{{0, 1, 2}}, {{1, 2, 0}}, {{2, 0, 1}}}};
 
         return cutout[cz.y % 3ul][cz.x % 3ul];
@@ -323,7 +323,7 @@ static auto twoddwave_clocking(const num_clks& n = num_clks::FOUR) noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function twoddwave_4_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
             {{{0, 1, 2, 3}}, {{1, 2, 3, 0}}, {{2, 3, 0, 1}}, {{3, 0, 1, 2}}}};
 
         return cutout[cz.y % 4ul][cz.x % 4ul];
@@ -544,7 +544,7 @@ static auto use_clocking() noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function use_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
             {{{0, 1, 2, 3}},
              {{3, 2, 1, 0}},
              {{2, 3, 0, 1}},
@@ -573,7 +573,7 @@ static auto res_clocking() noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function res_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
             {{{3, 0, 1, 2}},
              {{0, 1, 0, 3}},
              {{1, 2, 3, 0}},
@@ -602,7 +602,7 @@ static auto esr_clocking() noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function esr_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
             {{{3, 0, 1, 2}},
              {{0, 1, 2, 3}},
              {{1, 2, 3, 0}},
@@ -631,7 +631,7 @@ static auto cfe_clocking() noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function cfe_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 4u>, 4u> cutout{
             {{{0, 1, 0, 1}},
              {{3, 2, 3, 2}},
              {{0, 1, 0, 1}},
@@ -659,7 +659,7 @@ static auto bancs_clocking() noexcept
     static const typename clocking_scheme<clock_zone<Lyt>>::clock_function bancs_clock_function =
         [](const clock_zone<Lyt>& cz) noexcept
     {
-        constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 6u> cutout{
+        static constexpr std::array<std::array<typename clocking_scheme<clock_zone<Lyt>>::clock_number, 3u>, 6u> cutout{
             {{{0, 1, 2}},
              {{2, 1, 0}},
              {{2, 0, 1}},

--- a/include/fiction/utils/stl_utils.hpp
+++ b/include/fiction/utils/stl_utils.hpp
@@ -37,11 +37,10 @@ namespace fiction
 template <class InputIt, class ForwardIt>
 InputIt find_first_two_of(InputIt first, InputIt last, ForwardIt s_first, ForwardIt s_last) noexcept
 {
+    static_assert(std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<InputIt>::iterator_category>,
+                  "InputIt must meet the requirements of LegacyInputIterator");
     static_assert(
-        std::is_base_of<std::input_iterator_tag, typename std::iterator_traits<InputIt>::iterator_category>::value,
-        "InputIt must meet the requirements of LegacyInputIterator");
-    static_assert(
-        std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<ForwardIt>::iterator_category>::value,
+        std::is_base_of_v<std::forward_iterator_tag, typename std::iterator_traits<ForwardIt>::iterator_category>,
         "ForwardIt must meet the requirements of LegacyForwardIterator");
 
     for (; first != last - 1; ++first)
@@ -103,7 +102,7 @@ class searchable_priority_queue : public std::priority_queue<T, Container, Compa
      * @param val Value to search for.
      * @return Iterator to the stored value or to the end of the container if `val` is not contained.
      */
-    iterator find(const T& val)
+    iterator find(const T& val) noexcept
     {
         auto first = begin(), last = end();
 
@@ -126,7 +125,7 @@ class searchable_priority_queue : public std::priority_queue<T, Container, Compa
      * @param val Value to search for.
      * @return Iterator to the stored value or to the end of the container if `val` is not contained.
      */
-    const_iterator find(const T& val) const
+    const_iterator find(const T& val) const noexcept
     {
         auto       first = cbegin();
         const auto last  = cend();
@@ -149,7 +148,7 @@ class searchable_priority_queue : public std::priority_queue<T, Container, Compa
      * @param val Value to search for.
      * @return `true` iff `val` is contained in the priority queue.
      */
-    bool contains(const T& val) const
+    bool contains(const T& val) const noexcept
     {
         return find(val) != this->c.cend();
     }


### PR DESCRIPTION
## Description

This PR fixes minor oversights in two places that might have the possibility to slightly increase performance when heavily used.

1. Switched from dynamic to static allocation in `clocking_scheme.hpp`
2. Added missing `noexcept` annotations in `stl_utils.hpp`

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
