### PR TITLE
👷 Limit triggering of the pyfiction deployment CI 

### DIFF
--- a/.github/workflows/pyfiction-pypi-deployment.yml
+++ b/.github/workflows/pyfiction-pypi-deployment.yml
@@ -1,7 +1,7 @@
 # this file is heavily based on https://github.com/cda-tum/qmap/blob/main/.github/workflows/deploy.yml
 
 name: 🐍 Packaging
- 
+
 on:
   release:
     types: [ published ]

--- a/.github/workflows/pyfiction-pypi-deployment.yml
+++ b/.github/workflows/pyfiction-pypi-deployment.yml
@@ -1,15 +1,33 @@
 # this file is heavily based on https://github.com/cda-tum/qmap/blob/main/.github/workflows/deploy.yml
 
 name: 🐍 Packaging
-
+ 
 on:
   release:
     types: [ published ]
-  pull_request:
   merge_group:
   push:
-    branches:
-      - main
+    branches: [ 'main' ]
+    paths:
+      - 'bindings/pyfiction/**'
+      - '**/*.py'
+      - '**/*.hpp'
+      - '**/*.cpp'
+      - '**/*.cmake'
+      - '**/CMakeLists.txt'
+      - 'libs/**'
+      - '.github/workflows/pyfiction-pypi-deployment.yml'
+  pull_request:
+    branches: [ 'main' ]
+    paths:
+      - 'bindings/pyfiction/**'
+      - '**/*.py'
+      - '**/*.hpp'
+      - '**/*.cpp'
+      - '**/*.cmake'
+      - '**/CMakeLists.txt'
+      - 'libs/**'
+      - '.github/workflows/pyfiction-pypi-deployment.yml'
   workflow_dispatch:
   workflow_run:
     workflows: [ "pyfiction Docstring Generator" ]


### PR DESCRIPTION
## Description

Only trigger `pyfiction-pypi-deployment` when specific files are changed, similar to `python-binding.yml`

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
