### PR TITLE
:construction_worker: CI Restructuring

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: '${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}'
+          key: '${{matrix.os}}-${{matrix.compiler}}'
           variant: ccache
           save: true
           max-size: 10G
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.10.x'
           cache: 'pip'
 
       - name: Setup mold

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
 
-        run: ctest -C $BUILD_TYPE --verbose --output-on-failure --parallel 4
+        run: ctest -C $BUILD_TYPE --verbose --output-on-failure --repeat until-pass:3 --parallel 4
 
       - name: Setup and run lcov
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: '${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}'
+          key: '${{matrix.os}}-${{matrix.compiler}}'
           variant: ccache
           save: true
           max-size: 10G
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.10.x'
           cache: 'pip'
 
       - name: Setup mold

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -71,6 +71,11 @@ jobs:
       - name: Setup TBB
         run: brew install tbb
 
+      - name: Setup XCode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "^14.2"
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -93,6 +93,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+
       # Build and test pipeline for Debug mode
 
       - name: Create Build Environment (Debug)
@@ -117,11 +118,12 @@ jobs:
 
       - name: Build (Debug)
         working-directory: ${{github.workspace}}/build_debug
-        run: cmake --build . -j4  # all macOS runners provide at least 3 cores
+        run: cmake --build . --config Debug -j4  # all macOS runners provide at least 3 cores
 
       - name: Test (Debug)
         working-directory: ${{github.workspace}}/build_debug
         run: ctest -C Debug --verbose --output-on-failure --repeat until-pass:3 --parallel 4
+
 
       # Build and test pipeline for Release mode
 
@@ -147,7 +149,7 @@ jobs:
 
       - name: Build (Release)
         working-directory: ${{github.workspace}}/build_release
-        run: cmake --build . -j4  # all macOS runners provide at least 3 cores
+        run: cmake --build . --config Release -j4  # all macOS runners provide at least 3 cores
 
       - name: Test (Release)
         working-directory: ${{github.workspace}}/build_release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,7 +38,6 @@ jobs:
       matrix:
         os: [ macos-13, macos-14 ]
         compiler: [ g++-11, g++-12, g++-13, clang++ ]
-        build_type: [ Debug, Release ]
         include:
           - os: macos-13
             architecture: x64
@@ -58,7 +57,7 @@ jobs:
           - os: macos-14
             compiler: g++-13
 
-    name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
+    name: ${{matrix.os}} with ${{matrix.compiler}}
     runs-on: ${{matrix.os}}
 
     steps:
@@ -79,7 +78,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: '${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}'
+          key: '${{matrix.os}}-${{matrix.compiler}}'
           variant: ccache
           save: true
           max-size: 10G
@@ -94,15 +93,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Create Build Environment
-        run: cmake -E make_directory ${{github.workspace}}/build
+      # Build and test pipeline for Debug mode
 
-      - name: Configure CMake
-        working-directory: ${{github.workspace}}/build
+      - name: Create Build Environment (Debug)
+        run: cmake -E make_directory ${{github.workspace}}/build_debug
+
+      - name: Configure CMake (Debug)
+        working-directory: ${{github.workspace}}/build_debug
         run: >
           cmake ${{github.workspace}}
           -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DCMAKE_BUILD_TYPE=Debug
           -DFICTION_ENABLE_UNITY_BUILD=ON
           -DFICTION_ENABLE_PCH=ON
           -DFICTION_CLI=ON
@@ -114,12 +115,40 @@ jobs:
           -DFICTION_WARNINGS_AS_ERRORS=OFF
           -DMOCKTURTLE_EXAMPLES=OFF
 
-      - name: Build
-        working-directory: ${{github.workspace}}/build
+      - name: Build (Debug)
+        working-directory: ${{github.workspace}}/build_debug
         run: cmake --build . -j4  # all macOS runners provide at least 3 cores
 
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --parallel 4
+      - name: Test (Debug)
+        working-directory: ${{github.workspace}}/build_debug
+        run: ctest -C Debug --verbose --output-on-failure --repeat until-pass:3 --parallel 4
+
+      # Build and test pipeline for Release mode
+
+      - name: Create Build Environment (Release)
+        run: cmake -E make_directory ${{github.workspace}}/build_release
+
+      - name: Configure CMake (Release)
+        working-directory: ${{github.workspace}}/build_release
+        run: >
+          cmake ${{github.workspace}}
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          -DCMAKE_BUILD_TYPE=Release
+          -DFICTION_ENABLE_UNITY_BUILD=ON
+          -DFICTION_ENABLE_PCH=ON
+          -DFICTION_CLI=ON
+          -DFICTION_TEST=ON
+          -DFICTION_BENCHMARK=OFF
+          -DFICTION_EXPERIMENTS=ON
+          -DFICTION_Z3=ON
+          -DFICTION_PROGRESS_BARS=OFF
+          -DFICTION_WARNINGS_AS_ERRORS=OFF
+          -DMOCKTURTLE_EXAMPLES=OFF
+
+      - name: Build (Release)
+        working-directory: ${{github.workspace}}/build_release
+        run: cmake --build . -j4  # all macOS runners provide at least 3 cores
+
+      - name: Test (Release)
+        working-directory: ${{github.workspace}}/build_release
+        run: ctest -C Release --verbose --output-on-failure --repeat until-pass:3 --parallel 4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,12 +36,10 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ macos-12, macos-13, macos-14 ]
+        os: [ macos-13, macos-14 ]
         compiler: [ g++-11, g++-12, g++-13, clang++ ]
         build_type: [ Debug, Release ]
         include:
-          - os: macos-12
-            architecture: x64
           - os: macos-13
             architecture: x64
           - os: macos-14
@@ -69,23 +67,9 @@ jobs:
         with:
           submodules: recursive
 
-      # Setup TBB for parallel STL algorithms via Homebrew (macOS 11 is no longer supported)
-      - if: matrix.os != 'macos-11'
-        name: Setup TBB
+      # Setup TBB for parallel STL algorithms via Homebrew
+      - name: Setup TBB
         run: brew install tbb
-
-      # Use XCode 13.2 as a workaround because XCode 14.0 seems broken
-      - if: matrix.os == 'macos-12'
-        name: Setup XCode version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "^13.2"
-
-      - if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
-        name: Setup XCode version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "^14.2"
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -127,10 +111,10 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: cmake --build . -j3  # all macOS runners provide at least 3 cores
+        run: cmake --build . -j4  # all macOS runners provide at least 3 cores
 
       - name: Test
         working-directory: ${{github.workspace}}/build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --parallel 3
+        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --parallel 4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -142,4 +142,4 @@ jobs:
         working-directory: ${{github.workspace}}/build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --parallel 4
+        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --repeat until-pass:3 --parallel 4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,7 +38,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
         compiler: [ g++-10, g++-11, g++-12, clang++-10, clang++-11, clang++-12 ]
-        build_type: [ Debug, Release ]
         exclude:
           - os: ubuntu-20.04
             compiler: g++-12
@@ -47,29 +46,22 @@ jobs:
         include:
           - os: ubuntu-22.04
             compiler: clang++-13
-            build_type: Debug
           - os: ubuntu-22.04
             compiler: clang++-13
-            build_type: Release
           - os: ubuntu-22.04
             compiler: clang++-14
-            build_type: Debug
           - os: ubuntu-22.04
             compiler: clang++-14
-            build_type: Release
           - os: ubuntu-22.04
             compiler: clang++-15
-            build_type: Debug
           - os: ubuntu-22.04
             compiler: clang++-15
-            build_type: Release
           - os: ubuntu-20.04
             compiler: g++-10
-            build_type: Release
             cppstandard: -DCMAKE_CXX_STANDARD=20
             cppname: C++20
 
-    name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode) ${{matrix.cppname}}
+    name: ${{matrix.os}} with ${{matrix.compiler}} ${{matrix.cppname}}
     runs-on: ${{matrix.os}}
 
     steps:
@@ -84,7 +76,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: '${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}'
+          key: '${{matrix.os}}-${{matrix.compiler}}'
           variant: ccache
           save: true
           max-size: 10G
@@ -92,7 +84,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.10.x'
           cache: 'pip'
 
       - name: Install pip packages
@@ -113,15 +105,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Create Build Environment
-        run: cmake -E make_directory ${{github.workspace}}/build
 
-      - name: Configure CMake
-        working-directory: ${{github.workspace}}/build
+      # Build and test pipeline for Debug mode
+
+      - name: Create Build Environment (Debug)
+        run: cmake -E make_directory ${{github.workspace}}/build_debug
+
+      - name: Configure CMake (Debug)
+        working-directory: ${{github.workspace}}/build_debug
         run: >
           cmake ${{github.workspace}} ${{matrix.cppstandard}}
           -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DCMAKE_BUILD_TYPE=Debug
           -DFICTION_ENABLE_UNITY_BUILD=ON
           -DFICTION_ENABLE_PCH=ON
           -DFICTION_CLI=ON
@@ -134,12 +129,42 @@ jobs:
           -DFICTION_WARNINGS_AS_ERRORS=OFF
           -DMOCKTURTLE_EXAMPLES=OFF
 
-      - name: Build fiction
-        working-directory: ${{github.workspace}}/build
-        run: cmake --build . --config ${{matrix.build_type}} -j4
+      - name: Build (Debug)
+        working-directory: ${{github.workspace}}/build_debug
+        run: cmake --build . --config Debug -j4
 
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --repeat until-pass:3 --parallel 4
+      - name: Test (Debug)
+        working-directory: ${{github.workspace}}/build_debug
+        run: ctest -C Debug --verbose --output-on-failure --repeat until-pass:3 --parallel 4
+
+
+      # Build and test pipeline for Release mode
+
+      - name: Create Build Environment (Release)
+        run: cmake -E make_directory ${{github.workspace}}/build_release
+
+      - name: Configure CMake (Release)
+        working-directory: ${{github.workspace}}/build_release
+        run: >
+          cmake ${{github.workspace}} ${{matrix.cppstandard}}
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          -DCMAKE_BUILD_TYPE=Release
+          -DFICTION_ENABLE_UNITY_BUILD=ON
+          -DFICTION_ENABLE_PCH=ON
+          -DFICTION_CLI=ON
+          -DFICTION_TEST=ON
+          -DFICTION_BENCHMARK=OFF
+          -DFICTION_EXPERIMENTS=ON
+          -DFICTION_Z3=ON
+          -DFICTION_ENABLE_MUGEN=ON
+          -DFICTION_PROGRESS_BARS=OFF
+          -DFICTION_WARNINGS_AS_ERRORS=OFF
+          -DMOCKTURTLE_EXAMPLES=OFF
+
+      - name: Build (Release)
+        working-directory: ${{github.workspace}}/build_release
+        run: cmake --build . --config Release -j4
+
+      - name: Test (Release)
+        working-directory: ${{github.workspace}}/build_release
+        run: ctest -C Release --verbose --output-on-failure --repeat until-pass:3 --parallel 4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -47,13 +47,7 @@ jobs:
           - os: ubuntu-22.04
             compiler: clang++-13
           - os: ubuntu-22.04
-            compiler: clang++-13
-          - os: ubuntu-22.04
             compiler: clang++-14
-          - os: ubuntu-22.04
-            compiler: clang++-14
-          - os: ubuntu-22.04
-            compiler: clang++-15
           - os: ubuntu-22.04
             compiler: clang++-15
           - os: ubuntu-20.04

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,6 @@ jobs:
       matrix:
         os: [ windows-2019, windows-2022 ]
         toolset: [ v142, v143, ClangCL ]
-        build_type: [ Debug, Release ]
         include:
           - os: windows-2019
             env: 'Visual Studio 16 2019'
@@ -50,7 +49,7 @@ jobs:
           - os: windows-2022
             toolset: v142
 
-    name: ${{matrix.os}} with ${{matrix.env}} and ${{matrix.toolset}} toolset (${{matrix.build_type}} mode)
+    name: ${{matrix.os}} with ${{matrix.env}} and ${{matrix.toolset}} toolset
     runs-on: ${{matrix.os}}
 
     steps:
@@ -62,7 +61,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: '${{matrix.os}}-${{matrix.toolset}}-${{matrix.build_type}}'
+          key: '${{matrix.os}}-${{matrix.toolset}}'
           variant: ccache
           save: true
           max-size: 10G
@@ -77,14 +76,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Create Build Environment
-        run: cmake -E make_directory ${{github.workspace}}\build
+
+      # Build and test pipeline for Debug mode
+
+      - name: Create Build Environment (Debug)
+        run: cmake -E make_directory ${{github.workspace}}\build_debug
 
       - name: Configure CMake
-        working-directory: ${{github.workspace}}\build
+        working-directory: ${{github.workspace}}\build_debug
         run: >
           cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DCMAKE_BUILD_TYPE=Debug
           -DFICTION_ENABLE_UNITY_BUILD=ON
           -DFICTION_ENABLE_PCH=ON
           -DFICTION_CLI=ON
@@ -95,12 +97,39 @@ jobs:
           -DFICTION_WARNINGS_AS_ERRORS=OFF
           -DMOCKTURTLE_EXAMPLES=OFF
 
-      - name: Build
-        working-directory: ${{github.workspace}}\build
-        run: cmake --build . --config ${{matrix.build_type}} -j4
+      - name: Build (Debug)
+        working-directory: ${{github.workspace}}\build_debug
+        run: cmake --build . --config Debug -j4
 
-      - name: Test
-        working-directory: ${{github.workspace}}\build
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --repeat until-pass:3 --parallel 4
+      - name: Test (Debug)
+        working-directory: ${{github.workspace}}\build_debug
+        run: ctest -C Debug --verbose --output-on-failure --repeat until-pass:3 --parallel 4
+
+
+      # Build and test pipeline for Release mode
+
+      - name: Create Build Environment (Release)
+        run: cmake -E make_directory ${{github.workspace}}\build_release
+
+      - name: Configure CMake
+        working-directory: ${{github.workspace}}\build_release
+        run: >
+          cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
+          -DCMAKE_BUILD_TYPE=Release
+          -DFICTION_ENABLE_UNITY_BUILD=ON
+          -DFICTION_ENABLE_PCH=ON
+          -DFICTION_CLI=ON
+          -DFICTION_TEST=ON
+          -DFICTION_BENCHMARK=OFF
+          -DFICTION_EXPERIMENTS=ON
+          -DFICTION_Z3=ON
+          -DFICTION_WARNINGS_AS_ERRORS=OFF
+          -DMOCKTURTLE_EXAMPLES=OFF
+
+      - name: Build (Release)
+        working-directory: ${{github.workspace}}\build_release
+        run: cmake --build . --config Release -j4
+
+      - name: Test (Release)
+        working-directory: ${{github.workspace}}\build_release
+        run: ctest -C Release --verbose --output-on-failure --repeat until-pass:3 --parallel 4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -103,4 +103,4 @@ jobs:
         working-directory: ${{github.workspace}}\build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --parallel 4
+        run: ctest -C ${{matrix.build_type}} --verbose --output-on-failure --repeat until-pass:3 --parallel 4


### PR DESCRIPTION
## Description

This PR restructures the CI system to reduce the amount of runners spawned.

- Deprecate macOS-12 support
- Merge Debug and Release pipelines for all workflows into single runners for performance reasons

Additional changes:
- Bump Python in the runners to 3.10

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
