### PR TITLE
🐛 Atomic defect can be updated or new one can be assigned at specific coordinate.

### DIFF
--- a/include/fiction/technology/sidb_surface.hpp
+++ b/include/fiction/technology/sidb_surface.hpp
@@ -125,11 +125,11 @@ class sidb_surface<Lyt, false> : public Lyt
      */
     void assign_sidb_defect(const typename Lyt::coordinate& c, const sidb_defect& d) noexcept
     {
-        if (d.type == sidb_defect_type::NONE)  // delete defect
-        {
-            strg->defective_coordinates.erase(c);
-        }
-        else if (strg->params.ignore.count(d.type) == 0)  // add defect if this type is not ignored
+        // delete defect at the coordinate
+        strg->defective_coordinates.erase(c);
+
+        if (d.type != sidb_defect_type::NONE &&
+            strg->params.ignore.count(d.type) == 0)  // add defect if this type is not ignored and is not NONE
         {
             strg->defective_coordinates.insert({c, d});
         }

--- a/test/technology/sidb_surface.cpp
+++ b/test/technology/sidb_surface.cpp
@@ -109,7 +109,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "overwrite SiDB defect", "[sidb-surface]",
+    "Overwrite SiDB defect", "[sidb-surface]",
     (cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<offset::ucoord_t>>>),
     (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, odd_row_hex>>>),
     (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, even_row_hex>>>),

--- a/test/technology/sidb_surface.cpp
+++ b/test/technology/sidb_surface.cpp
@@ -109,6 +109,28 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
+    "overwrite SiDB defect", "[sidb-surface]",
+    (cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<offset::ucoord_t>>>),
+    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, odd_row_hex>>>),
+    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, even_row_hex>>>),
+    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, odd_column_hex>>>),
+    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, even_column_hex>>>))
+{
+    TestType lyt{{4, 4}};
+
+    sidb_surface<TestType> defect_layout{lyt};
+
+    defect_layout.assign_sidb_defect({0, 0}, sidb_defect{sidb_defect_type::UNKNOWN, 1});
+    CHECK(defect_layout.get_sidb_defect({0, 0}).type == sidb_defect_type::UNKNOWN);
+    CHECK(defect_layout.get_sidb_defect({0, 0}).charge == 1);
+    CHECK(defect_layout.num_defects() == 1);
+
+    defect_layout.assign_sidb_defect({0, 0}, sidb_defect{sidb_defect_type::DB, -1});
+    CHECK(defect_layout.get_sidb_defect({0, 0}).charge == -1);
+    CHECK(defect_layout.num_defects() == 1);
+}
+
+TEMPLATE_TEST_CASE(
     "Non-defective SiDB surface", "[sidb-surface]",
     (cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<offset::ucoord_t>>>),
     (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, odd_row_hex>>>),

--- a/test/technology/sidb_surface.cpp
+++ b/test/technology/sidb_surface.cpp
@@ -116,7 +116,7 @@ TEMPLATE_TEST_CASE(
     (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, odd_column_hex>>>),
     (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<offset::ucoord_t, even_column_hex>>>))
 {
-    TestType lyt{{4, 4}};
+    TestType lyt{{1, 1}};
 
     sidb_surface<TestType> defect_layout{lyt};
 


### PR DESCRIPTION
## Description

This PR allows a given atomic defect to be overwritten/updated with a newly assigned one.

- ``phmap::parallel_flat_hash_map`` does not work as intended.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
