### PR TITLE
:children_crossing: Add warning for leak sanitizer usage with AppleClang

### DIFF
--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -17,7 +17,7 @@ function(
 
     if(${ENABLE_SANITIZER_LEAK})
       if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-        message(WARNING "Leak sanitizer is not supported on Apple Clang.")
+        message(SEND_ERROR "Leak sanitizer is not supported on Apple Clang.")
       else()
         list(APPEND SANITIZERS "leak")
       endif()

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -16,7 +16,11 @@ function(
     endif()
 
     if(${ENABLE_SANITIZER_LEAK})
-      list(APPEND SANITIZERS "leak")
+      if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+        message(WARNING "Leak sanitizer is not supported on Apple Clang.")
+      else()
+        list(APPEND SANITIZERS "leak")
+      endif()
     endif()
 
     if(${ENABLE_SANITIZER_UNDEFINED_BEHAVIOR})


### PR DESCRIPTION
## Description

This PR introduces a warning when Leak Sanitizer is used with Apple Clang, as it is incompatible with this compiler.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
