### PR TITLE
:alembic: Updated the atomic defect-aware SiDB physical design experiment in accordance with the final paper

### DIFF
--- a/docs/technology/properties.rst
+++ b/docs/technology/properties.rst
@@ -7,6 +7,7 @@ Area Requirements
 **Header:** ``fiction/technology/area.hpp``
 
 .. doxygenfunction:: fiction::area(const Lyt& lyt, area_params<technology<Lyt>, AreaType>& ps = {}, area_stats<AreaType>* pst = nullptr)
+.. doxygenfunction:: area(const bounding_box_2d<Lyt>& bb, area_params<technology<Lyt>, AreaType>& ps = {}, area_stats<AreaType>* pst = nullptr)
 
 MagCAD Magnet Count
 ###################

--- a/experiments/defect_aware_physical_design/defect_aware_physical_design.cpp
+++ b/experiments/defect_aware_physical_design/defect_aware_physical_design.cpp
@@ -12,6 +12,7 @@
 #include <fiction/io/read_sidb_surface_defects.hpp>                               // reader for simulated SiDB surfaces
 #include <fiction/io/read_sqd_layout.hpp>                     // reader for SiDB layouts including surface scan data
 #include <fiction/io/write_sqd_layout.hpp>                    // writer for SiQAD files (physical simulation)
+#include <fiction/layouts/bounding_box.hpp>                   // bounding box
 #include <fiction/technology/area.hpp>                        // area requirement calculations
 #include <fiction/technology/cell_technologies.hpp>           // cell implementations
 #include <fiction/technology/sidb_bestagon_library.hpp>       // a pre-defined SiDB gate library
@@ -52,12 +53,13 @@ int main()  // NOLINT
     using cell_lyt = fiction::sidb_cell_clk_lyt;
 
     static const std::string layouts_folder = fmt::format("{}/defect_aware_physical_design/layouts", EXPERIMENTS_PATH);
-    // 740 x 545 dimers = 740 x 1090 DB positions = 12 x 31 Bestagon tiles
+
+    // Fabricated surface 1: 740 x 545 dimers = 740 x 1090 DB positions = 12 x 31 Bestagon tiles
     // static const std::string surface_data_path =
-    // fmt::format("{}/defect_aware_physical_design/full_scan_area/defects_full70.xml", EXPERIMENTS_PATH);
-    // 830 x 326 dimers = 830 x 652 DB positions = 13 x 18 Bestagon tiles
+    // fmt::format("{}/defect_aware_physical_design/full_scan_area/defects_full70.sqd", EXPERIMENTS_PATH);
+    // Fabricated surface 2: 830 x 326 dimers = 830 x 652 DB positions = 13 x 18 Bestagon tiles
     //    static const std::string surface_data_path =
-    //        fmt::format("{}/defect_aware_physical_design/full_scan_area/defects_full56_Oct.xml", EXPERIMENTS_PATH);
+    //        fmt::format("{}/defect_aware_physical_design/full_scan_area/defects_full56_Oct.sqd", EXPERIMENTS_PATH);
 
     experiments::experiment<std::string, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t,
                             uint64_t, uint64_t, uint64_t, uint32_t, uint32_t, uint64_t, uint64_t, double, bool,
@@ -85,9 +87,9 @@ int main()  // NOLINT
                    "layout area in nm²"};
 
     // instantiate a complete XAG NPN database for node re-synthesis
-    mockturtle::xag_npn_resynthesis<mockturtle::xag_network,                    // the input network type
-                                    mockturtle::xag_network,                    // the database network type
-                                    mockturtle::xag_npn_db_kind::xag_complete>  // the kind of database to use
+    const mockturtle::xag_npn_resynthesis<mockturtle::xag_network,                    // the input network type
+                                          mockturtle::xag_network,                    // the database network type
+                                          mockturtle::xag_npn_db_kind::xag_complete>  // the kind of database to use
         resynthesis_function{};
 
     // parameters for cut rewriting
@@ -103,23 +105,23 @@ int main()  // NOLINT
     std::vector<mockturtle::gate> gates{};
 
     // parameters for technology mapping
-    mockturtle::map_params map_params{};
+    const mockturtle::map_params map_params{};
 
     [[maybe_unused]] const auto read_genlib_result =
         lorina::read_genlib(library_stream, mockturtle::genlib_reader{gates});
     assert(read_genlib_result == lorina::return_code::success);
-    mockturtle::tech_library<2> gate_lib{gates};
+    const mockturtle::tech_library<2> gate_lib{gates};
 
     // parameterize the H-Si(100) 2x1 surface to ignore certain defect types
-    fiction::sidb_surface_params surface_params{
+    const fiction::sidb_surface_params surface_params{
         std::unordered_set<fiction::sidb_defect_type>{fiction::sidb_defect_type::DB}};
 
-    //    fiction::sidb_surface<cell_lyt> surface_lattice{surface_params};
+    // fiction::sidb_surface<cell_lyt> surface_lattice{surface_params};
 
     // read surface scan lattice data
     const auto surface_lattice = fiction::read_sidb_surface_defects<cell_lyt>(
         "../../experiments/defect_aware_physical_design/py_test_surface.txt", "py_test_surface");
-    //    fiction::read_sqd_layout(surface_lattice, surface_data_path);
+    // fiction::read_sqd_layout(surface_lattice, surface_data_path);
 
     const auto lattice_tiling = gate_lyt{{11, 30}};  // our surface data is 12 x 31 Bestagon tiles
     //    const auto lattice_tiling = gate_lyt{{12, 17}};  // our surface data is 13 x 18 Bestagon tiles
@@ -131,11 +133,11 @@ int main()  // NOLINT
     exact_params.scheme        = fiction::ptr<gate_lyt>(fiction::row_clocking<gate_lyt>(fiction::num_clks::FOUR));
     exact_params.crossings     = true;
     exact_params.border_io     = false;
-    exact_params.desynchronize = false;
-    exact_params.upper_bound_x = 11;      // 12 x 31 tiles
-    exact_params.upper_bound_y = 30;      // 12 x 31 tiles
-                                          //    exact_params.upper_bound_x = 12;         // 13 x 18 tiles
-                                          //    exact_params.upper_bound_y = 17;         // 13 x 18 tiles
+    exact_params.desynchronize = true;
+    exact_params.upper_bound_x = 11;  // 12 x 31 tiles
+    exact_params.upper_bound_y = 30;  // 12 x 31 tiles
+    // exact_params.upper_bound_x = 12;    // 13 x 18 tiles
+    // exact_params.upper_bound_y = 17;    // 13 x 18 tiles
     exact_params.timeout    = 3'600'000;  // 1h in ms
     exact_params.black_list = black_list;
     fiction::exact_physical_design_stats exact_stats{};
@@ -155,17 +157,17 @@ int main()  // NOLINT
         assert(read_verilog_result == lorina::return_code::success);
 
         // compute depth
-        mockturtle::depth_view depth_xag{xag};
+        const mockturtle::depth_view depth_xag{xag};
 
         // rewrite network cuts using the given re-synthesis function
         const auto cut_xag = mockturtle::cut_rewriting(xag, resynthesis_function, cut_params);
         // compute depth
-        mockturtle::depth_view depth_cut_xag{cut_xag};
+        const mockturtle::depth_view depth_cut_xag{cut_xag};
 
         // perform technology mapping
         const auto mapped_network = mockturtle::map(cut_xag, gate_lib, map_params);
         // compute depth
-        mockturtle::depth_view depth_mapped_network{mapped_network};
+        const mockturtle::depth_view depth_mapped_network{mapped_network};
 
         // perform layout generation with an SMT-based exact algorithm
         const auto gate_level_layout = fiction::exact<gate_lyt>(mapped_network, exact_params, &exact_stats);
@@ -185,14 +187,17 @@ int main()  // NOLINT
             const auto cell_level_layout =
                 fiction::apply_gate_library<cell_lyt, fiction::sidb_bestagon_library>(*gate_level_layout);
 
+            // determine bounding box
+            const auto bb = fiction::bounding_box_2d<cell_lyt>(cell_level_layout);
+
             // compute area
             fiction::area_stats                            area_stats{};
             fiction::area_params<fiction::sidb_technology> area_ps{};
-            fiction::area(cell_level_layout, area_ps, &area_stats);
+            fiction::area(bb, area_ps, &area_stats);
 
             // write a SiQAD simulation file
             fiction::write_sqd_layout(cell_level_layout, fmt::format("{}/{}.sqd", layouts_folder, benchmark));
-            // TODO copy defects to cell layout before writing
+            // TODO integrate defects into the cell layout before writing
 
             // log results
             defect_exp(benchmark, xag.num_pis(), xag.num_pos(), xag.num_gates(), depth_xag.depth(), cut_xag.num_gates(),

--- a/include/fiction/technology/area.hpp
+++ b/include/fiction/technology/area.hpp
@@ -5,6 +5,7 @@
 #ifndef FICTION_AREA_HPP
 #define FICTION_AREA_HPP
 
+#include "fiction/layouts/bounding_box.hpp"
 #include "fiction/traits.hpp"
 
 #include <cstdint>
@@ -60,6 +61,32 @@ void area(const Lyt& lyt, area_params<technology<Lyt>, AreaType>& ps = {}, area_
 
     st.area = (static_cast<AreaType>(lyt.x() + 1) * ps.width + static_cast<AreaType>(lyt.x()) * ps.hspace) *
               (static_cast<AreaType>(lyt.y() + 1) * ps.height + static_cast<AreaType>(lyt.y()) * ps.vspace);
+
+    if (pst)
+    {
+        *pst = st;
+    }
+}
+/**
+ * Computes real-world area requirements in nm² of the bounding box of a given cell-level layout. For this purpose, each
+ * cell position in the layout is assigned a vertical and horizontal size. Additionally, a spacing between cell
+ * positions in horizontal and vertical direction is taken into account.
+ *
+ * @tparam Lyt Cell-level layout type.
+ * @tparam AreaType Type for area representation.
+ * @param lyt The cell-level layout whose area is desired.
+ */
+template <typename Lyt, typename AreaType = double>
+void area(const bounding_box_2d<Lyt>& bb, area_params<technology<Lyt>, AreaType>& ps = {},
+          area_stats<AreaType>* pst = nullptr)
+{
+    static_assert(fiction::is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
+
+    area_stats st{};
+
+    st.area =
+        (static_cast<AreaType>(bb.get_x_size() + 1) * ps.width + static_cast<AreaType>(bb.get_x_size()) * ps.hspace) *
+        (static_cast<AreaType>(bb.get_y_size() + 1) * ps.height + static_cast<AreaType>(bb.get_y_size()) * ps.vspace);
 
     if (pst)
     {


### PR DESCRIPTION
## Description

This PR updates the atomic defect-aware SiDB physical design experiment in accordance with the final paper, which will be published at DATE 2024. 

In particular, the experiment script was not computing the bounding box of the generated layout, leading to confusing results.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
