### PR TITLE
:green_heart: Hotfix for the macOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -64,8 +64,9 @@ jobs:
         with:
           submodules: recursive
 
-      # Setup TBB for parallel STL algorithms via Homebrew
-      - name: Setup TBB
+      # Setup TBB for parallel STL algorithms via Homebrew (macOS 11 is no longer supported)
+      - if: matrix.os != macos-11
+        name: Setup TBB
         run: brew install tbb
 
       # Use XCode 13.2 as a workaround because XCode 14.0 seems broken


### PR DESCRIPTION
This PR constitutes a hotfix for our macOS CI by disabling the installation of TBB under macOS 11 as it seems to no longer be supported.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
