### PR TITLE
:sparkles: Added an upper bound option for the total layout area to `exact`

### DIFF
--- a/cli/cmd/physical_design/exact.hpp
+++ b/cli/cmd/physical_design/exact.hpp
@@ -40,8 +40,9 @@ class exact_command : public command
                    "Clocking scheme to use {OPEN[3|4], COLUMNAR[3|4], ROW[3|4] 2DDWAVE[3|4], 2DDWAVEHEX[3|4], USE, "
                    "RES, ESR, CFE, RIPPLE, BANCS}",
                    true);
-        add_option("--upper_x", ps.upper_bound_x, "Number of FCN gate tiles to use at maximum in x-direction");
-        add_option("--upper_y", ps.upper_bound_y, "Number of FCN gate tiles to use at maximum in y-direction");
+        add_option("--upper_area", ps.upper_bound_area, "Upper bound for the total number of tiles");
+        add_option("--upper_x", ps.upper_bound_x, "Upper bound for the number of tiles in x-direction");
+        add_option("--upper_y", ps.upper_bound_y, "Upper bound for the number of tiles in y-direction");
         add_option("--fixed_size,-f", ps.fixed_size,
                    "Execute only one iteration with the given number of upper bound tiles");
         add_option("--timeout,-t", ps.timeout, "Timeout in seconds");
@@ -192,6 +193,7 @@ class exact_command : public command
     {
         fiction::exact_physical_design_params<LytDest> ps_dest{};
 
+        ps_dest.upper_bound_area         = ps_src.upper_bound_area;
         ps_dest.upper_bound_x            = ps_src.upper_bound_x;
         ps_dest.upper_bound_y            = ps_src.upper_bound_y;
         ps_dest.fixed_size               = ps_src.fixed_size;
@@ -229,7 +231,8 @@ class exact_command : public command
 
         if (clk_scheme_ptr == nullptr)
         {
-            env->out() << "[e] \"" << clocking << "\" does not refer to a supported clocking scheme" << std::endl;
+            env->out() << fmt::format("[e] \"{}\" does not refer to a supported clocking scheme", clocking)
+                       << std::endl;
             reset_flags();
             return;
         }
@@ -256,7 +259,7 @@ class exact_command : public command
             }
             else
             {
-                env->out() << fmt::format("[e] impossible to place and route {} within the given parameters",
+                env->out() << fmt::format("[e] impossible to place and route '{}' within the given parameters",
                                           std::visit(get_name, ntk_ptr))
                            << std::endl;
             }
@@ -267,7 +270,7 @@ class exact_command : public command
         }
         catch (...)
         {
-            env->out() << fmt::format("[e] an error occurred while placing and routing {} with the given parameters",
+            env->out() << fmt::format("[e] an error occurred while placing and routing '{}' with the given parameters",
                                       std::visit(get_name, ntk_ptr))
                        << std::endl;
         }

--- a/include/fiction/algorithms/physical_design/exact.hpp
+++ b/include/fiction/algorithms/physical_design/exact.hpp
@@ -76,6 +76,14 @@ struct exact_physical_design_params
     std::shared_ptr<clocking_scheme<typename Lyt::tile>> scheme =
         std::make_shared<clocking_scheme<typename Lyt::tile>>(twoddwave_clocking<Lyt>());
     /**
+     * Number of total tiles to use as an upper bound.
+     *
+     * @note If `upper_bound_area` and (either) `upper_bound_x` or `upper_bound_y` are set, the imposed search space
+     * restrictions are cumulative. E.g., if `upper_bound_area == 20` and `upper_bound_x == 4`, all aspect ratios with
+     * an x-dimension of more than 4 *and* a total area of more than 20 will be skipped.
+     */
+    uint16_t upper_bound_area = std::numeric_limits<uint16_t>::max();
+    /**
      * Number of tiles to use as an upper bound in x direction.
      */
     uint16_t upper_bound_x = std::numeric_limits<uint16_t>::max();
@@ -84,7 +92,9 @@ struct exact_physical_design_params
      */
     uint16_t upper_bound_y = std::numeric_limits<uint16_t>::max();
     /**
-     * Investigate only aspect ratios with the number of tiles given as upper bound.
+     * Exclusively investigate aspect ratios that conform with the restrictions imposed by the upper bound options.
+     * E.g., if `fixed_size == true` *and* `upper_bound_area == 20`, only aspect ratios with exactly 20 tiles will be
+     * examined. Restricted imposed by the `upper_bound_x` and `upper_bound_y` flags additionally apply.
      */
     bool fixed_size = false;
     /**
@@ -180,7 +190,8 @@ class exact_impl
 
         // NOLINTNEXTLINE(*-prefer-member-initializer)
         ari = aspect_ratio_iterator<typename Lyt::aspect_ratio>{
-            ps.fixed_size ? static_cast<uint64_t>(ps.upper_bound_x * ps.upper_bound_y) :
+            ps.fixed_size ? std::min(static_cast<uint64_t>(ps.upper_bound_area),
+                                     static_cast<uint64_t>(ps.upper_bound_x * ps.upper_bound_y)) :
                             static_cast<uint64_t>(lower_bound)};
     }
 
@@ -270,7 +281,8 @@ class exact_impl
         [[nodiscard]] bool skippable(const typename Lyt::aspect_ratio& ar) const noexcept
         {
             // skip aspect ratios that extend beyond the specified upper bounds
-            if (ar.x >= params.upper_bound_x || ar.y >= params.upper_bound_y)
+            if ((ar.x + 1) * (ar.y + 1) > params.upper_bound_area || ar.x >= params.upper_bound_x ||
+                ar.y >= params.upper_bound_y)
             {
                 return true;
             }
@@ -2849,7 +2861,7 @@ class exact_impl
                 pst.num_aspect_ratios++;
             }
 
-            if (ar.x >= ps.upper_bound_x && ar.y >= ps.upper_bound_y)
+            if ((ar.x + 1) * (ar.y + 1) > ps.upper_bound_area || (ar.x >= ps.upper_bound_x && ar.y >= ps.upper_bound_y))
             {
                 return std::nullopt;
             }
@@ -3034,8 +3046,10 @@ class exact_impl
 
         smt_handler handler{std::make_shared<z3::context>(), layout, *ntk, ps};
 
-        for (; ari <= static_cast<uint64_t>(ps.upper_bound_x) * static_cast<uint64_t>(ps.upper_bound_y);
-             ++ari)  // <= to prevent overflow
+        const auto upper_bound = std::min(static_cast<uint64_t>(ps.upper_bound_area),
+                                          static_cast<uint64_t>(ps.upper_bound_x * ps.upper_bound_y));
+
+        for (; ari <= upper_bound; ++ari)  // <= to prevent overflow
         {
 
 #if (PROGRESS_BARS)

--- a/test/algorithms/physical_design/exact.cpp
+++ b/test/algorithms/physical_design/exact.cpp
@@ -663,6 +663,39 @@ TEST_CASE("High degree input networks", "[exact]")
                                            res(configuration<cart_gate_clk_lyt>())));
 }
 
+TEST_CASE("Exact physical design with upper bounds", "[exact]")
+{
+    auto upper_bound_config = twoddwave(crossings(configuration<cart_gate_clk_lyt>()));
+
+    SECTION("total area")
+    {
+        upper_bound_config.upper_bound_area = 5u;  // allow only 5 tiles total; this will fail (and is tested for)
+
+        const auto half_adder = blueprints::half_adder_network<mockturtle::aig_network>();
+        const auto layout     = exact<cart_gate_clk_lyt>(half_adder, upper_bound_config);
+
+        // since a half adder cannot be synthesized on just 5 tiles, layout should not have a value
+        CHECK(!layout.has_value());
+    }
+    SECTION("individual bounds")
+    {
+        upper_bound_config.upper_bound_y = 3u;  // allow only 3 tiles in y direction; this will work
+
+        const auto mux    = blueprints::mux21_network<technology_network>();
+        auto       layout = exact<cart_gate_clk_lyt>(mux, upper_bound_config);
+
+        REQUIRE(layout.has_value());
+
+        CHECK(layout->y() <= 3);
+
+        upper_bound_config.upper_bound_x = 2u;  // additionally, allow only 2 tiles in x direction; this will now fail
+
+        layout = exact<cart_gate_clk_lyt>(mux, upper_bound_config);
+
+        CHECK(!layout.has_value());
+    }
+}
+
 TEST_CASE("Exact physical design timeout", "[exact]")
 {
     auto timeout_config    = use(crossings(configuration<cart_gate_clk_lyt>()));


### PR DESCRIPTION
## Description

This PR adds an upper bound option for the total layout area to `exact` physical design.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
