### PR TITLE
✨ Function for determining the electrostatic influence region for a given sublayout of a layout

### DIFF
--- a/docs/algorithms/sidb_simulation.rst
+++ b/docs/algorithms/sidb_simulation.rst
@@ -194,3 +194,11 @@ Convert Potential to Distance
 **Header:** ``fiction/algorithms/simulation/sidb/convert_potential_to_distance.hpp``
 
 .. doxygenfunction:: fiction::convert_potential_to_distance
+
+
+Determine Electrostatic Influence Region
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Header:** ``fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp``
+
+.. doxygenfunction:: fiction::determine_influence_region

--- a/include/fiction/algorithms/simulation/sidb/assess_physical_population_stability.hpp
+++ b/include/fiction/algorithms/simulation/sidb/assess_physical_population_stability.hpp
@@ -128,9 +128,9 @@ class assess_physical_population_stability_impl
      */
     [[nodiscard]] std::vector<population_stability_information<Lyt>> run() noexcept
     {
-        const quickexact_params<Lyt> quickexact_parameters{params.physical_parameters};
-        const auto                   simulation_results = quickexact(layout, quickexact_parameters);
-        const auto energy_and_unique_charge_index       = collect_energy_and_charge_index(simulation_results);
+        const quickexact_params<cell<Lyt>> quickexact_parameters{params.physical_parameters};
+        const auto                         simulation_results = quickexact(layout, quickexact_parameters);
+        const auto energy_and_unique_charge_index             = collect_energy_and_charge_index(simulation_results);
 
         std::vector<population_stability_information<Lyt>> popstability_information{};
         popstability_information.reserve(simulation_results.charge_distributions.size());

--- a/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
+++ b/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
@@ -249,8 +249,9 @@ class critical_temperature_impl
             stats.algorithm_name = "QuickExact";
             // All physically valid charge configurations are determined for the given layout (`QuickExact` simulation
             // is used to provide 100 % accuracy for the Critical Temperature).
-            const quickexact_params<Lyt> qe_params{params.simulation_params.phys_params,
-                                                   quickexact_params<Lyt>::automatic_base_number_detection::OFF};
+            const quickexact_params<cell<Lyt>> qe_params{
+                params.simulation_params.phys_params,
+                quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
             simulation_results = quickexact(layout, qe_params);
         }
         else
@@ -421,9 +422,9 @@ class critical_temperature_impl
         if (params.engine == critical_temperature_params::simulation_engine::EXACT)
         {
             // perform exact simulation
-            const quickexact_params<Lyt> quickexact_params{
+            const quickexact_params<cell<Lyt>> quickexact_params{
                 params.simulation_params.phys_params,
-                fiction::quickexact_params<Lyt>::automatic_base_number_detection::OFF};
+                fiction::quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
             return quickexact(*bdl_iterator, quickexact_params);
         }
 

--- a/include/fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp
+++ b/include/fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp
@@ -145,10 +145,7 @@ class determine_influence_region_impl
     [[nodiscard]] std::set<uint64_t>
     simulate_charge_indices_of_the_ground_states(const sidb_surface<Lyt>& layout_with_non_influencing_cells) noexcept
     {
-        const auto simulation_results = quickexact(layout_with_non_influencing_cells, quickexact_parameter);
-        const auto ground_state       = std::min_element(
-            simulation_results.charge_distributions.cbegin(), simulation_results.charge_distributions.cend(),
-            [](const auto& lhs, const auto& rhs) { return lhs.get_system_energy() < rhs.get_system_energy(); });
+        const auto         simulation_results  = quickexact(layout_with_non_influencing_cells, quickexact_parameter);
         const auto         ground_state_energy = minimum_energy(simulation_results.charge_distributions);
         std::set<uint64_t> charge_indices      = {};
         for (const auto& lyt : simulation_results.charge_distributions)
@@ -197,9 +194,6 @@ class determine_influence_region_impl
     {
         const auto simulation_results = quickexact(sublayout, quickexact_parameter);
         // find the ground state, which is the charge distribution with the lowest energy
-        const auto ground_state = std::min_element(
-            simulation_results.charge_distributions.cbegin(), simulation_results.charge_distributions.cend(),
-            [](const auto& lhs, const auto& rhs) { return lhs.get_system_energy() < rhs.get_system_energy(); });
         const auto ground_state_energy = minimum_energy(simulation_results.charge_distributions);
         for (const auto& lyt : simulation_results.charge_distributions)
         {

--- a/include/fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp
+++ b/include/fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp
@@ -84,6 +84,7 @@ class determine_influence_region_impl
             }
             else
             {
+                // the influence region in the northwest direction is extended further towards the northwest
                 if (nw_influence_zone > min_cell_layout)
                 {
                     if (nw_influence_zone.x == min_cell_layout.x)
@@ -100,6 +101,7 @@ class determine_influence_region_impl
                         nw_influence_zone.y = nw_influence_zone.y - 1;
                     }
                 }
+                // the influence region in the southeast direction is extended further towards the southeast
                 if (se_influence_zone < max_cell_layout)
                 {
                     if (se_influence_zone.x == max_cell_layout.x)
@@ -142,8 +144,8 @@ class determine_influence_region_impl
      * @param layout The layout to simulate.
      * @return A set containing the charge indices of ground states.
      */
-    [[nodiscard]] std::set<uint64_t>
-    simulate_charge_indices_of_the_ground_states(const sidb_surface<Lyt>& layout_with_non_influencing_cells) noexcept
+    [[nodiscard]] std::set<uint64_t> simulate_charge_indices_of_the_ground_states(
+        const sidb_surface<Lyt>& layout_with_non_influencing_cells) const noexcept
     {
         const auto         simulation_results  = quickexact(layout_with_non_influencing_cells, quickexact_parameter);
         const auto         ground_state_energy = minimum_energy(simulation_results.charge_distributions);
@@ -209,7 +211,7 @@ class determine_influence_region_impl
      * @tparam Lyt The type of the layout.
      * @return `true` if the sublayout is a subset of the layout, `false` otherwise.
      */
-    bool is_sublayout_of_layout()
+    [[nodiscard]] bool is_sublayout_of_layout() const noexcept
     {
         std::vector<typename Lyt::cell> all_sidbs = {};
         all_sidbs.reserve(layout.num_cells());
@@ -268,7 +270,8 @@ class determine_influence_region_impl
  */
 template <typename Lyt>
 std::pair<typename Lyt::cell, typename Lyt::cell>
-determine_influence_region(const Lyt& layout, const Lyt& sublayout, const quickexact_params<cell<Lyt>>& params = {})
+determine_influence_region(const Lyt& layout, const Lyt& sublayout,
+                           const quickexact_params<cell<Lyt>>& params = {}) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");

--- a/include/fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp
+++ b/include/fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp
@@ -2,8 +2,8 @@
 // Created by Jan Drewniok on 03.12.23.
 //
 
-#ifndef FICTION_DETERMINE_INFLUENCE_REGION_HPP
-#define FICTION_DETERMINE_INFLUENCE_REGION_HPP
+#ifndef FICTION_DETERMINE_ELECTROSTATIC_INFLUENCE_REGION_HPP
+#define FICTION_DETERMINE_ELECTROSTATIC_INFLUENCE_REGION_HPP
 
 #include "fiction/algorithms/simulation/sidb/quickexact.hpp"
 #include "fiction/layouts/bounding_box.hpp"
@@ -285,4 +285,4 @@ determine_influence_region(const Lyt& layout, const Lyt& sublayout, const quicke
 
 }  // namespace fiction
 
-#endif  // FICTION_DETERMINE_INFLUENCE_REGION_HPP
+#endif  // FICTION_DETERMINE_ELECTROSTATIC_INFLUENCE_REGION_HPP

--- a/include/fiction/algorithms/simulation/sidb/determine_influence_region.hpp
+++ b/include/fiction/algorithms/simulation/sidb/determine_influence_region.hpp
@@ -1,0 +1,288 @@
+//
+// Created by Jan Drewniok on 03.12.23.
+//
+
+#ifndef FICTION_DETERMINE_INFLUENCE_REGION_HPP
+#define FICTION_DETERMINE_INFLUENCE_REGION_HPP
+
+#include "fiction/algorithms/simulation/sidb/quickexact.hpp"
+#include "fiction/layouts/bounding_box.hpp"
+#include "fiction/layouts/cell_level_layout.hpp"
+#include "fiction/technology/sidb_defects.hpp"
+#include "fiction/technology/sidb_surface.hpp"
+#include "fiction/traits.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace fiction
+{
+
+namespace detail
+{
+
+template <typename Lyt>
+class determine_influence_region_impl
+{
+  public:
+    determine_influence_region_impl(const Lyt& lyt, const Lyt& sublyt, const quickexact_params<cell<Lyt>>& params) :
+            layout{lyt},
+            sublayout{sublyt},
+            quickexact_parameter{params}
+    {
+        assert(is_sublayout_of_layout() && "sublyt is not a sub-layout of lyt");
+        collect_cells_of_layout_without_subcells();
+        simulate_ground_state_charge_indices_of_sublayout();
+    }
+    /**
+     * This function determines the influence zone, i.e., the region where SiDBs of the layout still affect the ground
+     * state of the sublayout.
+     *
+     * @return A pair of cells representing the northwest and southeast corners of the influence zone. This means that
+     * all cells of the layout outside of the influence region do not influence the ground state of the sublayout. Thus,
+     * their charge states can be neglected when simulating the ground state of the sublayout.
+     */
+    std::pair<typename Lyt::cell, typename Lyt::cell> run() noexcept
+    {
+        const bounding_box_2d<Lyt> bb{layout};
+        const auto                 min_cell_layout = bb.get_min();
+        const auto                 max_cell_layout = bb.get_max();
+
+        const bounding_box_2d<Lyt> bb_sub{sublayout};
+        const auto                 min_cell_sublayout = bb_sub.get_min();
+        const auto                 max_cell_sublayout = bb_sub.get_max();
+
+        auto nw_influence_zone = min_cell_sublayout;
+        auto se_influence_zone = max_cell_sublayout;
+
+        const auto all_cells_in_sublayout_box = all_coordinates_in_spanned_area(min_cell_sublayout, max_cell_sublayout);
+
+        sidb_surface<Lyt> layout_with_non_influencing_cells{sublayout};
+
+        bool found_non_influencing_region = false;
+
+        // IMPORTANT: We treat SiDBs with fixed charge states as atomic defects.
+        for (const auto& cell : cells_without_sublayout_cells)
+        {
+            layout_with_non_influencing_cells.assign_sidb_defect(
+                cell, sidb_defect{sidb_defect_type::UNKNOWN, -1, quickexact_parameter.physical_parameters.epsilon_r,
+                                  quickexact_parameter.physical_parameters.lambda_tf});
+        }
+
+        while (!found_non_influencing_region)
+        {
+            const auto charge_indices = simulate_charge_indices_of_the_ground_states(layout_with_non_influencing_cells);
+
+            if (charge_indices == ground_state_charge_indices_of_sublyt)
+            {
+                found_non_influencing_region = true;
+            }
+            else
+            {
+                if (nw_influence_zone > min_cell_layout)
+                {
+                    if (nw_influence_zone.x == min_cell_layout.x)
+                    {
+                        nw_influence_zone.y = nw_influence_zone.y - 1;
+                    }
+                    else if (nw_influence_zone.y == min_cell_layout.y)
+                    {
+                        nw_influence_zone.x = nw_influence_zone.x - 1;
+                    }
+                    else
+                    {
+                        nw_influence_zone.x = nw_influence_zone.x - 1;
+                        nw_influence_zone.y = nw_influence_zone.y - 1;
+                    }
+                }
+                if (se_influence_zone < max_cell_layout)
+                {
+                    if (se_influence_zone.x == max_cell_layout.x)
+                    {
+                        se_influence_zone.y = se_influence_zone.y + 1;
+                    }
+                    else if (se_influence_zone.y == max_cell_layout.y)
+                    {
+                        se_influence_zone.x = se_influence_zone.x + 1;
+                    }
+                    else
+                    {
+                        se_influence_zone.x = se_influence_zone.x + 1;
+                        se_influence_zone.y = se_influence_zone.y + 1;
+                    }
+                }
+
+                for (const auto& cell : cells_without_sublayout_cells)
+                {
+                    if ((cell.x >= nw_influence_zone.x) && (cell.y >= nw_influence_zone.y) &&
+                        (cell.x <= se_influence_zone.x) && (cell.y <= se_influence_zone.y) &&
+                        std::find(all_cells_in_sublayout_box.cbegin(), all_cells_in_sublayout_box.cend(), cell) ==
+                            all_cells_in_sublayout_box.end())
+                    {
+                        // IMPORTANT: All SiDBs that are within the influence region are deactivated to check if the
+                        // remaining SiDBs do not change the ground state of the sublayout.
+                        layout_with_non_influencing_cells.assign_sidb_defect(cell, sidb_defect{sidb_defect_type::NONE});
+                    }
+                }
+            }
+        }
+        return {nw_influence_zone, se_influence_zone};
+    }
+
+  private:
+    /**
+     * This function performs a simulation of the specified layout using *QuickExact*.
+     * It identifies the ground state charge distribution and their charge indices are returned.
+     *
+     * @param layout The layout to simulate.
+     * @return A set containing the charge indices of ground states.
+     */
+    [[nodiscard]] std::set<uint64_t>
+    simulate_charge_indices_of_the_ground_states(const sidb_surface<Lyt>& layout_with_non_influencing_cells) noexcept
+    {
+        const auto simulation_results = quickexact(layout_with_non_influencing_cells, quickexact_parameter);
+        const auto ground_state       = std::min_element(
+            simulation_results.charge_distributions.cbegin(), simulation_results.charge_distributions.cend(),
+            [](const auto& lhs, const auto& rhs) { return lhs.get_system_energy() < rhs.get_system_energy(); });
+        const auto         ground_state_energy = minimum_energy(simulation_results.charge_distributions);
+        std::set<uint64_t> charge_indices      = {};
+        for (const auto& lyt : simulation_results.charge_distributions)
+        {
+            if (std::fabs(lyt.get_system_energy() - ground_state_energy) < std::numeric_limits<double>::epsilon())
+            {
+                charge_indices.insert(lyt.get_charge_index_and_base().first);
+            }
+        }
+        return charge_indices;
+    }
+    /**
+     * This function iterates through all cells in the specified layout and sublayout.
+     * It identifies cells in the layout that are not present in the sublayout and collects
+     * them.
+     *
+     * @tparam Lyt The layout type.
+     */
+    void collect_cells_of_layout_without_subcells() noexcept
+    {
+        std::vector<typename Lyt::cell> all_sidbs = {};
+        all_sidbs.reserve(layout.num_cells());
+        layout.foreach_cell([&all_sidbs](const auto& c1) { all_sidbs.push_back(c1); });
+
+        std::vector<typename Lyt::cell> all_sidbs_sublayout = {};
+        all_sidbs_sublayout.reserve(sublayout.num_cells());
+        sublayout.foreach_cell([&all_sidbs_sublayout](const auto& c1) { all_sidbs_sublayout.push_back(c1); });
+
+        for (const auto& cell : all_sidbs)
+        {
+            auto it = std::find(all_sidbs_sublayout.begin(), all_sidbs_sublayout.end(), cell);
+
+            if (it == all_sidbs_sublayout.end())
+            {
+                cells_without_sublayout_cells.insert(cell);
+            }
+        }
+    }
+    /**
+     * This function simulates the ground state of the sublayout using *QuickExact*.
+     * The function then collects the charge indices of all charge distributions being considered as ground states.
+     *
+     * @tparam Lyt The layout type.
+     */
+    void simulate_ground_state_charge_indices_of_sublayout() noexcept
+    {
+        const auto simulation_results = quickexact(sublayout, quickexact_parameter);
+        // find the ground state, which is the charge distribution with the lowest energy
+        const auto ground_state = std::min_element(
+            simulation_results.charge_distributions.cbegin(), simulation_results.charge_distributions.cend(),
+            [](const auto& lhs, const auto& rhs) { return lhs.get_system_energy() < rhs.get_system_energy(); });
+        const auto ground_state_energy = minimum_energy(simulation_results.charge_distributions);
+        for (const auto& lyt : simulation_results.charge_distributions)
+        {
+            if (std::fabs(lyt.get_system_energy() - ground_state_energy) < std::numeric_limits<double>::epsilon())
+            {
+                ground_state_charge_indices_of_sublyt.insert(lyt.get_charge_index_and_base().first);
+            }
+        }
+    }
+    /**
+     * It determines if every cell in the sublayout is part of the layout.
+     *
+     * @tparam Lyt The type of the layout.
+     * @return `true` if the sublayout is a subset of the layout, `false` otherwise.
+     */
+    bool is_sublayout_of_layout()
+    {
+        std::vector<typename Lyt::cell> all_sidbs = {};
+        all_sidbs.reserve(layout.num_cells());
+        layout.foreach_cell([&all_sidbs](const auto& c1) { all_sidbs.push_back(c1); });
+
+        std::vector<typename Lyt::cell> all_sidbs_sublayout = {};
+        all_sidbs_sublayout.reserve(layout.num_cells());
+        sublayout.foreach_cell([&all_sidbs_sublayout](const auto& c1) { all_sidbs_sublayout.push_back(c1); });
+
+        for (const auto& cell : all_sidbs_sublayout)
+        {
+            auto it = std::find(all_sidbs.begin(), all_sidbs.end(), cell);
+
+            if (it == all_sidbs.end())
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    /**
+     * Complete Layout.
+     */
+    Lyt layout{};
+    /**
+     * Sublayout of layout.
+     */
+    Lyt sublayout{};
+    /**
+     * Simulation parameters.
+     */
+    quickexact_params<cell<Lyt>> quickexact_parameter{};
+    /**
+     * Charge indices of the ground state of the sublayout without neighboring SiDBs, i.e., undisturbed.
+     */
+    std::set<uint64_t> ground_state_charge_indices_of_sublyt{};
+    /**
+     * All cells of the layout, excluding the cells of the sublayout.
+     */
+    std::set<typename Lyt::cell> cells_without_sublayout_cells{};
+};
+
+}  // namespace detail
+
+/**
+ * This function identifies the influence zone for a given sublayout within a larger layout. The influence zone
+ * encompasses the neighboring SiDBs whose charge states can potentially affect the ground state of the sublayout.
+ * SiDBs outside the influence zone are considered to have no significant impact on the sublayout's ground state,
+ * and their charge states do not need to be considered during the simulation of the sublayout.
+ *
+ * @tparam Lyt The type representing the layout.
+ * @param layout Layout which includes the sublayout.
+ * @param sublayout Sublayout whose influence region is simulated and which is part of the layout.
+ * @param params *QuickExact* parameters for the physical simulation.
+ * @return A pair of cells representing the northwest and southeast corners of the determined influence zone.
+ */
+template <typename Lyt>
+std::pair<typename Lyt::cell, typename Lyt::cell>
+determine_influence_region(const Lyt& layout, const Lyt& sublayout, const quickexact_params<cell<Lyt>>& params = {})
+{
+    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
+    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
+
+    detail::determine_influence_region_impl<Lyt> p{layout, sublayout, params};
+    return p.run();
+}
+
+}  // namespace fiction
+
+#endif  // FICTION_DETERMINE_INFLUENCE_REGION_HPP

--- a/include/fiction/algorithms/simulation/sidb/is_operational.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_operational.hpp
@@ -238,8 +238,9 @@ class is_operational_impl
         if (parameters.sim_engine == sidb_simulation_engine::QUICKEXACT)
         {
             // perform exact simulation
-            const quickexact_params<Lyt> quickexact_params{
-                parameters.simulation_parameter, fiction::quickexact_params<Lyt>::automatic_base_number_detection::OFF};
+            const quickexact_params<cell<Lyt>> quickexact_params{
+                parameters.simulation_parameter,
+                fiction::quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
             return quickexact(*bdl_iterator, quickexact_params);
         }
 

--- a/include/fiction/algorithms/simulation/sidb/maximum_defect_influence_position_and_distance.hpp
+++ b/include/fiction/algorithms/simulation/sidb/maximum_defect_influence_position_and_distance.hpp
@@ -71,15 +71,15 @@ class maximum_defect_influence_position_and_distance_impl
 
     std::pair<typename Lyt::cell, double> run() noexcept
     {
-        const quickexact_params<sidb_surface<Lyt>> params_defect{
-            params.physical_params, quickexact_params<sidb_surface<Lyt>>::automatic_base_number_detection::OFF};
+        const quickexact_params<cell<Lyt>> params_defect{
+            params.physical_params, quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
 
         double          avoidance_distance{0};
         coordinate<Lyt> max_defect_position{};
 
-        const auto simulation_results =
-            quickexact(layout, quickexact_params<Lyt>{params.physical_params,
-                                                      quickexact_params<Lyt>::automatic_base_number_detection::OFF});
+        const auto simulation_results = quickexact(
+            layout, quickexact_params<cell<Lyt>>{params.physical_params,
+                                                 quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF});
 
         const auto min_energy          = minimum_energy(simulation_results.charge_distributions);
         uint64_t   charge_index_layout = 0;

--- a/include/fiction/algorithms/simulation/sidb/quickexact.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quickexact.hpp
@@ -40,8 +40,10 @@ enum class required_simulation_base_number
 };
 /**
  * This struct stores the parameters for the *QuickExact* algorithm.
+ *
+ * @tparam Type Cell type.
  */
-template <typename Lyt>
+template <typename CellType>
 struct quickexact_params
 {
     /**
@@ -71,7 +73,7 @@ struct quickexact_params
     /**
      * Local external electrostatic potentials (e.g locally applied electrodes).
      */
-    std::unordered_map<cell<Lyt>, double> local_external_potential = {};
+    std::unordered_map<CellType, double> local_external_potential = {};
     /**
      * Global external electrostatic potential. Value is applied on each cell in the layout.
      */
@@ -85,7 +87,7 @@ template <typename Lyt>
 class quickexact_impl
 {
   public:
-    quickexact_impl(const Lyt& lyt, const quickexact_params<Lyt>& parameter) :
+    quickexact_impl(const Lyt& lyt, const quickexact_params<cell<Lyt>>& parameter) :
             layout{lyt.clone()},
             charge_lyt{lyt},
             params{parameter}
@@ -107,9 +109,9 @@ class quickexact_impl
 
             // Determine if three state simulation (i.e., positively charged SiDBs can occur) is required.
             required_simulation_base_number base_number =
-                (params.base_number_detection == quickexact_params<Lyt>::automatic_base_number_detection::ON &&
+                (params.base_number_detection == quickexact_params<cell<Lyt>>::automatic_base_number_detection::ON &&
                  charge_lyt.is_three_state_simulation_required()) ||
-                        (params.base_number_detection == quickexact_params<Lyt>::automatic_base_number_detection::OFF &&
+                        (params.base_number_detection == quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF &&
                          params.physical_parameters.base == 3) ?
                     required_simulation_base_number::THREE :
                     required_simulation_base_number::TWO;
@@ -223,7 +225,7 @@ class quickexact_impl
     /**
      * Parameters used for the simulation.
      */
-    quickexact_params<Lyt> params{};
+    quickexact_params<typename Lyt::cell> params{};
     /**
      * Indices of all SiDBs that are pre-assigned to be negatively charged in a physically valid layout.
      */
@@ -576,7 +578,7 @@ class quickexact_impl
  * @return Simulation Results.
  */
 template <typename Lyt>
-[[nodiscard]] sidb_simulation_result<Lyt> quickexact(const Lyt& lyt, const quickexact_params<Lyt>& params = {}) noexcept
+[[nodiscard]] sidb_simulation_result<Lyt> quickexact(const Lyt& lyt, const quickexact_params<cell<Lyt>>& params = {}) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");

--- a/include/fiction/algorithms/simulation/sidb/quickexact.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quickexact.hpp
@@ -111,7 +111,8 @@ class quickexact_impl
             required_simulation_base_number base_number =
                 (params.base_number_detection == quickexact_params<cell<Lyt>>::automatic_base_number_detection::ON &&
                  charge_lyt.is_three_state_simulation_required()) ||
-                        (params.base_number_detection == quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF &&
+                        (params.base_number_detection ==
+                             quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF &&
                          params.physical_parameters.base == 3) ?
                     required_simulation_base_number::THREE :
                     required_simulation_base_number::TWO;
@@ -578,7 +579,8 @@ class quickexact_impl
  * @return Simulation Results.
  */
 template <typename Lyt>
-[[nodiscard]] sidb_simulation_result<Lyt> quickexact(const Lyt& lyt, const quickexact_params<cell<Lyt>>& params = {}) noexcept
+[[nodiscard]] sidb_simulation_result<Lyt> quickexact(const Lyt&                          lyt,
+                                                     const quickexact_params<cell<Lyt>>& params = {}) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");

--- a/include/fiction/algorithms/simulation/sidb/time_to_solution.hpp
+++ b/include/fiction/algorithms/simulation/sidb/time_to_solution.hpp
@@ -110,7 +110,7 @@ void time_to_solution(Lyt& lyt, const quicksim_params& quicksim_params, const ti
     }
     else
     {
-        const quickexact_params<Lyt> params{quicksim_params.phys_params};
+        const quickexact_params<cell<Lyt>> params{quicksim_params.phys_params};
         st.algorithm      = "QuickExact";
         simulation_result = quickexact(lyt, params);
     }

--- a/test/algorithms/simulation/sidb/determine_influence_region.cpp
+++ b/test/algorithms/simulation/sidb/determine_influence_region.cpp
@@ -1,0 +1,77 @@
+//
+// Created by Jan Drewniok on 03.12.23.
+//
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <fiction/algorithms/simulation/sidb/determine_influence_region.hpp>
+#include <fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp>
+#include <fiction/io/read_sqd_layout.hpp>
+#include <fiction/layouts/cell_level_layout.hpp>
+#include <fiction/technology/cell_technologies.hpp>
+#include <fiction/types.hpp>
+
+#include <filesystem>
+
+using namespace fiction;
+
+const auto current_path = std::filesystem::current_path();
+
+TEST_CASE("Three SiDBs with positive charge states", "[determine-influence-region]")
+{
+    sidb_cell_clk_lyt sublayout{{4, 5}};
+    sublayout.assign_cell_type({0, 0}, sidb_technology::cell_type::NORMAL);
+    sublayout.assign_cell_type({2, 0}, sidb_technology::cell_type::NORMAL);
+    sublayout.assign_cell_type({4, 0}, sidb_technology::cell_type::NORMAL);
+    sublayout.assign_cell_type({3, 5}, sidb_technology::cell_type::NORMAL);
+
+    sidb_cell_clk_lyt layout{{30, 11}};
+    layout.assign_cell_type({0, 0}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({2, 0}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({4, 0}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({3, 5}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({7, 2}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({21, 3}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({8, 11}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({0, 9}, sidb_technology::cell_type::NORMAL);
+
+    SECTION("Default physical parameters")
+    {
+        const auto [nw, se] = determine_influence_region(layout, sublayout);
+
+        CHECK(nw == cell<sidb_cell_clk_lyt>(0, 0));
+        CHECK(se == cell<sidb_cell_clk_lyt>(8, 9));
+    }
+    SECTION("set µ value")
+    {
+        const quickexact_params<cell<sidb_cell_clk_lyt>> params{sidb_simulation_parameters{2, -0.25}};
+        const auto [nw, se] = determine_influence_region(layout, sublayout, params);
+
+        CHECK(nw == cell<sidb_cell_clk_lyt>(0, 0));
+        CHECK(se == cell<sidb_cell_clk_lyt>(10, 11));
+    }
+}
+
+TEST_CASE("Using xnor layout and xnor gate as sublayout", "[determine-influence-region]")
+{
+    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/xnor2.sqd");
+    const auto sublayout = read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/xnor.sqd");
+
+    const auto [nw, se] = determine_influence_region(layout, sublayout);
+
+    CHECK(nw == cell<sidb_cell_clk_lyt>(24, 28));
+    CHECK(se == cell<sidb_cell_clk_lyt>(62, 72));
+}
+
+TEST_CASE("Using xnor layout and input wire as sublayout", "[determine-influence-region]")
+{
+    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/xnor2.sqd");
+    const auto sublayout =
+        read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/wire_of_xnor2.sqd");
+
+    const auto [nw, se] = determine_influence_region(layout, sublayout);
+
+    CHECK(nw == cell<sidb_cell_clk_lyt>(0, 0));
+    CHECK(se == cell<sidb_cell_clk_lyt>(32, 38));
+}

--- a/test/algorithms/simulation/sidb/determine_influence_region.cpp
+++ b/test/algorithms/simulation/sidb/determine_influence_region.cpp
@@ -53,25 +53,25 @@ TEST_CASE("Three SiDBs with positive charge states", "[determine-influence-regio
     }
 }
 
-TEST_CASE("Using xnor layout and xnor gate as sublayout", "[determine-influence-region]")
-{
-    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
-    const auto sublayout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor.sqd");
-
-    const auto [nw, se] = determine_influence_region(layout, sublayout);
-
-    CHECK(nw == cell<sidb_cell_clk_lyt>(24, 28));
-    CHECK(se == cell<sidb_cell_clk_lyt>(62, 72));
-}
-
-TEST_CASE("Using xnor layout and input wire as sublayout", "[determine-influence-region]")
-{
-    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
-    const auto sublayout =
-        read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/wire_of_xnor2.sqd");
-
-    const auto [nw, se] = determine_influence_region(layout, sublayout);
-
-    CHECK(nw == cell<sidb_cell_clk_lyt>(0, 0));
-    CHECK(se == cell<sidb_cell_clk_lyt>(32, 38));
-}
+//TEST_CASE("Using xnor layout and xnor gate as sublayout", "[determine-influence-region]")
+//{
+//    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
+//    const auto sublayout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor.sqd");
+//
+//    const auto [nw, se] = determine_influence_region(layout, sublayout);
+//
+//    CHECK(nw == cell<sidb_cell_clk_lyt>(24, 28));
+//    CHECK(se == cell<sidb_cell_clk_lyt>(62, 72));
+//}
+//
+//TEST_CASE("Using xnor layout and input wire as sublayout", "[determine-influence-region]")
+//{
+//    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
+//    const auto sublayout =
+//        read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/wire_of_xnor2.sqd");
+//
+//    const auto [nw, se] = determine_influence_region(layout, sublayout);
+//
+//    CHECK(nw == cell<sidb_cell_clk_lyt>(0, 0));
+//    CHECK(se == cell<sidb_cell_clk_lyt>(32, 38));
+//}

--- a/test/algorithms/simulation/sidb/determine_influence_region.cpp
+++ b/test/algorithms/simulation/sidb/determine_influence_region.cpp
@@ -5,7 +5,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include <fiction/algorithms/simulation/sidb/determine_influence_region.hpp>
+#include <fiction/algorithms/simulation/sidb/determine_electrostatic_influence_region.hpp>
 #include <fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp>
 #include <fiction/io/read_sqd_layout.hpp>
 #include <fiction/layouts/cell_level_layout.hpp>

--- a/test/algorithms/simulation/sidb/determine_influence_region.cpp
+++ b/test/algorithms/simulation/sidb/determine_influence_region.cpp
@@ -16,7 +16,7 @@
 
 using namespace fiction;
 
-const auto current_path = std::filesystem::current_path();
+const auto CURRENT_PATH = std::filesystem::current_path();
 
 TEST_CASE("Three SiDBs with positive charge states", "[determine-influence-region]")
 {
@@ -55,8 +55,8 @@ TEST_CASE("Three SiDBs with positive charge states", "[determine-influence-regio
 
 TEST_CASE("Using xnor layout and xnor gate as sublayout", "[determine-influence-region]")
 {
-    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/xnor2.sqd");
-    const auto sublayout = read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/xnor.sqd");
+    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
+    const auto sublayout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor.sqd");
 
     const auto [nw, se] = determine_influence_region(layout, sublayout);
 
@@ -66,9 +66,9 @@ TEST_CASE("Using xnor layout and xnor gate as sublayout", "[determine-influence-
 
 TEST_CASE("Using xnor layout and input wire as sublayout", "[determine-influence-region]")
 {
-    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/xnor2.sqd");
+    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
     const auto sublayout =
-        read_sqd_layout<sidb_cell_clk_lyt>(current_path.string() + "/../../test/resources/wire_of_xnor2.sqd");
+        read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/wire_of_xnor2.sqd");
 
     const auto [nw, se] = determine_influence_region(layout, sublayout);
 

--- a/test/algorithms/simulation/sidb/determine_influence_region.cpp
+++ b/test/algorithms/simulation/sidb/determine_influence_region.cpp
@@ -53,25 +53,25 @@ TEST_CASE("Three SiDBs with positive charge states", "[determine-influence-regio
     }
 }
 
-//TEST_CASE("Using xnor layout and xnor gate as sublayout", "[determine-influence-region]")
-//{
-//    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
-//    const auto sublayout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor.sqd");
-//
-//    const auto [nw, se] = determine_influence_region(layout, sublayout);
-//
-//    CHECK(nw == cell<sidb_cell_clk_lyt>(24, 28));
-//    CHECK(se == cell<sidb_cell_clk_lyt>(62, 72));
-//}
-//
-//TEST_CASE("Using xnor layout and input wire as sublayout", "[determine-influence-region]")
-//{
-//    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
-//    const auto sublayout =
-//        read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/wire_of_xnor2.sqd");
-//
-//    const auto [nw, se] = determine_influence_region(layout, sublayout);
-//
-//    CHECK(nw == cell<sidb_cell_clk_lyt>(0, 0));
-//    CHECK(se == cell<sidb_cell_clk_lyt>(32, 38));
-//}
+TEST_CASE("Using xnor layout and xnor gate as sublayout", "[determine-influence-region]")
+{
+    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
+    const auto sublayout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor.sqd");
+
+    const auto [nw, se] = determine_influence_region(layout, sublayout);
+
+    CHECK(nw == cell<sidb_cell_clk_lyt>(24, 28));
+    CHECK(se == cell<sidb_cell_clk_lyt>(62, 72));
+}
+
+TEST_CASE("Using xnor layout and input wire as sublayout", "[determine-influence-region]")
+{
+    const auto layout = read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/xnor2.sqd");
+    const auto sublayout =
+        read_sqd_layout<sidb_cell_clk_lyt>(CURRENT_PATH.string() + "/../../test/resources/wire_of_xnor2.sqd");
+
+    const auto [nw, se] = determine_influence_region(layout, sublayout);
+
+    CHECK(nw == cell<sidb_cell_clk_lyt>(0, 0));
+    CHECK(se == cell<sidb_cell_clk_lyt>(32, 38));
+}

--- a/test/algorithms/simulation/sidb/quickexact.cpp
+++ b/test/algorithms/simulation/sidb/quickexact.cpp
@@ -23,7 +23,7 @@ TEMPLATE_TEST_CASE(
 {
     TestType lyt{};
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.32}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.32}};
 
     const auto simulation_results = quickexact(lyt, params);
 
@@ -41,7 +41,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.32}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.32}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -58,7 +58,7 @@ TEMPLATE_TEST_CASE(
 {
     TestType lyt{};
     lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.25}};
     lyt.assign_sidb_defect({1, 2, 0}, sidb_defect{sidb_defect_type::UNKNOWN, -1, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf});
 
@@ -78,7 +78,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.25}};
 
     lyt.assign_sidb_defect({1, 2, 0},
                            sidb_defect{sidb_defect_type::UNKNOWN, -1, params.physical_parameters.epsilon_r, 2});
@@ -86,6 +86,27 @@ TEMPLATE_TEST_CASE(
 
     REQUIRE(simulation_results.charge_distributions.size() == 1);
     CHECK(simulation_results.charge_distributions.front().get_charge_state_by_index(0) == sidb_charge_state::NEGATIVE);
+}
+
+TEMPLATE_TEST_CASE(
+    "One QCA with one atomic defect", "[quickexact]",
+    (sidb_surface<cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<offset::ucoord_t>>>>),
+    (charge_distribution_surface<
+        sidb_surface<cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<offset::ucoord_t>>>>>))
+{
+    TestType layout{};
+    layout.assign_cell_type({0, 0}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({2, 0}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({2, 2}, sidb_technology::cell_type::NORMAL);
+    layout.assign_cell_type({0, 2}, sidb_technology::cell_type::NORMAL);
+
+    const quickexact_params<cell<TestType>> params{};
+
+    layout.assign_sidb_defect({5, 0}, sidb_defect{sidb_defect_type::UNKNOWN, -1, params.physical_parameters.epsilon_r,
+                                                  params.physical_parameters.lambda_tf});
+    const auto simulation_results = quickexact<TestType>(layout, params);
+
+    REQUIRE(simulation_results.charge_distributions.size() == 1);
 }
 
 TEMPLATE_TEST_CASE(
@@ -98,7 +119,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.25}};
 
     lyt.assign_sidb_defect({1, 6, 0},
                            sidb_defect{sidb_defect_type::UNKNOWN, -1, 0.3, params.physical_parameters.lambda_tf});
@@ -123,7 +144,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({0, 1, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({2, 1, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.15}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.15}};
 
     lyt.assign_sidb_defect({0, 0, 1}, sidb_defect{sidb_defect_type::UNKNOWN, -1, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf});
@@ -147,7 +168,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.1}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.1}};
 
     lyt.assign_sidb_defect({1, 2, 0}, sidb_defect{sidb_defect_type::UNKNOWN, -10, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf});
@@ -168,7 +189,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.1}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.1}};
 
     lyt.assign_sidb_defect({1, 2, 0}, sidb_defect{sidb_defect_type::UNKNOWN, -10, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf * 10E-5});
@@ -189,7 +210,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.1}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.1}};
 
     lyt.assign_sidb_defect({2, 0, 0}, sidb_defect{sidb_defect_type::UNKNOWN, -10, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf});
@@ -211,7 +232,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.25}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.25}};
 
     params.local_external_potential.insert({{0, 0, 0}, -0.5});
 
@@ -229,7 +250,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
 
     params.local_external_potential.insert({{{0, 0, 0}, -1}});
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -246,7 +267,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.25}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.25}};
     params.global_potential = -0.26;
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -263,7 +284,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
     params.global_potential = -1;
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -279,7 +300,7 @@ TEMPLATE_TEST_CASE(
     TestType lyt{};
     lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
     params.global_potential = 1;
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -296,7 +317,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({3, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -338,7 +359,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({17, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({19, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.32}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.32}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
     auto       size_before        = simulation_results.charge_distributions.size();
@@ -386,7 +407,7 @@ TEMPLATE_TEST_CASE("QuickExact simulation of a one-pair BDL wire with two pertur
 
     charge_layout_kon.update_after_charge_change();
 
-    const quickexact_params<TestType> sim_params{sidb_simulation_parameters{3, -0.32}};
+    const quickexact_params<cell<TestType>> sim_params{sidb_simulation_parameters{3, -0.32}};
 
     const auto simulation_results = quickexact<TestType>(lyt, sim_params);
 
@@ -420,7 +441,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({-7, 1, 1}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({-7, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> sim_params{sidb_simulation_parameters{3, -0.32}};
+    const quickexact_params<cell<TestType>> sim_params{sidb_simulation_parameters{3, -0.32}};
 
     const auto simulation_results = quickexact<TestType>(lyt, sim_params);
 
@@ -459,7 +480,7 @@ TEMPLATE_TEST_CASE(
 
     lyt.assign_cell_type({10, 8, 1}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> sim_params{sidb_simulation_parameters{2, -0.28}};
+    const quickexact_params<cell<TestType>> sim_params{sidb_simulation_parameters{2, -0.28}};
 
     const auto simulation_results = quickexact<TestType>(lyt, sim_params);
 
@@ -509,7 +530,7 @@ TEMPLATE_TEST_CASE("QuickExact simulation of a Y-shape SiDB OR gate with input 0
     lyt.assign_cell_type(siqad::to_fiction_coord<offset::ucoord_t>(siqad::coord_t{10, 8, 1}),
                          TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> sim_params{sidb_simulation_parameters{2, -0.28}};
+    const quickexact_params<cell<TestType>> sim_params{sidb_simulation_parameters{2, -0.28}};
 
     const auto simulation_results = quickexact<TestType>(lyt, sim_params);
 
@@ -559,7 +580,7 @@ TEMPLATE_TEST_CASE(
 
     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 8, 1}), TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> sim_params{sidb_simulation_parameters{2, -0.28}};
+    const quickexact_params<cell<TestType>> sim_params{sidb_simulation_parameters{2, -0.28}};
 
     const auto simulation_results = quickexact<TestType>(lyt, sim_params);
 
@@ -608,7 +629,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({10, 8, 1}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({16, 1, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
     params.local_external_potential.insert({{{6, 2, 0}, -0.5}});
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -644,7 +665,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 8, 1}), TestType::cell_type::NORMAL);
     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 1, 0}), TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
     params.local_external_potential.insert({{siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 2, 0}), -0.5}});
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -688,7 +709,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({10, 8, 1}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({16, 1, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
     params.global_potential = -0.5;
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -724,7 +745,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({10, 8, 1}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({16, 1, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
     params.global_potential = -2;
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -754,7 +775,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({20, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({30, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -777,7 +798,7 @@ TEMPLATE_TEST_CASE(
 
     lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.32}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.32}};
     lyt.assign_sidb_defect({-1, -1, 1}, sidb_defect{sidb_defect_type::UNKNOWN, -1, params.physical_parameters.epsilon_r,
                                                     params.physical_parameters.lambda_tf});
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -801,7 +822,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({20, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({30, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
     lyt.assign_sidb_defect({1, 0, 0}, sidb_defect{sidb_defect_type::UNKNOWN, -1, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf});
     const auto simulation_results = quickexact<TestType>(lyt, params);
@@ -828,7 +849,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({20, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({30, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
 
     lyt.assign_sidb_defect({1, 0, 0}, sidb_defect{sidb_defect_type::UNKNOWN, -1, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf});
@@ -861,7 +882,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({20, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({30, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
 
     lyt.assign_sidb_defect({1, 0, 0}, sidb_defect{sidb_defect_type::UNKNOWN, 1, params.physical_parameters.epsilon_r,
                                                   params.physical_parameters.lambda_tf});
@@ -896,7 +917,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({6, 10, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({7, 10, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -924,7 +945,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({2, 3, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({3, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.25}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -963,7 +984,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({2, 3, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({3, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.8}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.8}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -987,7 +1008,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({2, 3, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({3, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1012,7 +1033,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({5, 3, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({6, 3, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1039,7 +1060,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({6, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({7, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1063,7 +1084,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({-1, -1, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({0, 2, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1082,7 +1103,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({2, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({10, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.1}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.1}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1103,7 +1124,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({7, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({10, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.25}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1124,7 +1145,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({6, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({7, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.32}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.32}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1145,7 +1166,7 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({6, 0, 0}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({7, 0, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.32}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.32}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1153,8 +1174,8 @@ TEMPLATE_TEST_CASE(
     CHECK(simulation_results.additional_simulation_parameters[0].first == "base_number");
     CHECK(std::any_cast<uint64_t>(simulation_results.additional_simulation_parameters[0].second) == 3);
 
-    const quickexact_params<TestType> params_new{sidb_simulation_parameters{2, -0.32},
-                                                 quickexact_params<TestType>::automatic_base_number_detection::OFF};
+    const quickexact_params<cell<TestType>> params_new{
+        sidb_simulation_parameters{2, -0.32}, quickexact_params<cell<TestType>>::automatic_base_number_detection::OFF};
 
     const auto simulation_results_new = quickexact<TestType>(lyt, params_new);
 
@@ -1190,7 +1211,7 @@ TEMPLATE_TEST_CASE(
 
     lyt.assign_cell_type({30, 15, 0}, TestType::cell_type::NORMAL);
 
-    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.32}};
+    const quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.32}};
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1222,8 +1243,8 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({10, 8, 1}, TestType::cell_type::NORMAL);
     lyt.assign_cell_type({16, 1, 0}, TestType::cell_type::NORMAL);
 
-    quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.28},
-                                       quickexact_params<TestType>::automatic_base_number_detection::OFF};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{2, -0.28},
+                                             quickexact_params<cell<TestType>>::automatic_base_number_detection::OFF};
 
     SECTION("Check if QuickExact is deterministic")
     {
@@ -1395,8 +1416,8 @@ TEMPLATE_TEST_CASE(
     lyt.assign_cell_type({29, 0, 0}, TestType::cell_type::NORMAL);
 
     // quickexact parameters are initialized
-    quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.28},
-                                       quickexact_params<TestType>::automatic_base_number_detection::OFF};
+    quickexact_params<cell<TestType>> params{sidb_simulation_parameters{3, -0.28},
+                                             quickexact_params<cell<TestType>>::automatic_base_number_detection::OFF};
 
     SECTION("Standard Physical Parameters")
     {
@@ -1612,8 +1633,9 @@ TEMPLATE_TEST_CASE(
 
     SECTION("automatic base number detection is off")
     {
-        const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.32, 1.0e-3},
-                                                 quickexact_params<TestType>::automatic_base_number_detection::OFF};
+        const quickexact_params<cell<TestType>> params{
+            sidb_simulation_parameters{2, -0.32, 1.0e-3},
+            quickexact_params<cell<TestType>>::automatic_base_number_detection::OFF};
 
         const auto simulation_results = quickexact<TestType>(lyt, params);
 
@@ -1622,8 +1644,9 @@ TEMPLATE_TEST_CASE(
 
     SECTION("automatic base number detection is on")
     {
-        const quickexact_params<TestType> params{sidb_simulation_parameters{2, -0.32, 1.0e-3},
-                                                 quickexact_params<TestType>::automatic_base_number_detection::ON};
+        const quickexact_params<cell<TestType>> params{
+            sidb_simulation_parameters{2, -0.32, 1.0e-3},
+            quickexact_params<cell<TestType>>::automatic_base_number_detection::ON};
 
         const auto simulation_results = quickexact<TestType>(lyt, params);
 


### PR DESCRIPTION
## Description

This PR introduces a feature to determine the influence zone for a given sublayout within a larger layout. The influence zone includes the SiDBs whose charge states can potentially affect the ground state of the sublayout. SiDBs outside the influence zone are considered to have no significant influence on the ground state of the sublayout, and their charge states need not be taken into account when simulating the sublayout.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
