### PR TITLE
:bug: Include x_min and y_min in OpDomain and check non-emptyness of vector before accessing element.

### DIFF
--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -274,14 +274,14 @@ class operational_domain_impl
         std::iota(x_indices.begin(), x_indices.end(), 0ul);
         std::iota(y_indices.begin(), y_indices.end(), 0ul);
 
-        // If the value of the x-parameter is greater than params.x_max after num_x_steps() steps, this value is
+        // if the value of the x-parameter is greater than params.x_max after num_x_steps() steps, this value is
         // ignored in the operational domain calculation.
         if ((params.x_min + (x_indices.size() - 1) * params.x_step) - params.x_max >
             physical_constants::POP_STABILITY_ERR)
         {
             x_indices.pop_back();
         }
-        // If the value of the y-parameter is greater than params.y_max after num_y_steps() steps, this value is
+        // if the value of the y-parameter is greater than params.y_max after num_y_steps() steps, this value is
         // ignored in the operational domain calculation.
         if (((params.y_min + (y_indices.size() - 1) * params.y_step) - params.y_max) >
             physical_constants::POP_STABILITY_ERR)
@@ -290,13 +290,13 @@ class operational_domain_impl
         }
 
         // generate the x dimension values
-        for (size_t i = 0; i <= x_indices.size(); ++i)
+        for (std::size_t i = 0; i <= x_indices.size(); ++i)
         {
             x_values.push_back(params.x_min + i * params.x_step);
         }
 
         // generate the y dimension values
-        for (size_t i = 0; i <= y_indices.size(); ++i)
+        for (std::size_t i = 0; i <= y_indices.size(); ++i)
         {
             y_values.push_back(params.y_min + i * params.y_step);
         }

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -340,7 +340,7 @@ class operational_domain_impl
         const auto step_point_samples = generate_random_step_points(samples);
 
         // for each sample point in parallel
-        std::for_each(FICTION_EXECUTION_POLICY_PAR_UNSEQ step_point_samples.cbegin(), step_point_samples.cend(),
+        std::for_each(FICTION_EXECUTION_POLICY_SEQ step_point_samples.cbegin(), step_point_samples.cend(),
                       [this](const auto& sp) { is_step_point_operational(sp); });
 
         log_stats();

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -340,7 +340,7 @@ class operational_domain_impl
         const auto step_point_samples = generate_random_step_points(samples);
 
         // for each sample point in parallel
-        std::for_each(FICTION_EXECUTION_POLICY_SEQ step_point_samples.cbegin(), step_point_samples.cend(),
+        std::for_each(FICTION_EXECUTION_POLICY_PAR_UNSEQ step_point_samples.cbegin(), step_point_samples.cend(),
                       [this](const auto& sp) { is_step_point_operational(sp); });
 
         log_stats();

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -290,19 +290,15 @@ class operational_domain_impl
         }
 
         // generate the x dimension values
-        auto x_val = params.x_min;
         for (size_t i = 0; i <= x_indices.size(); ++i)
         {
-            x_values.push_back(x_val);
-            x_val += params.x_step;
+            x_values.push_back(params.x_min + i * params.x_step);
         }
 
         // generate the y dimension values
-        auto y_val = params.y_min;
         for (size_t i = 0; i <= y_indices.size(); ++i)
         {
-            y_values.push_back(y_val);
-            y_val += params.y_step;
+            y_values.push_back(params.y_min + i * params.y_step);
         }
     }
     /**

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -464,9 +464,20 @@ class operational_domain_impl
                                          step_point{current_contour_point.x - 1, current_contour_point.y};
 
         auto current_neighborhood = moore_neighborhood(current_contour_point);
-        auto next_point           = current_contour_point == backtrack_point ?
-                                        current_neighborhood.front() :
-                                        next_clockwise_point(current_neighborhood, backtrack_point);
+        if (current_neighborhood.empty())
+        {
+            assert(true && "The neighborhood should not be empty");
+        }
+
+        step_point front_neighborhood{};
+        auto       next_point = contour_starting_point;
+
+        if (!current_neighborhood.empty())
+        {
+            next_point = current_contour_point == backtrack_point ?
+                             current_neighborhood.front() :
+                             next_clockwise_point(current_neighborhood, backtrack_point);
+        }
 
         while (next_point != contour_starting_point)
         {

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -274,14 +274,14 @@ class operational_domain_impl
         std::iota(x_indices.begin(), x_indices.end(), 0ul);
         std::iota(y_indices.begin(), y_indices.end(), 0ul);
 
-        // If the value of the x-parameter is not less than params.x_max after num_x_steps() steps, this value is
+        // If the value of the x-parameter is greater than params.x_max after num_x_steps() steps, this value is
         // ignored in the operational domain calculation.
         if ((params.x_min + (x_indices.size() - 1) * params.x_step) - params.x_max >
             physical_constants::POP_STABILITY_ERR)
         {
             x_indices.pop_back();
         }
-        // If the value of the y-parameter is not less than params.y_max after num_y_steps() steps, this value is
+        // If the value of the y-parameter is greater than params.y_max after num_y_steps() steps, this value is
         // ignored in the operational domain calculation.
         if (((params.y_min + (y_indices.size() - 1) * params.y_step) - params.y_max) >
             physical_constants::POP_STABILITY_ERR)

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -464,10 +464,6 @@ class operational_domain_impl
                                          step_point{current_contour_point.x - 1, current_contour_point.y};
 
         auto current_neighborhood = moore_neighborhood(current_contour_point);
-        if (current_neighborhood.empty())
-        {
-            assert(true && "The neighborhood should not be empty");
-        }
 
         step_point front_neighborhood{};
         auto       next_point = contour_starting_point;

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -274,11 +274,15 @@ class operational_domain_impl
         std::iota(x_indices.begin(), x_indices.end(), 0ul);
         std::iota(y_indices.begin(), y_indices.end(), 0ul);
 
+        // If the value of the x-parameter is not less than params.x_max after num_x_steps() steps, this value is
+        // ignored in the operational domain calculation.
         if ((params.x_min + (x_indices.size() - 1) * params.x_step) - params.x_max >
             physical_constants::POP_STABILITY_ERR)
         {
             x_indices.pop_back();
         }
+        // If the value of the y-parameter is not less than params.y_max after num_y_steps() steps, this value is
+        // ignored in the operational domain calculation.
         if (((params.y_min + (y_indices.size() - 1) * params.y_step) - params.y_max) >
             physical_constants::POP_STABILITY_ERR)
         {
@@ -287,14 +291,15 @@ class operational_domain_impl
 
         // generate the x dimension values
         auto x_val = params.x_min;
-        for (size_t y = 0; y < x_indices.size() && x_val < params.x_max + physical_constants::POP_STABILITY_ERR; ++y)
+        for (size_t i = 0; i <= x_indices.size(); ++i)
         {
             x_values.push_back(x_val);
             x_val += params.x_step;
         }
 
+        // generate the y dimension values
         auto y_val = params.y_min;
-        for (size_t y = 0; y < y_indices.size() && y_val < params.y_max + physical_constants::POP_STABILITY_ERR; ++y)
+        for (size_t i = 0; i <= y_indices.size(); ++i)
         {
             y_values.push_back(y_val);
             y_val += params.y_step;
@@ -465,8 +470,7 @@ class operational_domain_impl
 
         auto current_neighborhood = moore_neighborhood(current_contour_point);
 
-        step_point front_neighborhood{};
-        auto       next_point = contour_starting_point;
+        auto next_point = contour_starting_point;
 
         if (!current_neighborhood.empty())
         {

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -1938,17 +1938,17 @@ class charge_distribution_surface<Lyt, false> : public Lyt
 
         if (strg->charge_index_sublayout == 0)
         {
-            for (const auto& cell : strg->three_state_cells)
+            for (const auto& c : strg->three_state_cells)
             {
-                this->assign_charge_state(cell, sidb_charge_state::NEGATIVE, false);
+                this->assign_charge_state(c, sidb_charge_state::NEGATIVE, false);
             }
         }
 
         if (strg->charge_index_and_base.first == 0)
         {
-            for (const auto& cell : strg->sidb_order_without_three_state_cells)
+            for (const auto& c : strg->sidb_order_without_three_state_cells)
             {
-                this->assign_charge_state(cell, sidb_charge_state::NEGATIVE, false);
+                this->assign_charge_state(c, sidb_charge_state::NEGATIVE, false);
             }
         }
 

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -99,72 +99,88 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
         SECTION("grid_search")
         {
-            const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
-                                                                  op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
+                                                                      op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() == 1);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() == 1);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations == 2);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
-            CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations == 2);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
+                CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
         SECTION("random_sampling")
         {
-            const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
-                                                                      op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
+                                                                          op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() == 1);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() == 1);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations <= 200);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
-            CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations <= 200);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
+                CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
         SECTION("flood_fill")
         {
-            const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                 op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                     op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() == 1);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() == 1);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations == 2);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
-            CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations == 2);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
+                CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
         SECTION("contour_tracing")
         {
-            const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                      op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                          op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() == 1);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() == 1);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations == 2);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
-            CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations == 2);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
+                CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
     }
 
@@ -180,72 +196,88 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
         SECTION("grid_search")
         {
-            const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
-                                                                  op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
+                                                                      op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() == 100);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() == 100);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations == 200);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-            CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations == 200);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+                CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
         SECTION("random_sampling")
         {
-            const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
-                                                                      op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
+                                                                          op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() <= 100);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() <= 100);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations <= 200);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
-            CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations <= 200);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
+                CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
         SECTION("flood_fill")
         {
-            const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                 op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                     op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() == 100);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() == 100);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations == 200);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-            CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations == 200);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+                CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
         SECTION("contour_tracing")
         {
-            const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                      op_domain_params, &op_domain_stats);
+            for (auto i = 0u; i< 10;i++)
+            {
+                const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                          op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() <= 100);
+                // check if the operational domain has the correct size
+                CHECK(op_domain.operational_values.size() <= 100);
 
-            // for the selected range, all samples should be within the parameters and operational
-            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+                // for the selected range, all samples should be within the parameters and operational
+                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
+                                                              operational_status::OPERATIONAL);
 
-            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations <= 200);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-            CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+                CHECK(op_domain_stats.num_simulator_invocations <= 200);
+                CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+                CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+            }
         }
     }
 

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -8,6 +8,7 @@
 #include <fiction/algorithms/simulation/sidb/operational_domain.hpp>
 #include <fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp>
 #include <fiction/technology/cell_technologies.hpp>
+#include <fiction/technology/physical_constants.hpp>
 #include <fiction/technology/sidb_lattice.hpp>
 #include <fiction/technology/sidb_lattice_orientations.hpp>
 #include <fiction/types.hpp>
@@ -47,6 +48,7 @@ void check_op_domain_params_and_operational_status(const operational_domain&    
 
         if (status)
         {
+            std::cout << fmt::format("point: {}, {}, status: {}\n", coord.x, coord.y, *status);
             CHECK(op_value == *status);
         }
     }

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -359,21 +359,21 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
         }
         SECTION("random_sampling")
         {
-            const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 50,
+            const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 5000,
                                                                       op_domain_params, &op_domain_stats);
 
             // check if the operational domain has the correct maximum size
-            CHECK(op_domain.operational_values.size() <= 50);
+            CHECK(op_domain.operational_values.size() <= 5000);
 
             // for the selected range, all samples should be within the parameters and non-operational
             check_op_domain_params_and_operational_status(op_domain, op_domain_params,
                                                           operational_status::NON_OPERATIONAL);
 
             CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations <= 100);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 50);
+            CHECK(op_domain_stats.num_simulator_invocations <= 10000);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 5000);
             CHECK(op_domain_stats.num_operational_parameter_combinations == 0);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations <= 50);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations <= 5000);
         }
         SECTION("flood_fill")
         {

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -525,241 +525,241 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
     }
 }
 
-// TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
-//{
-//     using layout = sidb_cell_clk_lyt_siqad;
-//
-//     layout lyt{{20, 10}, "AND gate"};
-//
-//     lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
-//     lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
-//
-//     lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
-//     lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
-//
-//     lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
-//     lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
-//
-//     lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
-//     lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
-//
-//     lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
-//     lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
-//
-//     lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
-//
-//     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
-//
-//     sidb_simulation_parameters sim_params{};
-//     sim_params.base     = 2;
-//     sim_params.mu_minus = -0.28;
-//
-//     operational_domain_params op_domain_params{};
-//     op_domain_params.sim_params  = sim_params;
-//     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-//     op_domain_params.x_min       = 5.1;
-//     op_domain_params.x_max       = 6.0;
-//     op_domain_params.x_step      = 0.1;
-//     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-//     op_domain_params.y_min       = 4.5;
-//     op_domain_params.y_max       = 5.4;
-//     op_domain_params.y_step      = 0.1;
-//
-//     operational_domain_stats op_domain_stats{};
-//
-//     SECTION("grid_search")
-//     {
-//         const auto op_domain =
-//             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
-//             &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() == 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations == 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-//     SECTION("random_sampling")
-//     {
-//         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-//                                                                   op_domain_params, &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (max 10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() <= 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-//     SECTION("flood_fill")
-//     {
-//         const auto op_domain =
-//             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
-//             &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() == 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations == 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-//     SECTION("contour_tracing")
-//     {
-//         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-//                                                                   op_domain_params, &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (max 10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() <= 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-// }
-//
-// TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
-//{
-//     using layout = sidb_cell_clk_lyt_cube;
-//
-//     layout lyt{{20, 10}, "AND gate"};
-//
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
-//                          sidb_technology::cell_type::INPUT);
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
-//                          sidb_technology::cell_type::INPUT);
-//
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
-//                          sidb_technology::cell_type::INPUT);
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
-//                          sidb_technology::cell_type::INPUT);
-//
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
-//                          sidb_technology::cell_type::NORMAL);
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
-//                          sidb_technology::cell_type::NORMAL);
-//
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
-//                          sidb_technology::cell_type::NORMAL);
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
-//                          sidb_technology::cell_type::NORMAL);
-//
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
-//                          sidb_technology::cell_type::OUTPUT);
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
-//                          sidb_technology::cell_type::OUTPUT);
-//
-//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
-//                          sidb_technology::cell_type::NORMAL);
-//
-//     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
-//
-//     sidb_simulation_parameters sim_params{};
-//     sim_params.base     = 2;
-//     sim_params.mu_minus = -0.28;
-//
-//     operational_domain_params op_domain_params{};
-//     op_domain_params.sim_params  = sim_params;
-//     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-//     op_domain_params.x_min       = 5.1;
-//     op_domain_params.x_max       = 6.0;
-//     op_domain_params.x_step      = 0.1;
-//     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-//     op_domain_params.y_min       = 4.5;
-//     op_domain_params.y_max       = 5.4;
-//     op_domain_params.y_step      = 0.1;
-//
-//     operational_domain_stats op_domain_stats{};
-//
-//     SECTION("grid_search")
-//     {
-//         const auto op_domain =
-//             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
-//             &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() == 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations == 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-//     SECTION("random_sampling")
-//     {
-//         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-//                                                                   op_domain_params, &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (max 10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() <= 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-//     SECTION("flood_fill")
-//     {
-//         const auto op_domain =
-//             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
-//             &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() == 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations == 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-//     SECTION("contour_tracing")
-//     {
-//         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-//                                                                   op_domain_params, &op_domain_stats);
-//
-//         // check if the operational domain has the correct size (max 10 steps in each dimension)
-//         CHECK(op_domain.operational_values.size() <= 100);
-//
-//         // for the selected range, all samples should be within the parameters and operational
-//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-//
-//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//     }
-// }
+ TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
+{
+     using layout = sidb_cell_clk_lyt_siqad;
+
+     layout lyt{{20, 10}, "AND gate"};
+
+     lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
+     lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
+
+     lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
+     lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
+
+     lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
+     lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
+
+     lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
+     lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
+
+     lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
+     lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
+
+     lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
+
+     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+
+     sidb_simulation_parameters sim_params{};
+     sim_params.base     = 2;
+     sim_params.mu_minus = -0.28;
+
+     operational_domain_params op_domain_params{};
+     op_domain_params.sim_params  = sim_params;
+     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+     op_domain_params.x_min       = 5.1;
+     op_domain_params.x_max       = 6.0;
+     op_domain_params.x_step      = 0.1;
+     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+     op_domain_params.y_min       = 4.5;
+     op_domain_params.y_max       = 5.4;
+     op_domain_params.y_step      = 0.1;
+
+     operational_domain_stats op_domain_stats{};
+
+     SECTION("grid_search")
+     {
+         const auto op_domain =
+             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
+             &op_domain_stats);
+
+         // check if the operational domain has the correct size (10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() == 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations == 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+     SECTION("random_sampling")
+     {
+         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+                                                                   op_domain_params, &op_domain_stats);
+
+         // check if the operational domain has the correct size (max 10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() <= 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+     SECTION("flood_fill")
+     {
+         const auto op_domain =
+             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
+             &op_domain_stats);
+
+         // check if the operational domain has the correct size (10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() == 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations == 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+     SECTION("contour_tracing")
+     {
+         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+                                                                   op_domain_params, &op_domain_stats);
+
+         // check if the operational domain has the correct size (max 10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() <= 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+ }
+
+ TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
+{
+     using layout = sidb_cell_clk_lyt_cube;
+
+     layout lyt{{20, 10}, "AND gate"};
+
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
+                          sidb_technology::cell_type::INPUT);
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
+                          sidb_technology::cell_type::INPUT);
+
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
+                          sidb_technology::cell_type::INPUT);
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
+                          sidb_technology::cell_type::INPUT);
+
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
+                          sidb_technology::cell_type::NORMAL);
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
+                          sidb_technology::cell_type::NORMAL);
+
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
+                          sidb_technology::cell_type::NORMAL);
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
+                          sidb_technology::cell_type::NORMAL);
+
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
+                          sidb_technology::cell_type::OUTPUT);
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
+                          sidb_technology::cell_type::OUTPUT);
+
+     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
+                          sidb_technology::cell_type::NORMAL);
+
+     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+
+     sidb_simulation_parameters sim_params{};
+     sim_params.base     = 2;
+     sim_params.mu_minus = -0.28;
+
+     operational_domain_params op_domain_params{};
+     op_domain_params.sim_params  = sim_params;
+     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+     op_domain_params.x_min       = 5.1;
+     op_domain_params.x_max       = 6.0;
+     op_domain_params.x_step      = 0.1;
+     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+     op_domain_params.y_min       = 4.5;
+     op_domain_params.y_max       = 5.4;
+     op_domain_params.y_step      = 0.1;
+
+     operational_domain_stats op_domain_stats{};
+
+     SECTION("grid_search")
+     {
+         const auto op_domain =
+             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
+             &op_domain_stats);
+
+         // check if the operational domain has the correct size (10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() == 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations == 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+     SECTION("random_sampling")
+     {
+         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+                                                                   op_domain_params, &op_domain_stats);
+
+         // check if the operational domain has the correct size (max 10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() <= 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+     SECTION("flood_fill")
+     {
+         const auto op_domain =
+             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
+             &op_domain_stats);
+
+         // check if the operational domain has the correct size (10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() == 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations == 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+     SECTION("contour_tracing")
+     {
+         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+                                                                   op_domain_params, &op_domain_stats);
+
+         // check if the operational domain has the correct size (max 10 steps in each dimension)
+         CHECK(op_domain.operational_values.size() <= 100);
+
+         // for the selected range, all samples should be within the parameters and operational
+         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+
+         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+     }
+ }

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -525,237 +525,241 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
     }
 }
 
-//TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
+// TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
 //{
-//    using layout = sidb_cell_clk_lyt_siqad;
+//     using layout = sidb_cell_clk_lyt_siqad;
 //
-//    layout lyt{{20, 10}, "AND gate"};
+//     layout lyt{{20, 10}, "AND gate"};
 //
-//    lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
-//    lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
 //
-//    lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
-//    lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
 //
-//    lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
-//    lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
 //
-//    lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
-//    lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
 //
-//    lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
-//    lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
+//     lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
+//     lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
 //
-//    lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
 //
-//    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+//     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
 //
-//    sidb_simulation_parameters sim_params{};
-//    sim_params.base     = 2;
-//    sim_params.mu_minus = -0.28;
+//     sidb_simulation_parameters sim_params{};
+//     sim_params.base     = 2;
+//     sim_params.mu_minus = -0.28;
 //
-//    operational_domain_params op_domain_params{};
-//    op_domain_params.sim_params  = sim_params;
-//    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-//    op_domain_params.x_min       = 5.1;
-//    op_domain_params.x_max       = 6.0;
-//    op_domain_params.x_step      = 0.1;
-//    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-//    op_domain_params.y_min       = 4.5;
-//    op_domain_params.y_max       = 5.4;
-//    op_domain_params.y_step      = 0.1;
+//     operational_domain_params op_domain_params{};
+//     op_domain_params.sim_params  = sim_params;
+//     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+//     op_domain_params.x_min       = 5.1;
+//     op_domain_params.x_max       = 6.0;
+//     op_domain_params.x_step      = 0.1;
+//     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+//     op_domain_params.y_min       = 4.5;
+//     op_domain_params.y_max       = 5.4;
+//     op_domain_params.y_step      = 0.1;
 //
-//    operational_domain_stats op_domain_stats{};
+//     operational_domain_stats op_domain_stats{};
 //
-//    SECTION("grid_search")
-//    {
-//        const auto op_domain =
-//            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
+//     SECTION("grid_search")
+//     {
+//         const auto op_domain =
+//             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
+//             &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() == 100);
+//         // check if the operational domain has the correct size (10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() == 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations == 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//    SECTION("random_sampling")
-//    {
-//        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-//                                                                  op_domain_params, &op_domain_stats);
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations == 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+//     SECTION("random_sampling")
+//     {
+//         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+//                                                                   op_domain_params, &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (max 10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() <= 100);
+//         // check if the operational domain has the correct size (max 10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() <= 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//    SECTION("flood_fill")
-//    {
-//        const auto op_domain =
-//            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+//     SECTION("flood_fill")
+//     {
+//         const auto op_domain =
+//             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
+//             &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() == 100);
+//         // check if the operational domain has the correct size (10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() == 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations == 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//    SECTION("contour_tracing")
-//    {
-//        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-//                                                                  op_domain_params, &op_domain_stats);
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations == 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+//     SECTION("contour_tracing")
+//     {
+//         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+//                                                                   op_domain_params, &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (max 10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() <= 100);
+//         // check if the operational domain has the correct size (max 10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() <= 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//}
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+// }
 //
-//TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
+// TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
 //{
-//    using layout = sidb_cell_clk_lyt_cube;
+//     using layout = sidb_cell_clk_lyt_cube;
 //
-//    layout lyt{{20, 10}, "AND gate"};
+//     layout lyt{{20, 10}, "AND gate"};
 //
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
-//                         sidb_technology::cell_type::INPUT);
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
-//                         sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
+//                          sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
+//                          sidb_technology::cell_type::INPUT);
 //
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
-//                         sidb_technology::cell_type::INPUT);
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
-//                         sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
+//                          sidb_technology::cell_type::INPUT);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
+//                          sidb_technology::cell_type::INPUT);
 //
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
-//                         sidb_technology::cell_type::NORMAL);
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
-//                         sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
+//                          sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
+//                          sidb_technology::cell_type::NORMAL);
 //
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
-//                         sidb_technology::cell_type::NORMAL);
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
-//                         sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
+//                          sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
+//                          sidb_technology::cell_type::NORMAL);
 //
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
-//                         sidb_technology::cell_type::OUTPUT);
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
-//                         sidb_technology::cell_type::OUTPUT);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
+//                          sidb_technology::cell_type::OUTPUT);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
+//                          sidb_technology::cell_type::OUTPUT);
 //
-//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
-//                         sidb_technology::cell_type::NORMAL);
+//     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
+//                          sidb_technology::cell_type::NORMAL);
 //
-//    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+//     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
 //
-//    sidb_simulation_parameters sim_params{};
-//    sim_params.base     = 2;
-//    sim_params.mu_minus = -0.28;
+//     sidb_simulation_parameters sim_params{};
+//     sim_params.base     = 2;
+//     sim_params.mu_minus = -0.28;
 //
-//    operational_domain_params op_domain_params{};
-//    op_domain_params.sim_params  = sim_params;
-//    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-//    op_domain_params.x_min       = 5.1;
-//    op_domain_params.x_max       = 6.0;
-//    op_domain_params.x_step      = 0.1;
-//    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-//    op_domain_params.y_min       = 4.5;
-//    op_domain_params.y_max       = 5.4;
-//    op_domain_params.y_step      = 0.1;
+//     operational_domain_params op_domain_params{};
+//     op_domain_params.sim_params  = sim_params;
+//     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+//     op_domain_params.x_min       = 5.1;
+//     op_domain_params.x_max       = 6.0;
+//     op_domain_params.x_step      = 0.1;
+//     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+//     op_domain_params.y_min       = 4.5;
+//     op_domain_params.y_max       = 5.4;
+//     op_domain_params.y_step      = 0.1;
 //
-//    operational_domain_stats op_domain_stats{};
+//     operational_domain_stats op_domain_stats{};
 //
-//    SECTION("grid_search")
-//    {
-//        const auto op_domain =
-//            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
+//     SECTION("grid_search")
+//     {
+//         const auto op_domain =
+//             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
+//             &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() == 100);
+//         // check if the operational domain has the correct size (10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() == 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations == 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//    SECTION("random_sampling")
-//    {
-//        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-//                                                                  op_domain_params, &op_domain_stats);
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations == 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+//     SECTION("random_sampling")
+//     {
+//         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+//                                                                   op_domain_params, &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (max 10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() <= 100);
+//         // check if the operational domain has the correct size (max 10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() <= 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//    SECTION("flood_fill")
-//    {
-//        const auto op_domain =
-//            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+//     SECTION("flood_fill")
+//     {
+//         const auto op_domain =
+//             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
+//             &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() == 100);
+//         // check if the operational domain has the correct size (10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() == 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations == 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//    SECTION("contour_tracing")
-//    {
-//        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-//                                                                  op_domain_params, &op_domain_stats);
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations == 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+//     SECTION("contour_tracing")
+//     {
+//         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+//                                                                   op_domain_params, &op_domain_stats);
 //
-//        // check if the operational domain has the correct size (max 10 steps in each dimension)
-//        CHECK(op_domain.operational_values.size() <= 100);
+//         // check if the operational domain has the correct size (max 10 steps in each dimension)
+//         CHECK(op_domain.operational_values.size() <= 100);
 //
-//        // for the selected range, all samples should be within the parameters and operational
-//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//         // for the selected range, all samples should be within the parameters and operational
+//         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 //
-//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-//    }
-//}
+//         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//         CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//     }
+// }

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -48,10 +48,18 @@ void check_op_domain_params_and_operational_status(const operational_domain&    
 
         if (status)
         {
-            std::cout << fmt::format("point: {}, {}, status: {}\n", coord.x, coord.y, *status);
+            if (*status == operational_status::OPERATIONAL)
+            {
+                std::cout << fmt::format("point: {}, {}, status: {}\n", coord.x, coord.y, "operational");
+            }
+            else
+            {
+                std::cout << fmt::format("point: {}, {}, status: {}\n", coord.x, coord.y, *status);
+            }
             CHECK(op_value == *status);
         }
     }
+    std::cout << "___________________________________________________\n";
 }
 
 TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
@@ -517,237 +525,237 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
     }
 }
 
-TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
-{
-    using layout = sidb_cell_clk_lyt_siqad;
-
-    layout lyt{{20, 10}, "AND gate"};
-
-    lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
-    lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
-
-    lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
-    lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
-
-    lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
-    lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
-
-    lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
-    lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
-
-    lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
-    lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
-
-    lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
-
-    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
-
-    sidb_simulation_parameters sim_params{};
-    sim_params.base     = 2;
-    sim_params.mu_minus = -0.28;
-
-    operational_domain_params op_domain_params{};
-    op_domain_params.sim_params  = sim_params;
-    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-    op_domain_params.x_min       = 5.1;
-    op_domain_params.x_max       = 6.0;
-    op_domain_params.x_step      = 0.1;
-    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-    op_domain_params.y_min       = 4.5;
-    op_domain_params.y_max       = 5.4;
-    op_domain_params.y_step      = 0.1;
-
-    operational_domain_stats op_domain_stats{};
-
-    SECTION("grid_search")
-    {
-        const auto op_domain =
-            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() == 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations == 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-    SECTION("random_sampling")
-    {
-        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-                                                                  op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (max 10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() <= 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-    SECTION("flood_fill")
-    {
-        const auto op_domain =
-            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() == 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations == 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-    SECTION("contour_tracing")
-    {
-        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-                                                                  op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (max 10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() <= 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-}
-
-TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
-{
-    using layout = sidb_cell_clk_lyt_cube;
-
-    layout lyt{{20, 10}, "AND gate"};
-
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
-                         sidb_technology::cell_type::INPUT);
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
-                         sidb_technology::cell_type::INPUT);
-
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
-                         sidb_technology::cell_type::INPUT);
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
-                         sidb_technology::cell_type::INPUT);
-
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
-                         sidb_technology::cell_type::NORMAL);
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
-                         sidb_technology::cell_type::NORMAL);
-
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
-                         sidb_technology::cell_type::NORMAL);
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
-                         sidb_technology::cell_type::NORMAL);
-
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
-                         sidb_technology::cell_type::OUTPUT);
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
-                         sidb_technology::cell_type::OUTPUT);
-
-    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
-                         sidb_technology::cell_type::NORMAL);
-
-    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
-
-    sidb_simulation_parameters sim_params{};
-    sim_params.base     = 2;
-    sim_params.mu_minus = -0.28;
-
-    operational_domain_params op_domain_params{};
-    op_domain_params.sim_params  = sim_params;
-    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-    op_domain_params.x_min       = 5.1;
-    op_domain_params.x_max       = 6.0;
-    op_domain_params.x_step      = 0.1;
-    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-    op_domain_params.y_min       = 4.5;
-    op_domain_params.y_max       = 5.4;
-    op_domain_params.y_step      = 0.1;
-
-    operational_domain_stats op_domain_stats{};
-
-    SECTION("grid_search")
-    {
-        const auto op_domain =
-            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() == 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations == 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-    SECTION("random_sampling")
-    {
-        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-                                                                  op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (max 10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() <= 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-    SECTION("flood_fill")
-    {
-        const auto op_domain =
-            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() == 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations == 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-    SECTION("contour_tracing")
-    {
-        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-                                                                  op_domain_params, &op_domain_stats);
-
-        // check if the operational domain has the correct size (max 10 steps in each dimension)
-        CHECK(op_domain.operational_values.size() <= 100);
-
-        // for the selected range, all samples should be within the parameters and operational
-        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
-
-        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-        CHECK(op_domain_stats.num_simulator_invocations <= 400);
-        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-    }
-}
+//TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
+//{
+//    using layout = sidb_cell_clk_lyt_siqad;
+//
+//    layout lyt{{20, 10}, "AND gate"};
+//
+//    lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
+//    lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
+//
+//    lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
+//    lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
+//
+//    lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
+//    lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
+//
+//    lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
+//    lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
+//
+//    lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
+//    lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
+//
+//    lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
+//
+//    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+//
+//    sidb_simulation_parameters sim_params{};
+//    sim_params.base     = 2;
+//    sim_params.mu_minus = -0.28;
+//
+//    operational_domain_params op_domain_params{};
+//    op_domain_params.sim_params  = sim_params;
+//    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+//    op_domain_params.x_min       = 5.1;
+//    op_domain_params.x_max       = 6.0;
+//    op_domain_params.x_step      = 0.1;
+//    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+//    op_domain_params.y_min       = 4.5;
+//    op_domain_params.y_max       = 5.4;
+//    op_domain_params.y_step      = 0.1;
+//
+//    operational_domain_stats op_domain_stats{};
+//
+//    SECTION("grid_search")
+//    {
+//        const auto op_domain =
+//            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() == 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations == 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//    SECTION("random_sampling")
+//    {
+//        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+//                                                                  op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (max 10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() <= 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//    SECTION("flood_fill")
+//    {
+//        const auto op_domain =
+//            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() == 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations == 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//    SECTION("contour_tracing")
+//    {
+//        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+//                                                                  op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (max 10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() <= 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//}
+//
+//TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
+//{
+//    using layout = sidb_cell_clk_lyt_cube;
+//
+//    layout lyt{{20, 10}, "AND gate"};
+//
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
+//                         sidb_technology::cell_type::INPUT);
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
+//                         sidb_technology::cell_type::INPUT);
+//
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
+//                         sidb_technology::cell_type::INPUT);
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
+//                         sidb_technology::cell_type::INPUT);
+//
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
+//                         sidb_technology::cell_type::NORMAL);
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
+//                         sidb_technology::cell_type::NORMAL);
+//
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
+//                         sidb_technology::cell_type::NORMAL);
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
+//                         sidb_technology::cell_type::NORMAL);
+//
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
+//                         sidb_technology::cell_type::OUTPUT);
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
+//                         sidb_technology::cell_type::OUTPUT);
+//
+//    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
+//                         sidb_technology::cell_type::NORMAL);
+//
+//    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+//
+//    sidb_simulation_parameters sim_params{};
+//    sim_params.base     = 2;
+//    sim_params.mu_minus = -0.28;
+//
+//    operational_domain_params op_domain_params{};
+//    op_domain_params.sim_params  = sim_params;
+//    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+//    op_domain_params.x_min       = 5.1;
+//    op_domain_params.x_max       = 6.0;
+//    op_domain_params.x_step      = 0.1;
+//    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+//    op_domain_params.y_min       = 4.5;
+//    op_domain_params.y_max       = 5.4;
+//    op_domain_params.y_step      = 0.1;
+//
+//    operational_domain_stats op_domain_stats{};
+//
+//    SECTION("grid_search")
+//    {
+//        const auto op_domain =
+//            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() == 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations == 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//    SECTION("random_sampling")
+//    {
+//        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+//                                                                  op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (max 10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() <= 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//    SECTION("flood_fill")
+//    {
+//        const auto op_domain =
+//            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() == 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations == 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//    SECTION("contour_tracing")
+//    {
+//        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+//                                                                  op_domain_params, &op_domain_stats);
+//
+//        // check if the operational domain has the correct size (max 10 steps in each dimension)
+//        CHECK(op_domain.operational_values.size() <= 100);
+//
+//        // for the selected range, all samples should be within the parameters and operational
+//        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+//
+//        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+//        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+//        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+//        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+//    }
+//}

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -48,18 +48,9 @@ void check_op_domain_params_and_operational_status(const operational_domain&    
 
         if (status)
         {
-            if (*status == operational_status::OPERATIONAL)
-            {
-                std::cout << fmt::format("point: {}, {}, status: {}\n", coord.x, coord.y, "operational");
-            }
-            else
-            {
-                std::cout << fmt::format("point: {}, {}, status: {}\n", coord.x, coord.y, *status);
-            }
             CHECK(op_value == *status);
         }
     }
-    std::cout << "___________________________________________________\n";
 }
 
 TEST_CASE("BDL wire operational domain computation", "[operational-domain]")

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -99,88 +99,72 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
         SECTION("grid_search")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
-                                                                      op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
+                                                                  op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() == 1);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() == 1);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations == 2);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
-                CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations == 2);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
+            CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
         SECTION("random_sampling")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
-                                                                          op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
+                                                                      op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() == 1);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() == 1);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations <= 200);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
-                CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations <= 200);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
+            CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
         SECTION("flood_fill")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                     op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                 op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() == 1);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() == 1);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations == 2);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
-                CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations == 2);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
+            CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
         SECTION("contour_tracing")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                          op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                      op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() == 1);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() == 1);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations == 2);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
-                CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations == 2);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 1);
+            CHECK(op_domain_stats.num_operational_parameter_combinations == 1);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
     }
 
@@ -196,88 +180,72 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
         SECTION("grid_search")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
-                                                                      op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
+                                                                  op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() == 100);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() == 100);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations == 200);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-                CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations == 200);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+            CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
         SECTION("random_sampling")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
-                                                                          op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
+                                                                      op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() <= 100);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() <= 100);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations <= 200);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
-                CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations <= 200);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations > 0);
+            CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
         SECTION("flood_fill")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                     op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                 op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() == 100);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() == 100);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations == 200);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-                CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations == 200);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+            CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
         SECTION("contour_tracing")
         {
-            for (auto i = 0u; i< 10;i++)
-            {
-                const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
-                                                                          op_domain_params, &op_domain_stats);
+            const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
+                                                                      op_domain_params, &op_domain_stats);
 
-                // check if the operational domain has the correct size
-                CHECK(op_domain.operational_values.size() <= 100);
+            // check if the operational domain has the correct size
+            CHECK(op_domain.operational_values.size() <= 100);
 
-                // for the selected range, all samples should be within the parameters and operational
-                check_op_domain_params_and_operational_status(op_domain, op_domain_params,
-                                                              operational_status::OPERATIONAL);
+            // for the selected range, all samples should be within the parameters and operational
+            check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-                CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-                CHECK(op_domain_stats.num_simulator_invocations <= 200);
-                CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-                CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-                CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-            }
+            CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+            CHECK(op_domain_stats.num_simulator_invocations <= 200);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
         }
     }
 

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -525,241 +525,237 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
     }
 }
 
- TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
+TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
 {
-     using layout = sidb_cell_clk_lyt_siqad;
+    using layout = sidb_cell_clk_lyt_siqad;
 
-     layout lyt{{20, 10}, "AND gate"};
+    layout lyt{{20, 10}, "AND gate"};
 
-     lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
-     lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type({0, 0, 1}, sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type({2, 1, 1}, sidb_technology::cell_type::INPUT);
 
-     lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
-     lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type({20, 0, 1}, sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type({18, 1, 1}, sidb_technology::cell_type::INPUT);
 
-     lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
-     lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({4, 2, 1}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({6, 3, 1}, sidb_technology::cell_type::NORMAL);
 
-     lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
-     lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({14, 3, 1}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({16, 2, 1}, sidb_technology::cell_type::NORMAL);
 
-     lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
-     lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
+    lyt.assign_cell_type({10, 6, 0}, sidb_technology::cell_type::OUTPUT);
+    lyt.assign_cell_type({10, 7, 0}, sidb_technology::cell_type::OUTPUT);
 
-     lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
 
-     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
 
-     sidb_simulation_parameters sim_params{};
-     sim_params.base     = 2;
-     sim_params.mu_minus = -0.28;
+    sidb_simulation_parameters sim_params{};
+    sim_params.base     = 2;
+    sim_params.mu_minus = -0.28;
 
-     operational_domain_params op_domain_params{};
-     op_domain_params.sim_params  = sim_params;
-     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-     op_domain_params.x_min       = 5.1;
-     op_domain_params.x_max       = 6.0;
-     op_domain_params.x_step      = 0.1;
-     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-     op_domain_params.y_min       = 4.5;
-     op_domain_params.y_max       = 5.4;
-     op_domain_params.y_step      = 0.1;
+    operational_domain_params op_domain_params{};
+    op_domain_params.sim_params  = sim_params;
+    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+    op_domain_params.x_min       = 5.1;
+    op_domain_params.x_max       = 6.0;
+    op_domain_params.x_step      = 0.1;
+    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+    op_domain_params.y_min       = 4.5;
+    op_domain_params.y_max       = 5.4;
+    op_domain_params.y_step      = 0.1;
 
-     operational_domain_stats op_domain_stats{};
+    operational_domain_stats op_domain_stats{};
 
-     SECTION("grid_search")
-     {
-         const auto op_domain =
-             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
-             &op_domain_stats);
+    SECTION("grid_search")
+    {
+        const auto op_domain =
+            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() == 100);
+        // check if the operational domain has the correct size (10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() == 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations == 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
-     SECTION("random_sampling")
-     {
-         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-                                                                   op_domain_params, &op_domain_stats);
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations == 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+    SECTION("random_sampling")
+    {
+        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+                                                                  op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (max 10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() <= 100);
+        // check if the operational domain has the correct size (max 10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() <= 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
-     SECTION("flood_fill")
-     {
-         const auto op_domain =
-             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
-             &op_domain_stats);
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+    SECTION("flood_fill")
+    {
+        const auto op_domain =
+            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() == 100);
+        // check if the operational domain has the correct size (10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() == 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations == 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
-     SECTION("contour_tracing")
-     {
-         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-                                                                   op_domain_params, &op_domain_stats);
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations == 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+    SECTION("contour_tracing")
+    {
+        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+                                                                  op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (max 10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() <= 100);
+        // check if the operational domain has the correct size (max 10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() <= 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
- }
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+}
 
- TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
+TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinates", "[operational-domain]")
 {
-     using layout = sidb_cell_clk_lyt_cube;
+    using layout = sidb_cell_clk_lyt_cube;
 
-     layout lyt{{20, 10}, "AND gate"};
+    layout lyt{{20, 10}, "AND gate"};
 
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
-                          sidb_technology::cell_type::INPUT);
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
-                          sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{0, 0, 1}),
+                         sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 1}),
+                         sidb_technology::cell_type::INPUT);
 
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
-                          sidb_technology::cell_type::INPUT);
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
-                          sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{20, 0, 1}),
+                         sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{18, 1, 1}),
+                         sidb_technology::cell_type::INPUT);
 
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
-                          sidb_technology::cell_type::NORMAL);
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
-                          sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{4, 2, 1}),
+                         sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{6, 3, 1}),
+                         sidb_technology::cell_type::NORMAL);
 
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
-                          sidb_technology::cell_type::NORMAL);
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
-                          sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{14, 3, 1}),
+                         sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{16, 2, 1}),
+                         sidb_technology::cell_type::NORMAL);
 
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
-                          sidb_technology::cell_type::OUTPUT);
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
-                          sidb_technology::cell_type::OUTPUT);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 6, 0}),
+                         sidb_technology::cell_type::OUTPUT);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 7, 0}),
+                         sidb_technology::cell_type::OUTPUT);
 
-     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
-                          sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
+                         sidb_technology::cell_type::NORMAL);
 
-     const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
 
-     sidb_simulation_parameters sim_params{};
-     sim_params.base     = 2;
-     sim_params.mu_minus = -0.28;
+    sidb_simulation_parameters sim_params{};
+    sim_params.base     = 2;
+    sim_params.mu_minus = -0.28;
 
-     operational_domain_params op_domain_params{};
-     op_domain_params.sim_params  = sim_params;
-     op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
-     op_domain_params.x_min       = 5.1;
-     op_domain_params.x_max       = 6.0;
-     op_domain_params.x_step      = 0.1;
-     op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
-     op_domain_params.y_min       = 4.5;
-     op_domain_params.y_max       = 5.4;
-     op_domain_params.y_step      = 0.1;
+    operational_domain_params op_domain_params{};
+    op_domain_params.sim_params  = sim_params;
+    op_domain_params.x_dimension = operational_domain::sweep_parameter::EPSILON_R;
+    op_domain_params.x_min       = 5.1;
+    op_domain_params.x_max       = 6.0;
+    op_domain_params.x_step      = 0.1;
+    op_domain_params.y_dimension = operational_domain::sweep_parameter::LAMBDA_TF;
+    op_domain_params.y_min       = 4.5;
+    op_domain_params.y_max       = 5.4;
+    op_domain_params.y_step      = 0.1;
 
-     operational_domain_stats op_domain_stats{};
+    operational_domain_stats op_domain_stats{};
 
-     SECTION("grid_search")
-     {
-         const auto op_domain =
-             operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params,
-             &op_domain_stats);
+    SECTION("grid_search")
+    {
+        const auto op_domain =
+            operational_domain_grid_search(lat, std::vector<tt>{create_and_tt()}, op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() == 100);
+        // check if the operational domain has the correct size (10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() == 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations == 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
-     SECTION("random_sampling")
-     {
-         const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
-                                                                   op_domain_params, &op_domain_stats);
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations == 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+    SECTION("random_sampling")
+    {
+        const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_and_tt()}, 100,
+                                                                  op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (max 10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() <= 100);
+        // check if the operational domain has the correct size (max 10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() <= 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
-     SECTION("flood_fill")
-     {
-         const auto op_domain =
-             operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params,
-             &op_domain_stats);
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+    SECTION("flood_fill")
+    {
+        const auto op_domain =
+            operational_domain_flood_fill(lat, std::vector<tt>{create_and_tt()}, 1, op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() == 100);
+        // check if the operational domain has the correct size (10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() == 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations == 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
-     SECTION("contour_tracing")
-     {
-         const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
-                                                                   op_domain_params, &op_domain_stats);
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations == 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations == 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+    SECTION("contour_tracing")
+    {
+        const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_and_tt()}, 1,
+                                                                  op_domain_params, &op_domain_stats);
 
-         // check if the operational domain has the correct size (max 10 steps in each dimension)
-         CHECK(op_domain.operational_values.size() <= 100);
+        // check if the operational domain has the correct size (max 10 steps in each dimension)
+        CHECK(op_domain.operational_values.size() <= 100);
 
-         // for the selected range, all samples should be within the parameters and operational
-         check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
+        // for the selected range, all samples should be within the parameters and operational
+        check_op_domain_params_and_operational_status(op_domain, op_domain_params, operational_status::OPERATIONAL);
 
-         CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-         CHECK(op_domain_stats.num_simulator_invocations <= 400);
-         CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
-         CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
-     }
- }
+        CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
+        CHECK(op_domain_stats.num_simulator_invocations <= 400);
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_operational_parameter_combinations <= 100);
+        CHECK(op_domain_stats.num_non_operational_parameter_combinations == 0);
+    }
+}

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -40,10 +40,10 @@ void check_op_domain_params_and_operational_status(const operational_domain&    
 
     for (const auto& [coord, op_value] : op_domain.operational_values)
     {
-        CHECK(std::abs(coord.x - params.x_min) > -physical_constants::POP_STABILITY_ERR);
-        CHECK(std::abs(params.x_max - coord.x) > -physical_constants::POP_STABILITY_ERR);
-        CHECK(std::abs(coord.y - params.y_min) > -physical_constants::POP_STABILITY_ERR);
-        CHECK(std::abs(params.y_max - coord.y) > -physical_constants::POP_STABILITY_ERR);
+        CHECK(coord.x - params.x_min > -physical_constants::POP_STABILITY_ERR);
+        CHECK(params.x_max - coord.x > -physical_constants::POP_STABILITY_ERR);
+        CHECK(coord.y - params.y_min > -physical_constants::POP_STABILITY_ERR);
+        CHECK(params.y_max - coord.y > -physical_constants::POP_STABILITY_ERR);
 
         if (status)
         {
@@ -100,7 +100,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
                                                                   op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() == 1);
 
             // for the selected range, all samples should be within the parameters and operational
@@ -117,7 +117,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
                                                                       op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (max 10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() == 1);
 
             // for the selected range, all samples should be within the parameters and operational
@@ -135,7 +135,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
                                                                  op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (max 10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() == 1);
 
             // for the selected range, all samples should be within the parameters and operational
@@ -152,7 +152,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
                                                                       op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (max 10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() == 1);
 
             // for the selected range, all samples should be within the parameters and operational
@@ -181,7 +181,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_grid_search(lat, std::vector<tt>{create_id_tt()},
                                                                   op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() == 100);
 
             // for the selected range, all samples should be within the parameters and operational
@@ -198,7 +198,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_random_sampling(lat, std::vector<tt>{create_id_tt()}, 100,
                                                                       op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (max 10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() <= 100);
 
             // for the selected range, all samples should be within the parameters and operational
@@ -216,7 +216,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_flood_fill(lat, std::vector<tt>{create_id_tt()}, 1,
                                                                  op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (max 10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() == 100);
 
             // for the selected range, all samples should be within the parameters and operational
@@ -233,7 +233,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
             const auto op_domain = operational_domain_contour_tracing(lat, std::vector<tt>{create_id_tt()}, 1,
                                                                       op_domain_params, &op_domain_stats);
 
-            // check if the operational domain has the correct size (max 10 steps in each dimension)
+            // check if the operational domain has the correct size
             CHECK(op_domain.operational_values.size() <= 100);
 
             // for the selected range, all samples should be within the parameters and operational


### PR DESCRIPTION
## Description

This PR fixes a non-deterministic failure of the operational domain unit tests on Ubuntu and Windows. This is fixed by checking that ``moore_neighborhood`` is not empty before selecting the front step point. It also ensures that ``x_min`` and ``y_min`` are part of the parameter space that is checked for operation.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
