### PR TITLE
:construction_worker: Update macOS CI to support Apple Silicon runners

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13, macos-14 ]
+        os: [ macos-11, macos-12, macos-13 ]
         compiler: [ g++-11, g++-12, clang++ ]
         build_type: [ Debug, Release ]
         include:
@@ -59,14 +59,6 @@ jobs:
             ccompiler: gcc-13
             build_type: Debug
           - os: macos-13
-            compiler: g++-13
-            ccompiler: gcc-13
-            build_type: Release
-          - os: macos-14
-            compiler: g++-13
-            ccompiler: gcc-13
-            build_type: Debug
-          - os: macos-14
             compiler: g++-13
             ccompiler: gcc-13
             build_type: Release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,6 +52,9 @@ jobs:
             ccompiler: gcc-11
           - compiler: g++-12
             ccompiler: gcc-12
+        exclude:
+          - os: macos-12
+            compiler: g++13
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,29 +36,35 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ macos-11, macos-12, macos-13 ]
+        os: [ macos-12, macos-13, macos-14 ]
         compiler: [ g++-11, g++-12, clang++ ]
         build_type: [ Debug, Release ]
         include:
+          - os: macos-12
+            architecture: x64
+          - os: macos-13
+            architecture: x64
+          - os: macos-14
+            architecture: arm64
           - compiler: clang++
             ccompiler: clang
           - compiler: g++-11
             ccompiler: gcc-11
           - compiler: g++-12
             ccompiler: gcc-12
-          - os: macos-11
-            compiler: g++-10
-            ccompiler: gcc-10
-            build_type: Debug
-          - os: macos-11
-            compiler: g++-10
-            ccompiler: gcc-10
-            build_type: Release
           - os: macos-13
             compiler: g++-13
             ccompiler: gcc-13
             build_type: Debug
           - os: macos-13
+            compiler: g++-13
+            ccompiler: gcc-13
+            build_type: Release
+          - os: macos-14
+            compiler: g++-13
+            ccompiler: gcc-13
+            build_type: Debug
+          - os: macos-14
             compiler: g++-13
             ccompiler: gcc-13
             build_type: Release
@@ -78,7 +84,7 @@ jobs:
         run: brew install tbb
 
       # Use XCode 13.2 as a workaround because XCode 14.0 seems broken
-      - if: matrix.os == 'macos-12' || matrix.os == 'macos-11'
+      - if: matrix.os == 'macos-12'
         name: Setup XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -104,7 +110,7 @@ jobs:
         with:
           version: ${{env.Z3_VERSION}}
           platform: macOS
-          architecture: x64
+          architecture: ${{matrix.architecture}}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -130,7 +136,7 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: cmake --build . -j3  # macOS runners provide 3 cores
+        run: cmake --build . -j3  # all macOS runners provide at least 3 cores
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ macos-11, macos-12 ]
+        os: [ macos-11, macos-12, macos-13, macos-14 ]
         compiler: [ g++-11, g++-12, clang++ ]
         build_type: [ Debug, Release ]
         include:
@@ -46,14 +46,8 @@ jobs:
             ccompiler: gcc-11
           - compiler: g++-12
             ccompiler: gcc-12
-          - os: macos-11
-            compiler: g++-10
-            ccompiler: gcc-10
-            build_type: Debug
-          - os: macos-11
-            compiler: g++-10
-            ccompiler: gcc-10
-            build_type: Release
+          - compiler: g++-13
+            ccompiler: gcc-13
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -86,10 +86,17 @@ jobs:
         run: brew install tbb
 
       # Use XCode 13.2 as a workaround because XCode 14.0 seems broken
-      - name: Setup XCode version
+      - if: matrix.os == 'macos-12' || matrix.os == 'macos-11'
+        name: Setup XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "^14.1"
+          xcode-version: "^13.2"
+
+      - if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        name: Setup XCode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "^14.2"
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-12, macos-13, macos-14 ]
-        compiler: [ g++-11, g++-12, clang++ ]
+        compiler: [ g++-11, g++-12, g++13, clang++ ]
         build_type: [ Debug, Release ]
         include:
           - os: macos-12
@@ -52,22 +52,6 @@ jobs:
             ccompiler: gcc-11
           - compiler: g++-12
             ccompiler: gcc-12
-          - os: macos-13
-            compiler: g++-13
-            ccompiler: gcc-13
-            build_type: Debug
-          - os: macos-13
-            compiler: g++-13
-            ccompiler: gcc-13
-            build_type: Release
-          - os: macos-14
-            compiler: g++-13
-            ccompiler: gcc-13
-            build_type: Debug
-          - os: macos-14
-            compiler: g++-13
-            ccompiler: gcc-13
-            build_type: Release
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,7 +71,6 @@ jobs:
             ccompiler: gcc-13
             build_type: Release
 
-
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "^13.2"
+          xcode-version: "^14.1"
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-12, macos-13, macos-14 ]
-        compiler: [ g++-11, g++-12, g++13, clang++ ]
+        compiler: [ g++-11, g++-12, g++-13, clang++ ]
         build_type: [ Debug, Release ]
         include:
           - os: macos-12
@@ -53,8 +53,12 @@ jobs:
           - compiler: g++-12
             ccompiler: gcc-12
         exclude:
-          - os: macos-12
-            compiler: g++13
+          - os: macos-14
+            compiler: g++-11
+          - os: macos-14
+            compiler: g++-12
+          - os: macos-14
+            compiler: g++-13
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,8 +46,31 @@ jobs:
             ccompiler: gcc-11
           - compiler: g++-12
             ccompiler: gcc-12
-          - compiler: g++-13
+          - os: macos-11
+            compiler: g++-10
+            ccompiler: gcc-10
+            build_type: Debug
+          - os: macos-11
+            compiler: g++-10
+            ccompiler: gcc-10
+            build_type: Release
+          - os: macos-13
+            compiler: g++-13
             ccompiler: gcc-13
+            build_type: Debug
+          - os: macos-13
+            compiler: g++-13
+            ccompiler: gcc-13
+            build_type: Release
+          - os: macos-14
+            compiler: g++-13
+            ccompiler: gcc-13
+            build_type: Debug
+          - os: macos-14
+            compiler: g++-13
+            ccompiler: gcc-13
+            build_type: Release
+
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
## Description

This PR adds ``macos-13`` and ``macos-14`` to the MacOS CI. 

## Checklist:
<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
