### PR TITLE
:bug: Fixed conversion of cube coordinate with negative y-value to SiQAD coordinate

### DIFF
--- a/include/fiction/layouts/coordinates.hpp
+++ b/include/fiction/layouts/coordinates.hpp
@@ -800,7 +800,11 @@ constexpr CoordinateType to_fiction_coord(const siqad::coord_t& coord) noexcept
 template <typename CoordinateType>
 constexpr coord_t to_siqad_coord(const CoordinateType& coord) noexcept
 {
-    return {coord.x, (coord.y - coord.y % 2) / 2, coord.y % 2};
+    if (coord.y >= 0)
+    {
+        return {coord.x, (coord.y - coord.y % 2) / 2, coord.y % 2};
+    }
+    return {coord.x, (coord.y + coord.y % 2) / 2, (-coord.y - 1) % 2 + 1};
 }
 
 }  // namespace siqad

--- a/test/layouts/coordinates.cpp
+++ b/test/layouts/coordinates.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Unsigned offset coordinates", "[coordinates]")
     CHECK(os.str() == "(3,2,1)");
 }
 
-TEST_CASE("SiQAD coordinate conversion", "[coordinates]")
+TEST_CASE("Convert cube to SiQAD coordinates", "[coordinates]")
 {
     using coordinate         = siqad::coord_t;
     using coordinate_fiction = cube::coord_t;
@@ -116,17 +116,41 @@ TEST_CASE("SiQAD coordinate conversion", "[coordinates]")
     CHECK(t3_siqad.x == t3_fiction.x);
     CHECK(t3_siqad.y == 1);
     CHECK(t3_siqad.z == 0);
+    CHECK(t3_fiction == siqad::to_fiction_coord<coordinate_fiction>(t3_siqad));
 
     auto t4_fiction = coordinate_fiction{-1, -2};
     auto t4_siqad   = siqad::to_siqad_coord<coordinate_fiction>(t4_fiction);
     CHECK(t4_siqad.x == t4_fiction.x);
     CHECK(t4_siqad.y == -1);
     CHECK(t4_siqad.z == 0);
+    CHECK(t4_fiction == siqad::to_fiction_coord<coordinate_fiction>(t4_siqad));
 
     auto t5_siqad   = coordinate{-1, -2, 1};
     auto t5_fiction = siqad::to_fiction_coord<coordinate_fiction>(t5_siqad);
     CHECK(t5_fiction.x == -1);
     CHECK(t5_fiction.y == -3);
+    CHECK(t5_fiction == siqad::to_fiction_coord<coordinate_fiction>(t5_siqad));
+
+    auto t6_fiction = coordinate_fiction{-1, -1};
+    auto t6_siqad   = siqad::to_siqad_coord<coordinate_fiction>(t6_fiction);
+    CHECK(t6_siqad.x == t6_fiction.x);
+    CHECK(t6_siqad.y == -1);
+    CHECK(t6_siqad.z == 1);
+    CHECK(t6_fiction == siqad::to_fiction_coord<coordinate_fiction>(t6_siqad));
+
+    auto t7_fiction = coordinate_fiction{-1, -3};
+    auto t7_siqad   = siqad::to_siqad_coord<coordinate_fiction>(t7_fiction);
+    CHECK(t7_siqad.x == t7_fiction.x);
+    CHECK(t7_siqad.y == -2);
+    CHECK(t7_siqad.z == 1);
+    CHECK(t7_fiction == siqad::to_fiction_coord<coordinate_fiction>(t7_siqad));
+
+    auto t8_fiction = coordinate_fiction{-1, -4};
+    auto t8_siqad   = siqad::to_siqad_coord<coordinate_fiction>(t8_fiction);
+    CHECK(t8_siqad.x == t8_fiction.x);
+    CHECK(t8_siqad.y == -2);
+    CHECK(t8_siqad.z == 0);
+    CHECK(t8_fiction == siqad::to_fiction_coord<coordinate_fiction>(t8_siqad));
 }
 
 TEMPLATE_TEST_CASE("Coordinate iteration", "[coordinates]", offset::ucoord_t, cube::coord_t, siqad::coord_t)

--- a/test/layouts/coordinates.cpp
+++ b/test/layouts/coordinates.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Unsigned offset coordinates", "[coordinates]")
     CHECK(os.str() == "(3,2,1)");
 }
 
-TEST_CASE("Convert cube to SiQAD coordinates", "[coordinates]")
+TEST_CASE("SiQAD coordinate conversion", "[coordinates]")
 {
     using coordinate         = siqad::coord_t;
     using coordinate_fiction = cube::coord_t;

--- a/test/technology/sidb_nm_position.cpp
+++ b/test/technology/sidb_nm_position.cpp
@@ -5,7 +5,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include <fiction/technology/sidb_lattice.hpp>
 #include <fiction/technology/sidb_lattice_orientations.hpp>
 #include <fiction/technology/sidb_nm_position.hpp>
 #include <fiction/types.hpp>
@@ -20,27 +19,27 @@ TEST_CASE("SiDB position in nanometer for siqad coordinates", "[sidb-nm-position
 
     SECTION("Cell-level layout without lattice layout")
     {
-        const auto [pos_x, pos_y] = sidb_nm_position<sidb_cell_clk_lyt_siqad>({1, 0, 0});
+        const auto [pos_x, pos_y] = sidb_nm_position<lattice>({1, 0, 0});
         CHECK_THAT(pos_x, WithinAbs(sidb_100_lattice::LAT_A * 0.1, 1E-5));
         CHECK_THAT(pos_x, WithinAbs(sidb_100_lattice::LAT_A * 0.1, 1E-5));
 
-        const auto [pos2_x, pos2_y] = sidb_nm_position<sidb_cell_clk_lyt_siqad>({0, 1, 0});
+        const auto [pos2_x, pos2_y] = sidb_nm_position<lattice>({0, 1, 0});
         CHECK_THAT(pos2_x, WithinAbs(0.0, 1E-5));
         CHECK_THAT(pos2_y, WithinAbs(sidb_100_lattice::LAT_B * 0.1, 1E-5));
 
-        const auto [pos3_x, pos3_y] = sidb_nm_position<sidb_cell_clk_lyt_siqad>({0, 8, 1});
+        const auto [pos3_x, pos3_y] = sidb_nm_position<lattice>({0, 8, 1});
         CHECK_THAT(pos3_x, WithinAbs(0.0, 1E-5));
         CHECK_THAT(pos3_y, WithinAbs(sidb_100_lattice::LAT_B * 0.8 + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
 
-        const auto [pos4_x, pos4_y] = sidb_nm_position<sidb_cell_clk_lyt_siqad>({1, 1});
+        const auto [pos4_x, pos4_y] = sidb_nm_position<lattice>({1, 1});
         CHECK_THAT(pos4_x, WithinAbs(sidb_100_lattice::LAT_A * 0.1, 1E-5));
         CHECK_THAT(pos4_y, WithinAbs(sidb_100_lattice::LAT_B * 0.1, 1E-5));
 
-        const auto [pos5_x, pos5_y] = sidb_nm_position<sidb_cell_clk_lyt_siqad>({1, 1, 1});
+        const auto [pos5_x, pos5_y] = sidb_nm_position<lattice>({1, 1, 1});
         CHECK_THAT(pos5_x, WithinAbs(sidb_100_lattice::LAT_A * 0.1, 1E-5));
         CHECK_THAT(pos5_y, WithinAbs(sidb_100_lattice::LAT_B * 0.1 + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
 
-        const auto [pos6_x, pos6_y] = sidb_nm_position<sidb_cell_clk_lyt_siqad>({1, 10, 1});
+        const auto [pos6_x, pos6_y] = sidb_nm_position<lattice>({1, 10, 1});
         CHECK_THAT(pos6_x, WithinAbs(sidb_100_lattice::LAT_A * 0.1, 1E-5));
         CHECK_THAT(pos6_y, WithinAbs(sidb_100_lattice::LAT_B + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
     }
@@ -174,10 +173,18 @@ TEST_CASE("SiDB position in nanometer for fiction coordinates", "[sidb-nm-positi
 
         const auto [pos4_x, pos4_y] = sidb_nm_position<lattice>({-1, -3});
         CHECK_THAT(pos4_x, WithinAbs(-sidb_100_lattice::LAT_A * 0.1, 1E-5));
-        CHECK_THAT(pos4_y, WithinAbs(-sidb_100_lattice::LAT_B * 0.1 + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
+        CHECK_THAT(pos4_y, WithinAbs(-2 * sidb_100_lattice::LAT_B * 0.1 + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
 
         const auto [pos5_x, pos5_y] = sidb_nm_position<lattice>({-1, -21});
         CHECK_THAT(pos5_x, WithinAbs(-sidb_100_lattice::LAT_A * 0.1, 1E-5));
-        CHECK_THAT(pos5_y, WithinAbs(-sidb_100_lattice::LAT_B + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
+        CHECK_THAT(pos5_y, WithinAbs(-11 * sidb_100_lattice::LAT_B * 0.1 + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
+
+        const auto [pos6_x, pos6_y] = sidb_nm_position<lattice>({-1, -2});
+        CHECK_THAT(pos6_x, WithinAbs(-sidb_100_lattice::LAT_A * 0.1, 1E-5));
+        CHECK_THAT(pos6_y, WithinAbs(-sidb_100_lattice::LAT_B * 0.1, 1E-5));
+
+        const auto [pos7_x, pos7_y] = sidb_nm_position<lattice>({-2, -4});
+        CHECK_THAT(pos7_x, WithinAbs(-2 * sidb_100_lattice::LAT_A * 0.1, 1E-5));
+        CHECK_THAT(pos7_y, WithinAbs(-2 * sidb_100_lattice::LAT_B * 0.1, 1E-5));
     }
 }

--- a/test/technology/sidb_nm_position.cpp
+++ b/test/technology/sidb_nm_position.cpp
@@ -186,5 +186,9 @@ TEST_CASE("SiDB position in nanometer for fiction coordinates", "[sidb-nm-positi
         const auto [pos7_x, pos7_y] = sidb_nm_position<lattice>({-2, -4});
         CHECK_THAT(pos7_x, WithinAbs(-2 * sidb_100_lattice::LAT_A * 0.1, 1E-5));
         CHECK_THAT(pos7_y, WithinAbs(-2 * sidb_100_lattice::LAT_B * 0.1, 1E-5));
+
+        const auto [pos8_x, pos8_y] = sidb_nm_position<lattice>({-2, -1});
+        CHECK_THAT(pos8_x, WithinAbs(-2 * sidb_100_lattice::LAT_A * 0.1, 1E-5));
+        CHECK_THAT(pos8_y, WithinAbs(-sidb_100_lattice::LAT_B * 0.1 + sidb_100_lattice::LAT_C.second * 0.1, 1E-5));
     }
 }


### PR DESCRIPTION
## Description

This pull request solves a problem in the ``to_siqad_coord`` function. When converting cube coordinates with negative y-values, it was giving incorrect results for siqad coordinates. This fix makes sure that the conversion works correctly, even with negative y-values.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
