### PR TITLE
✨ Add naming utils to logic network

### DIFF
--- a/bindings/pyfiction/include/pyfiction/networks/logic_network.hpp
+++ b/bindings/pyfiction/include/pyfiction/networks/logic_network.hpp
@@ -13,6 +13,7 @@
 
 #include <fmt/format.h>
 #include <mockturtle/traits.hpp>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -136,8 +137,16 @@ void network(pybind11::module& m, const std::string& network_name)
         .def(
             "is_xnor", [](const Ntk& ntk, const mockturtle::node<Ntk>& n) { return ntk.is_xnor(n); }, "n"_a,
             DOC(fiction_technology_network_is_xnor))
-
-        ;
+        .def(
+            "has_name", [](const Ntk& ntk, const mockturtle::node<Ntk>& n) { return ntk.has_name(n); }, "n"_a)
+        .def(
+            "get_name", [](const Ntk& ntk, const mockturtle::node<Ntk>& n) { return ntk.get_name(n); }, "n"_a)
+        .def(
+            "has_output_name", [](const Ntk& ntk, const uint32_t index) { return ntk.has_output_name(index); },
+            "index"_a)
+        .def(
+            "get_output_name", [](const Ntk& ntk, const uint32_t index) { return ntk.get_output_name(index); },
+            "index"_a);
 
     /**
      * Network parsing function.

--- a/bindings/pyfiction/include/pyfiction/networks/logic_network.hpp
+++ b/bindings/pyfiction/include/pyfiction/networks/logic_network.hpp
@@ -146,7 +146,11 @@ void network(pybind11::module& m, const std::string& network_name)
             "index"_a)
         .def(
             "get_output_name", [](const Ntk& ntk, const uint32_t index) { return ntk.get_output_name(index); },
-            "index"_a);
+            "index"_a)
+        .def(
+            "po_index", [](const Ntk& ntk, const mockturtle::node<Ntk>& n) { return ntk.po_index(n); }, "n"_a)
+        .def(
+            "po_at", [](const Ntk& ntk, const uint32_t index) { return ntk.po_at(index); }, "index"_a);
 
     /**
      * Network parsing function.

--- a/bindings/pyfiction/test/networks/test_logic_network.py
+++ b/bindings/pyfiction/test/networks/test_logic_network.py
@@ -27,10 +27,18 @@ class TestLogicNetwork(unittest.TestCase):
         self.assertTrue(network.is_pi(2))
         self.assertTrue(network.is_pi(3))
         self.assertTrue(network.is_pi(4))
+        self.assertTrue(network.has_name(2))
+        self.assertTrue(network.has_name(3))
+        self.assertTrue(network.has_name(4))
+        self.assertEqual(network.get_name(2), "in0")
+        self.assertEqual(network.get_name(3), "in1")
+        self.assertEqual(network.get_name(4), "in2")
 
         self.assertEqual(network.num_pos(), 1)
         self.assertEqual(network.pos(), [9])
         self.assertTrue(network.is_po(9))
+        self.assertTrue(network.has_output_name(0))
+        self.assertEqual(network.get_output_name(0), "out")
 
         self.assertEqual(network.fanins(0), [])
         self.assertEqual(network.fanins(1), [])

--- a/bindings/pyfiction/test/networks/test_logic_network.py
+++ b/bindings/pyfiction/test/networks/test_logic_network.py
@@ -37,8 +37,10 @@ class TestLogicNetwork(unittest.TestCase):
         self.assertEqual(network.num_pos(), 1)
         self.assertEqual(network.pos(), [9])
         self.assertTrue(network.is_po(9))
-        self.assertTrue(network.has_output_name(0))
-        self.assertEqual(network.get_output_name(0), "out")
+        self.assertEqual(network.po_index(9), 0)
+        self.assertEqual(network.po_at(0), 9)
+        self.assertTrue(network.has_output_name(network.po_index(9)))
+        self.assertEqual(network.get_output_name(network.po_index(9)), "out")
 
         self.assertEqual(network.fanins(0), [])
         self.assertEqual(network.fanins(1), [])


### PR DESCRIPTION
## Description

Added the possibility to get the name of nodes in a logic network.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
