### PR TITLE
🐛  Fix wrong values in unit test for OpDomain and introduce uniqueness set for sample points.

### DIFF
--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -5,18 +5,12 @@
 #ifndef FICTION_OPERATIONAL_DOMAIN_HPP
 #define FICTION_OPERATIONAL_DOMAIN_HPP
 
-#include "fiction/algorithms/iter/bdl_input_iterator.hpp"
-#include "fiction/algorithms/simulation/sidb/can_positive_charges_occur.hpp"
 #include "fiction/algorithms/simulation/sidb/detect_bdl_pairs.hpp"
-#include "fiction/algorithms/simulation/sidb/energy_distribution.hpp"
-#include "fiction/algorithms/simulation/sidb/exhaustive_ground_state_simulation.hpp"
 #include "fiction/algorithms/simulation/sidb/is_operational.hpp"
-#include "fiction/algorithms/simulation/sidb/quickexact.hpp"
-#include "fiction/algorithms/simulation/sidb/quicksim.hpp"
 #include "fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp"
 #include "fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp"
-#include "fiction/layouts/cell_level_layout.hpp"
 #include "fiction/technology/cell_technologies.hpp"
+#include "fiction/technology/physical_constants.hpp"
 #include "fiction/traits.hpp"
 #include "fiction/utils/execution_utils.hpp"
 #include "fiction/utils/hash.hpp"
@@ -37,6 +31,7 @@
 #include <optional>
 #include <queue>
 #include <random>
+#include <set>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -292,13 +287,13 @@ class operational_domain_impl
         // generate the x dimension values
         for (std::size_t i = 0; i <= x_indices.size(); ++i)
         {
-            x_values.push_back(params.x_min + i * params.x_step);
+            x_values.push_back(params.x_min + static_cast<double>(i) * params.x_step);
         }
 
         // generate the y dimension values
         for (std::size_t i = 0; i <= y_indices.size(); ++i)
         {
-            y_values.push_back(params.y_min + i * params.y_step);
+            y_values.push_back(params.y_min + static_cast<double>(i) * params.y_step);
         }
     }
     /**
@@ -594,6 +589,20 @@ class operational_domain_impl
         {
             return !(*this == other);
         }
+        /**
+         * Less than operator.
+         *
+         * @param other Other step point to compare with.
+         * @return `true` if this step point is less than to the other.
+         */
+        [[nodiscard]] bool operator<(const step_point& other) const noexcept
+        {
+            if (y != other.y)
+            {
+                return y < other.y;
+            }
+            return x < other.x;
+        }
     };
     /**
      * Converts a step point to a parameter point.
@@ -794,7 +803,7 @@ class operational_domain_impl
      * @param samples Number of random `step_point`s to generate.
      * @return A vector of random `step_point`s in the stored parameter range.
      */
-    [[nodiscard]] std::vector<step_point> generate_random_step_points(const std::size_t samples) noexcept
+    [[nodiscard]] std::set<step_point> generate_random_step_points(const std::size_t samples) noexcept
     {
         static std::mt19937_64 generator{std::random_device{}()};
 
@@ -803,13 +812,12 @@ class operational_domain_impl
         std::uniform_int_distribution<std::size_t> y_distribution{0, y_indices.size() - 1};
 
         // container for the random samples
-        std::vector<step_point> step_point_samples{};
-        step_point_samples.reserve(samples);
+        std::set<step_point> step_point_samples{};
 
         for (std::size_t i = 0; i < samples; ++i)
         {
             // sample x and y dimension
-            step_point_samples.emplace_back(x_distribution(generator), y_distribution(generator));
+            step_point_samples.insert(step_point{x_distribution(generator), y_distribution(generator)});
         }
 
         return step_point_samples;

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -801,7 +801,7 @@ class operational_domain_impl
      * points is exactly equal to `samples`.
      *
      * @param samples Number of random `step_point`s to generate.
-     * @return A vector of random `step_point`s in the stored parameter range.
+     * @return A set of random `step_point`s in the stored parameter range.
      */
     [[nodiscard]] std::set<step_point> generate_random_step_points(const std::size_t samples) noexcept
     {

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -9,8 +9,6 @@
 #include <fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp>
 #include <fiction/technology/cell_technologies.hpp>
 #include <fiction/technology/physical_constants.hpp>
-#include <fiction/technology/sidb_lattice.hpp>
-#include <fiction/technology/sidb_lattice_orientations.hpp>
 #include <fiction/types.hpp>
 #include <fiction/utils/truth_table_utils.hpp>
 
@@ -74,7 +72,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
     // output perturber
     lyt.assign_cell_type({24, 0, 0}, sidb_technology::cell_type::NORMAL);
 
-    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+    const sidb_100_cell_clk_lyt_siqad lat{lyt};
 
     sidb_simulation_parameters sim_params{};
     sim_params.base = 2;
@@ -371,7 +369,7 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
                                                           operational_status::NON_OPERATIONAL);
 
             CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations <= 10000);
+            CHECK(op_domain_stats.num_simulator_invocations < 10000);
             CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 5000);
             CHECK(op_domain_stats.num_operational_parameter_combinations == 0);
             CHECK(op_domain_stats.num_non_operational_parameter_combinations <= 5000);
@@ -485,16 +483,16 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
                                                                  op_domain_params, &op_domain_stats);
 
             // check if the operational domain has the correct size
-            CHECK(op_domain.operational_values.size() >= 80);
+            CHECK(op_domain.operational_values.size() <= 256);
 
             // for the selected range, all samples should be within the parameters
             check_op_domain_params_and_operational_status(op_domain, op_domain_params, std::nullopt);
 
             CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
             CHECK(op_domain_stats.num_simulator_invocations <= 512);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 512);
-            CHECK(op_domain_stats.num_operational_parameter_combinations == 80);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 256);
+            CHECK(op_domain_stats.num_operational_parameter_combinations <= 80);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations <= 176);
         }
         SECTION("contour_tracing")
         {
@@ -502,16 +500,16 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
                                                                       op_domain_params, &op_domain_stats);
 
             // check if the operational domain has the correct size (max 10 steps in each dimension)
-            CHECK(op_domain.operational_values.size() <= 100);
+            CHECK(op_domain.operational_values.size() <= 256);
 
             // for the selected range, all samples should be within the parameters
             check_op_domain_params_and_operational_status(op_domain, op_domain_params, std::nullopt);
 
             CHECK(mockturtle::to_seconds(op_domain_stats.time_total) > 0.0);
-            CHECK(op_domain_stats.num_simulator_invocations <= 200);
-            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 512);
+            CHECK(op_domain_stats.num_simulator_invocations <= 512);
+            CHECK(op_domain_stats.num_evaluated_parameter_combinations <= 256);
             CHECK(op_domain_stats.num_operational_parameter_combinations <= 80);
-            CHECK(op_domain_stats.num_non_operational_parameter_combinations <= 100);
+            CHECK(op_domain_stats.num_non_operational_parameter_combinations <= 176);
         }
     }
 }

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -537,7 +537,7 @@ TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domai
 
     lyt.assign_cell_type({10, 9, 1}, sidb_technology::cell_type::NORMAL);
 
-    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+    const sidb_100_cell_clk_lyt_siqad lat{lyt};
 
     sidb_simulation_parameters sim_params{};
     sim_params.base     = 2;
@@ -660,7 +660,7 @@ TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinat
     lyt.assign_cell_type(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{10, 9, 1}),
                          sidb_technology::cell_type::NORMAL);
 
-    const sidb_lattice<sidb_100_lattice, layout> lat{lyt};
+    const sidb_100_cell_clk_lyt_cube lat{lyt};
 
     sidb_simulation_parameters sim_params{};
     sim_params.base     = 2;


### PR DESCRIPTION
## Description

This PR replaces the ``std::vector`` with a ``std::set`` to ensure uniqueness of sample points. It also updates the unit test and corrects the upper bound of the number of values of the operational domain when using contour tracing. Thanks to @wlambooy for finding and mentioning this! 🙏 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
