### PR TITLE
:bug: Use correct parameter in ``is_ground_state``.

### DIFF
--- a/include/fiction/algorithms/simulation/sidb/is_ground_state.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_ground_state.hpp
@@ -21,13 +21,13 @@ namespace fiction
  * This function checks if the ground state is found by the *QuickSim* algorithm.
  *
  * @tparam Lyt Cell-level layout type.
- * @param quicksim_results All found physically valid charge distribution surfaces obtained by the *QuickSim* algorithm.
+ * @param heuristic_results All found physically valid charge distribution surfaces obtained by a heuristic algorithm.
  * @param exhaustive_results All valid charge distribution surfaces determined by ExGS.
  * @return Returns `true` if the relative difference between the lowest energies of the two sets is less than \f$
  * 0.00001 \f$, `false` otherwise.
  */
 template <typename Lyt>
-[[nodiscard]] bool is_ground_state(const sidb_simulation_result<Lyt>& quicksim_results,
+[[nodiscard]] bool is_ground_state(const sidb_simulation_result<Lyt>& heuristic_results,
                                    const sidb_simulation_result<Lyt>& exhaustive_results) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
@@ -38,12 +38,12 @@ template <typename Lyt>
         return false;
     }
 
-    const auto min_energy_exact  = minimum_energy(exhaustive_results.charge_distributions.cbegin(),
-                                                  exhaustive_results.charge_distributions.cend());
-    const auto min_energy_new_ap = minimum_energy(exhaustive_results.charge_distributions.cbegin(),
-                                                  exhaustive_results.charge_distributions.cend());
+    const auto min_energy_exact = minimum_energy(exhaustive_results.charge_distributions.cbegin(),
+                                                 exhaustive_results.charge_distributions.cend());
+    const auto min_energy_heuristic =
+        minimum_energy(heuristic_results.charge_distributions.cbegin(), heuristic_results.charge_distributions.cend());
 
-    return round_to_n_decimal_places(std::abs(min_energy_exact - min_energy_new_ap), 6) == 0;
+    return round_to_n_decimal_places(std::abs(min_energy_exact - min_energy_heuristic), 6) == 0;
 }
 
 }  // namespace fiction

--- a/test/algorithms/simulation/sidb/is_groundstate.cpp
+++ b/test/algorithms/simulation/sidb/is_groundstate.cpp
@@ -7,28 +7,21 @@
 #include <fiction/algorithms/simulation/sidb/exhaustive_ground_state_simulation.hpp>
 #include <fiction/algorithms/simulation/sidb/is_ground_state.hpp>
 #include <fiction/algorithms/simulation/sidb/quicksim.hpp>
-#include <fiction/algorithms/simulation/sidb/sidb_simulation_result.hpp>
-#include <fiction/layouts/cartesian_layout.hpp>
-#include <fiction/layouts/cell_level_layout.hpp>
-#include <fiction/layouts/clocked_layout.hpp>
-#include <fiction/layouts/hexagonal_layout.hpp>
+#include <fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp>
 #include <fiction/technology/cell_technologies.hpp>
+#include <fiction/technology/charge_distribution_surface.hpp>
+#include <fiction/types.hpp>
 
 using namespace fiction;
 
-TEMPLATE_TEST_CASE(
-    "check if ground state is found", "[is-ground-state]",
-    (cell_level_layout<sidb_technology, clocked_layout<cartesian_layout<siqad::coord_t>>>),
-    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<siqad::coord_t, odd_row_hex>>>),
-    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<siqad::coord_t, even_row_hex>>>),
-    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<siqad::coord_t, odd_column_hex>>>),
-    (cell_level_layout<sidb_technology, clocked_layout<hexagonal_layout<siqad::coord_t, even_column_hex>>>))
+TEMPLATE_TEST_CASE("check if ground state is found", "[is-ground-state]", (sidb_cell_clk_lyt_siqad),
+                   (charge_distribution_surface<sidb_cell_clk_lyt_siqad>))
 {
     SECTION("layout with no SiDB placed")
     {
-        TestType                         lyt{{20, 10}};
-        charge_distribution_surface      charge_layout{lyt};
-        const sidb_simulation_parameters params{2, -0.32};
+        TestType                          lyt{};
+        const charge_distribution_surface charge_layout{lyt};
+        const sidb_simulation_parameters  params{2, -0.32};
         const auto simulation_results_exgs = exhaustive_ground_state_simulation<TestType>(charge_layout, params);
         const quicksim_params quicksim_params{params};
         const auto            simulation_results_quicksim = quicksim<TestType>(charge_layout, quicksim_params);
@@ -38,7 +31,7 @@ TEMPLATE_TEST_CASE(
 
     SECTION("layout with seven SiDBs placed")
     {
-        TestType lyt{{20, 10}};
+        TestType lyt{};
 
         lyt.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);
         lyt.assign_cell_type({3, 3, 0}, TestType::cell_type::NORMAL);
@@ -50,8 +43,8 @@ TEMPLATE_TEST_CASE(
         lyt.assign_cell_type({6, 10, 0}, TestType::cell_type::NORMAL);
         lyt.assign_cell_type({7, 10, 0}, TestType::cell_type::NORMAL);
 
-        charge_distribution_surface      charge_layout{lyt};
-        const sidb_simulation_parameters params{2, -0.32};
+        const charge_distribution_surface charge_layout{lyt};
+        const sidb_simulation_parameters  params{2, -0.32};
 
         const auto simulation_results_exgs = exhaustive_ground_state_simulation<TestType>(charge_layout, params);
 


### PR DESCRIPTION
## Description

This PR fixes a bug in ``is_ground_state``. Previously, the wrong parameter was used for the calculation. This bug was already fixed in #380, but to ensure quick integration, this separate PR is created.

Fixes #392 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
