### PR TITLE
📝 Run python docstring generator on forks during PRs

### DIFF
--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '**/*.hpp'
       - '.github/workflows/pyfiction-docstring-generator.yml'
+  pull_request:
+    paths:
+      - '**/*.hpp'
+      - '.github/workflows/pyfiction-docstring-generator.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

The python docstring generator stopped working on PRs from forks. Adding `on: pull_request` should fix that.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
