### PR TITLE
🐛 Fix exclude pattern in clang-tidy-review.yml

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -36,7 +36,7 @@ jobs:
             -DMOCKTURTLE_EXAMPLES=OFF
           build_dir: build
           config_file: '.clang-tidy'
-          exclude: 'libs/*, docs/*, benchmarks/*, bib/*, */pyfiction/pybind11_mkdoc_docstrings.hpp, */pyfiction/documentation.hpp'
+          exclude: 'libs/*,docs/*,benchmarks/*,bib/*,*/pyfiction/pybind11_mkdoc_docstrings.hpp,*/pyfiction/documentation.hpp'
           split_workflow: true
 
       - name: Make sure that the review file exists


### PR DESCRIPTION
## Description

Clang-tidy did not exclude all files specified in the exclude pattern due to whitespaces, which are not stripped correctly.

Minimal code example taken from https://github.com/ZedThree/clang-tidy-review:

```
import fnmatch

def strip_enclosing_quotes(string: str) -> str:
    """Strip leading/trailing whitespace and remove any enclosing quotes"""
    stripped = string.strip()

    for quote in ['"', "'", '"']:
        if stripped.startswith(quote) and stripped.endswith(quote):
            stripped = stripped[1:-1]
    return stripped

files = ['bindings/pyfiction/include/pyfiction/algorithms/physical_design/post_layout_optimization.hpp', 'bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp']
ex = '*/pyfiction/pybind11_mkdoc_docstrings.hpp, */pyfiction/documentation.hpp'
exclude = strip_enclosing_quotes(ex).split(",")
for pattern in exclude:
	files = [f for f in files if not fnmatch.fnmatch(f, pattern)]
	print(f"exclude: {pattern}, file list now: {files}")
```

It is working on Mac, but it did not work on Ubunutu in the CI.

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
