### PR TITLE
🐛 Fixed hop energy calculation from neutral to positive SiDB

### DIFF
--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -1371,6 +1371,42 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         return required;
     }
     /**
+     * Counts the number of SiDBs with a negative charge state.
+     *
+     * @return The number of SiDBs with a negative charge state.
+     */
+    [[nodiscard]] std::size_t num_negative_sidbs() const noexcept
+    {
+        uint64_t count_negative_sidbs = 0;
+        this->foreach_cell([this, &count_negative_sidbs](const auto& c)
+                           { count_negative_sidbs += (get_charge_state(c) == sidb_charge_state::NEGATIVE) ? 1 : 0; });
+        return count_negative_sidbs;
+    }
+    /**
+     * Counts the number of SiDBs with a neutral charge state.
+     *
+     * @return The number of SiDBs with a neutral charge state.
+     */
+    [[nodiscard]] std::size_t num_neutral_sidbs() const noexcept
+    {
+        uint64_t count_neutral_sidbs = 0;
+        this->foreach_cell([this, &count_neutral_sidbs](const auto& c)
+                           { count_neutral_sidbs += (get_charge_state(c) == sidb_charge_state::NEUTRAL) ? 1 : 0; });
+        return count_neutral_sidbs;
+    }
+    /**
+     * Counts the number of SiDBs with a positive charge state.
+     *
+     * @return The number of SiDBs with a positive charge state.
+     */
+    [[nodiscard]] std::size_t num_positive_sidbs() const noexcept
+    {
+        uint64_t count_positive_sidbs = 0;
+        this->foreach_cell([this, &count_positive_sidbs](const auto& c)
+                           { count_positive_sidbs += (get_charge_state(c) == sidb_charge_state::POSITIVE) ? 1 : 0; });
+        return count_positive_sidbs;
+    }
+    /**
      * This functions returns all cells that could be positively charged. However, this must not be necessarily the case
      * in a physically valid layout.
      *

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -984,12 +984,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         {
             const auto hop_del =
                 [this](const uint64_t c1, const uint64_t c2)  // energy change when charge hops between two SiDBs.
-            {
-                const int dn_i = (strg->cell_charge[c1] == sidb_charge_state::NEGATIVE) ? 1 : -1;
-                const int dn_j = -dn_i;
-
-                return strg->local_pot[c1] * dn_i + strg->local_pot[c2] * dn_j - strg->pot_mat[c1][c2] * 1;
-            };
+            { return strg->local_pot[c1] - strg->local_pot[c2] - strg->pot_mat[c1][c2] * 1; };
 
             uint64_t hop_counter = 0;
             for (uint64_t i = 0u; i < strg->local_pot.size(); ++i)

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -984,7 +984,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         {
             const auto hop_del =
                 [this](const uint64_t c1, const uint64_t c2)  // energy change when charge hops between two SiDBs.
-            { return strg->local_pot[c1] - strg->local_pot[c2] - strg->pot_mat[c1][c2] * 1; };
+            { return strg->local_pot[c1] - strg->local_pot[c2] - strg->pot_mat[c1][c2]; };
 
             uint64_t hop_counter = 0;
             for (uint64_t i = 0u; i < strg->local_pot.size(); ++i)

--- a/test/algorithms/simulation/sidb/quickexact.cpp
+++ b/test/algorithms/simulation/sidb/quickexact.cpp
@@ -928,27 +928,16 @@ TEMPLATE_TEST_CASE(
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
-    REQUIRE(simulation_results.charge_distributions.size() == 3);
+    REQUIRE(simulation_results.charge_distributions.size() == 4);
 
-    auto energy_min = std::numeric_limits<double>::max();
-    for (const auto& layout : simulation_results.charge_distributions)
-    {
-        if (layout.get_system_energy() < energy_min)
-        {
-            energy_min = layout.get_system_energy();
-        }
-    }
+    const auto ground_state = std::min_element(
+        simulation_results.charge_distributions.cbegin(), simulation_results.charge_distributions.cend(),
+        [](const auto& lhs, const auto& rhs) { return lhs.get_system_energy() < rhs.get_system_energy(); });
 
-    for (const auto& layout : simulation_results.charge_distributions)
-    {
-        if (std::abs(layout.get_system_energy() - energy_min) < physical_constants::POP_STABILITY_ERR)
-        {
-            CHECK(layout.get_charge_state({1, 3, 0}) == sidb_charge_state::NEGATIVE);
-            CHECK(layout.get_charge_state({1, 3, 0}) == sidb_charge_state::NEGATIVE);
-            CHECK(layout.get_charge_state({2, 3, 0}) == sidb_charge_state::POSITIVE);
-            CHECK(layout.get_charge_state({3, 3, 0}) == sidb_charge_state::NEGATIVE);
-        }
-    }
+    CHECK(ground_state->get_charge_state({-1, 3, 0}) == sidb_charge_state::NEGATIVE);
+    CHECK(ground_state->get_charge_state({1, 3, 0}) == sidb_charge_state::POSITIVE);
+    CHECK(ground_state->get_charge_state({2, 3, 0}) == sidb_charge_state::NEGATIVE);
+    CHECK(ground_state->get_charge_state({3, 3, 0}) == sidb_charge_state::NEUTRAL);
 }
 
 TEMPLATE_TEST_CASE(
@@ -991,7 +980,7 @@ TEMPLATE_TEST_CASE(
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
-    REQUIRE(simulation_results.charge_distributions.size() == 2);
+    REQUIRE(simulation_results.charge_distributions.size() == 4);
     const auto& charge_lyt_first = simulation_results.charge_distributions.front();
     CHECK_THAT(charge_lyt_first.get_system_energy(),
                Catch::Matchers::WithinAbs(0, physical_constants::POP_STABILITY_ERR));
@@ -1016,7 +1005,7 @@ TEMPLATE_TEST_CASE(
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
-    REQUIRE(simulation_results.charge_distributions.size() == 3);
+    REQUIRE(simulation_results.charge_distributions.size() == 10);
     const auto& charge_lyt_first = simulation_results.charge_distributions.front();
     CHECK(charge_lyt_first.get_system_energy() < 0.08);
     CHECK(charge_lyt_first.get_system_energy() > -2.74);
@@ -1043,7 +1032,7 @@ TEMPLATE_TEST_CASE(
 
     const auto simulation_results = quickexact<TestType>(lyt, params);
 
-    CHECK(simulation_results.charge_distributions.size() == 5);
+    CHECK(simulation_results.charge_distributions.size() == 17);
 }
 
 TEMPLATE_TEST_CASE(
@@ -1109,7 +1098,26 @@ TEMPLATE_TEST_CASE(
 
     CHECK(lyt.num_cells() == 6);
 
-    CHECK(simulation_results.charge_distributions.size() == 1);
+    CHECK(simulation_results.charge_distributions.size() == 3);
+}
+
+TEMPLATE_TEST_CASE(
+    "4 DBs which can be only simulated if electron hop from negative to positiv is prohibited", "[quickexact]",
+    (cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<siqad::coord_t>>>),
+    (charge_distribution_surface<cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<siqad::coord_t>>>>))
+{
+    TestType lyt{};
+
+    lyt.assign_cell_type({0, 0, 1}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({3, 0, 1}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({5, 0, 1}, TestType::cell_type::NORMAL);
+
+    const quickexact_params<TestType> params{sidb_simulation_parameters{3, -0.25}};
+
+    const auto simulation_results = quickexact<TestType>(lyt, params);
+
+    CHECK(simulation_results.charge_distributions.size() > 0);
 }
 
 TEMPLATE_TEST_CASE(
@@ -1237,6 +1245,22 @@ TEMPLATE_TEST_CASE(
         }
         CHECK(ground_state.size() == 1);
         CHECK(charge_index.size() == 1);
+    }
+
+    SECTION(
+        "Add SiDBs which are positively charged in the ground state, layout does not work fulfill the logic anymore.")
+    {
+        params.physical_parameters.base = 3;
+        lyt.assign_cell_type({15, 2, 1}, TestType::cell_type::NORMAL);
+        lyt.assign_cell_type({15, 2, 0}, TestType::cell_type::NORMAL);
+
+        const auto simulation_results = quickexact<TestType>(lyt, params);
+        // find the ground state, which is the charge distribution with the lowest energy
+        const auto ground_state = std::min_element(
+            simulation_results.charge_distributions.cbegin(), simulation_results.charge_distributions.cend(),
+            [](const auto& lhs, const auto& rhs) { return lhs.get_system_energy() < rhs.get_system_energy(); });
+
+        CHECK(ground_state->num_positive_sidbs() > 0);
     }
 
     SECTION("Standard Physical Parameters")
@@ -1407,6 +1431,10 @@ TEMPLATE_TEST_CASE(
         const auto ground_state = std::min_element(
             simulation_results.charge_distributions.cbegin(), simulation_results.charge_distributions.cend(),
             [](const auto& lhs, const auto& rhs) { return lhs.get_system_energy() < rhs.get_system_energy(); });
+
+        CHECK(ground_state->num_negative_sidbs() == 5);
+        CHECK(ground_state->num_neutral_sidbs() == 4);
+        CHECK(ground_state->num_positive_sidbs() == 0);
 
         // check that charge distribution is correct; binary 1 is propagated through the BDL wire
         CHECK(ground_state->get_charge_state({0, 0, 0}) == sidb_charge_state::NEGATIVE);

--- a/test/algorithms/simulation/sidb/quickexact.cpp
+++ b/test/algorithms/simulation/sidb/quickexact.cpp
@@ -1102,7 +1102,7 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
-    "4 DBs which can be only simulated if electron hop from negative to positiv is prohibited", "[quickexact]",
+    "4 DBs close to each other", "[quickexact]",
     (cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<siqad::coord_t>>>),
     (charge_distribution_surface<cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<siqad::coord_t>>>>))
 {
@@ -1247,8 +1247,7 @@ TEMPLATE_TEST_CASE(
         CHECK(charge_index.size() == 1);
     }
 
-    SECTION(
-        "Add SiDBs which are positively charged in the ground state, layout does not work fulfill the logic anymore.")
+    SECTION("Add SiDBs which are positively charged in the ground state, layout does not fulfill the logic anymore.")
     {
         params.physical_parameters.base = 3;
         lyt.assign_cell_type({15, 2, 1}, TestType::cell_type::NORMAL);


### PR DESCRIPTION
## Description:

This PR fixes a major bug. The hopping energy from a neutrally to a positively charged SiDB was calculated incorrectly. Finally, this fix allows the successful simulation of positively charged SiDBs.

@samuelngsh I would strongly recommend to make this change in *SiQAD* as well. Many thanks! 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
