### PR TITLE
📝 Update docstring generator to include target branch for push

### DIFF
--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -55,8 +55,3 @@ jobs:
           message: ':memo: Update pyfiction docstrings'
           author_name: GitHub Actions
           author_email: actions@github.com
-
-      - name: Push changes
-        run: git push origin HEAD:${{ github.ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -5,10 +5,6 @@ on:
     paths:
       - '**/*.hpp'
       - '.github/workflows/pyfiction-docstring-generator.yml'
-  pull_request:
-    paths:
-      - '**/*.hpp'
-      - '.github/workflows/pyfiction-docstring-generator.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0 # Fetch all history for all branches and tags
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -47,10 +47,16 @@ jobs:
           path: ${{ github.workspace }}/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
           overwrite: true
 
-      - uses: EndBug/add-and-commit@v9
+      - name: Commit docstrings
+        uses: EndBug/add-and-commit@v9
         with:
           add: 'bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp'
           commit: '--signoff'
           message: ':memo: Update pyfiction docstrings'
           author_name: GitHub Actions
           author_email: actions@github.com
+
+      - name: Push changes
+        run: git push origin HEAD:${{ github.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -50,12 +50,13 @@ jobs:
           path: ${{ github.workspace }}/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
           overwrite: true
 
-      - name: Add and Commit changes
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          git add .
-          git commit -m ":memo: Update pyfiction docstrings"
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: 'bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp'
+          commit: '--signoff'
+          message: ':memo: Update pyfiction docstrings'
+          author_name: GitHub Actions
+          author_email: actions@github.com
 
       - name: Push changes
         run: git push origin HEAD:${{ github.ref }}

--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -50,10 +50,12 @@ jobs:
           path: ${{ github.workspace }}/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
           overwrite: true
 
-      - uses: EndBug/add-and-commit@v9
-        with:
-          add: 'bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp'
-          commit: '--signoff'
-          message: ':memo: Update pyfiction docstrings'
-          author_name: GitHub Actions
-          author_email: actions@github.com
+      - name: Add and Commit changes
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add .
+          git commit -m ":memo: Update pyfiction docstrings"
+
+      - name: Push changes
+        run: git push origin HEAD:${{ github.ref }}

--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -53,6 +54,3 @@ jobs:
           message: ':memo: Update pyfiction docstrings'
           author_name: GitHub Actions
           author_email: actions@github.com
-
-      - name: Push changes
-        run: git push origin HEAD:${{ github.ref }}


### PR DESCRIPTION
## Description

The docstring generator workflow successfully runs when merging branches originating from ``upstream-main``. However, it fails to push docstrings during workflow execution for branches originating from ``fork-main`` due to detached branches.

This PR resolves the issue by specifying the target branch for pushing docstrings.

Thanks @simon1hofmann for helping to figure this out!

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
