### PR TITLE
🚨 Fixed compiler warnings

### DIFF
--- a/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
+++ b/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
@@ -943,8 +943,8 @@ class post_layout_optimization_impl
                 {
                     if (!layout.is_po_tile(gate_tile))
                     {
-                        max_non_po.x = std::max(max_non_po.x, static_cast<decltype(max_non_po.x)>(gate_tile.x));
-                        max_non_po.y = std::max(max_non_po.y, static_cast<decltype(max_non_po.y)>(gate_tile.y));
+                        max_non_po.x = static_cast<decltype(max_non_po.x)>(std::max(max_non_po.x, static_cast<decltype(max_non_po.x)>(gate_tile.x)));
+                        max_non_po.y = static_cast<decltype(max_non_po.x)>(std::max(max_non_po.y, static_cast<decltype(max_non_po.y)>(gate_tile.y)));
                     }
                 }
                 moved_at_least_one_gate = false;

--- a/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
+++ b/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
@@ -943,8 +943,10 @@ class post_layout_optimization_impl
                 {
                     if (!layout.is_po_tile(gate_tile))
                     {
-                        max_non_po.x = static_cast<decltype(max_non_po.x)>(std::max(max_non_po.x, static_cast<decltype(max_non_po.x)>(gate_tile.x)));
-                        max_non_po.y = static_cast<decltype(max_non_po.x)>(std::max(max_non_po.y, static_cast<decltype(max_non_po.y)>(gate_tile.y)));
+                        max_non_po.x = static_cast<decltype(max_non_po.x)>(
+                            std::max(max_non_po.x, static_cast<decltype(max_non_po.x)>(gate_tile.x)));
+                        max_non_po.y = static_cast<decltype(max_non_po.x)>(
+                            std::max(max_non_po.y, static_cast<decltype(max_non_po.y)>(gate_tile.y)));
                     }
                 }
                 moved_at_least_one_gate = false;

--- a/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
+++ b/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
@@ -943,8 +943,8 @@ class post_layout_optimization_impl
                 {
                     if (!layout.is_po_tile(gate_tile))
                     {
-                        max_non_po.x = std::max(max_non_po.x, gate_tile.x);
-                        max_non_po.y = std::max(max_non_po.y, gate_tile.y);
+                        max_non_po.x = static_cast<decltype(max_non_po.x)>(std::max(max_non_po.x, gate_tile.x));
+                        max_non_po.y = static_cast<decltype(max_non_po.y)>(std::max(max_non_po.y, gate_tile.y));
                     }
                 }
                 moved_at_least_one_gate = false;

--- a/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
+++ b/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
@@ -943,8 +943,8 @@ class post_layout_optimization_impl
                 {
                     if (!layout.is_po_tile(gate_tile))
                     {
-                        max_non_po.x = static_cast<decltype(max_non_po.x)>(std::max(max_non_po.x, gate_tile.x));
-                        max_non_po.y = static_cast<decltype(max_non_po.y)>(std::max(max_non_po.y, gate_tile.y));
+                        max_non_po.x = std::max(max_non_po.x, static_cast<decltype(max_non_po.x)>(gate_tile.x));
+                        max_non_po.y = std::max(max_non_po.y, static_cast<decltype(max_non_po.y)>(gate_tile.y));
                     }
                 }
                 moved_at_least_one_gate = false;

--- a/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
+++ b/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
@@ -5,6 +5,9 @@
 #ifndef FICTION_POST_LAYOUT_OPTIMIZATION_HPP
 #define FICTION_POST_LAYOUT_OPTIMIZATION_HPP
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+
 #include "fiction/algorithms/path_finding/a_star.hpp"
 #include "fiction/algorithms/path_finding/cost.hpp"
 #include "fiction/algorithms/path_finding/distance.hpp"
@@ -943,10 +946,8 @@ class post_layout_optimization_impl
                 {
                     if (!layout.is_po_tile(gate_tile))
                     {
-                        max_non_po.x = static_cast<decltype(max_non_po.x)>(
-                            std::max(max_non_po.x, static_cast<decltype(max_non_po.x)>(gate_tile.x)));
-                        max_non_po.y = static_cast<decltype(max_non_po.x)>(
-                            std::max(max_non_po.y, static_cast<decltype(max_non_po.y)>(gate_tile.y)));
+                        max_non_po.x = std::max(max_non_po.x, gate_tile.x);
+                        max_non_po.y = std::max(max_non_po.y, gate_tile.y);
                     }
                 }
                 moved_at_least_one_gate = false;
@@ -1048,5 +1049,7 @@ void post_layout_optimization(const Lyt& lyt, post_layout_optimization_params ps
 }
 
 }  // namespace fiction
+
+#pragma GCC diagnostic pop
 
 #endif  // FICTION_POST_LAYOUT_OPTIMIZATION_HPP

--- a/include/fiction/algorithms/physical_design/wiring_reduction.hpp
+++ b/include/fiction/algorithms/physical_design/wiring_reduction.hpp
@@ -403,11 +403,11 @@ create_wiring_reduction_layout(const Lyt& lyt, const uint64_t x_offset = 0, cons
             // crossing:
             //
             // =
-            auto is_single_wire = [&lyt, &old_coord](const uint64_t x_offset, const uint64_t y_offset)
+            auto is_single_wire = [&lyt, &old_coord](const uint64_t add_x_offset, const uint64_t add_y_offset)
             {
-                return lyt.is_wire_tile({old_coord.x - x_offset, old_coord.y - y_offset, 0}) &&
-                       !lyt.is_fanout(lyt.get_node({old_coord.x - x_offset, old_coord.y - y_offset, 0}) &&
-                                      lyt.is_empty_tile({old_coord.x - x_offset, old_coord.y - y_offset, 1}));
+                return lyt.is_wire_tile({old_coord.x - add_x_offset, old_coord.y - add_y_offset, 0}) &&
+                       !lyt.is_fanout(lyt.get_node({old_coord.x - add_x_offset, old_coord.y - add_y_offset, 0}) &&
+                                      lyt.is_empty_tile({old_coord.x - add_x_offset, old_coord.y - add_y_offset, 1}));
             };
 
             // utility function to check for crossings with outgoing wires to the bottom layer:
@@ -415,18 +415,18 @@ create_wiring_reduction_layout(const Lyt& lyt, const uint64_t x_offset = 0, cons
             // +→=
             // ↓
             // =
-            auto is_crossing = [&lyt, &old_coord](const uint64_t x_offset, const uint64_t y_offset)
+            auto is_crossing = [&lyt, &old_coord](const uint64_t add_x_offset, const uint64_t add_y_offset)
             {
-                return lyt.has_northern_incoming_signal({old_coord.x - x_offset, old_coord.y - y_offset + 1, 0}) &&
-                       lyt.has_western_incoming_signal({old_coord.x - x_offset + 1, old_coord.y - y_offset, 0});
+                return lyt.has_northern_incoming_signal({old_coord.x - add_x_offset, old_coord.y - add_y_offset + 1, 0}) &&
+                       lyt.has_western_incoming_signal({old_coord.x - add_x_offset + 1, old_coord.y - add_y_offset, 0});
             };
 
             // utility function to fully obstruct a coordinate
             auto obstruct_coordinate =
-                [&wiring_reduction_lyt, &new_coord](const uint64_t x_offset, const uint64_t y_offset)
+                [&wiring_reduction_lyt, &new_coord](const uint64_t add_x_offset, const uint64_t add_y_offset)
             {
-                wiring_reduction_lyt.obstruct_coordinate({new_coord.x - x_offset, new_coord.y - y_offset, 0});
-                wiring_reduction_lyt.obstruct_coordinate({new_coord.x - x_offset, new_coord.y - y_offset, 1});
+                wiring_reduction_lyt.obstruct_coordinate({new_coord.x - add_x_offset, new_coord.y - add_y_offset, 0});
+                wiring_reduction_lyt.obstruct_coordinate({new_coord.x - add_x_offset, new_coord.y - add_y_offset, 1});
             };
 
             // handle single input gates and wires

--- a/include/fiction/algorithms/physical_design/wiring_reduction.hpp
+++ b/include/fiction/algorithms/physical_design/wiring_reduction.hpp
@@ -417,7 +417,8 @@ create_wiring_reduction_layout(const Lyt& lyt, const uint64_t x_offset = 0, cons
             // =
             auto is_crossing = [&lyt, &old_coord](const uint64_t add_x_offset, const uint64_t add_y_offset)
             {
-                return lyt.has_northern_incoming_signal({old_coord.x - add_x_offset, old_coord.y - add_y_offset + 1, 0}) &&
+                return lyt.has_northern_incoming_signal(
+                           {old_coord.x - add_x_offset, old_coord.y - add_y_offset + 1, 0}) &&
                        lyt.has_western_incoming_signal({old_coord.x - add_x_offset + 1, old_coord.y - add_y_offset, 0});
             };
 


### PR DESCRIPTION
## Description

Fixed compiler warnings:
`warning: declaration of 'x_offset' shadows a lambda capture [-Wshadow]`
`warning: declaration of 'y_offset' shadows a lambda capture [-Wshadow]`
`warning: conversion from ‘long unsigned int’ to ‘unsigned int:31’ may change value [-Wconversion]`

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
