### PR TITLE
:green_heart: Added Python Setup to CI Workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.x'
+          cache: 'pip'
+
       # Setup TBB for parallel STL algorithms via Homebrew
       - name: Setup TBB
         run: brew install tbb

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -72,7 +72,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10.x'
-          cache: 'pip'
 
       # Setup TBB for parallel STL algorithms via Homebrew
       - name: Setup TBB

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,7 +64,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10.x'
-          cache: 'pip'
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,6 +60,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.x'
+          cache: 'pip'
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:


### PR DESCRIPTION
## Description

This PR updates the Windows and MacOS CI workflow to include Python 3.10 and pip caching. This change is required due to pybind's removal (https://github.com/pybind/pybind11/commit/723307283ed7dc03c901fba1da1127c7b16a4a0d) of support for Python versions earlier than 3.8. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
