### PR TITLE
:construction_worker: Update GCC versions on macOS CIs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-13, macos-14 ]
-        compiler: [ g++-11, g++-12, g++-13, clang++ ]
+        compiler: [ g++-12, g++-13, g++-14, clang++ ]
         include:
           - os: macos-13
             architecture: x64
@@ -47,17 +47,19 @@ jobs:
             architecture: arm64
           - compiler: clang++
             ccompiler: clang
-          - compiler: g++-11
-            ccompiler: gcc-11
           - compiler: g++-12
             ccompiler: gcc-12
+          - compiler: g++-13
+            ccompiler: gcc-13
+          - compiler: g++-14
+            ccompiler: gcc-14
         exclude:
-          - os: macos-14
-            compiler: g++-11
           - os: macos-14
             compiler: g++-12
           - os: macos-14
             compiler: g++-13
+          - os: macos-14
+            compiler: g++-14
 
     name: 🍎 ${{matrix.os}} with ${{matrix.compiler}}
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,20 +77,6 @@ jobs:
       - name: Setup TBB
         run: brew install tbb
 
-      # The fmt library pre-installed on the runners causes conflicts with the version shipped with alice
-      - name: Uninstall fmt
-        run: |
-          if [ -d "/usr/local/include/fmt" ]; then
-            if rm -rf /usr/local/include/fmt; then
-              echo "Pre-installed fmt removed successfully."
-            else
-              echo "Failed to remove pre-installed fmt."
-              exit 1
-            fi
-          else
-            echo "No pre-installed fmt found, skipping removal."
-          fi
-
       - name: Setup XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/bindings/pyfiction/include/pyfiction/layouts/cell_level_layout.hpp
+++ b/bindings/pyfiction/include/pyfiction/layouts/cell_level_layout.hpp
@@ -164,7 +164,7 @@ void fcn_technology_cell_level_layout(pybind11::module& m)
 
                  if constexpr (std::is_same_v<Technology, fiction::sidb_technology>)
                  {
-                     print_layout(convert_to_siqad_coordinates(lyt), stream);
+                     print_layout(convert_layout_to_siqad_coordinates(lyt), stream);
                  }
                  else
                  {

--- a/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -2385,6 +2385,42 @@ Returns:
     was created by casting each element in `a` to `ElementType` using
     `static_cast`.)doc";
 
+static const char *__doc_fiction_convert_layout_to_fiction_coordinates =
+R"doc(Converts the coordinates of a given SiDB cell-level layout (cds and
+defect surface can be layered on top) to alternative coordinates, such
+as `offset::ucoord_t` or `cube::coord_t`. Returns a new layout
+equivalent to the original layout but based on the specified
+coordinate system.
+
+Template parameter ``LytDest``:
+    Source SiDB cell-level layout type.
+
+Template parameter ``LytSrc``:
+    Target SiDB cell-level layout type.
+
+Parameter ``lyt``:
+    The layout that is to be converted to a new layout based on
+    fiction coordinates.
+
+Returns:
+    A new equivalent layout based on fiction coordinates.)doc";
+
+static const char *__doc_fiction_convert_layout_to_siqad_coordinates =
+R"doc(Converts the coordinates of a given cell-level layout (cds and defect
+surface can be layered on top) to SiQAD coordinates. A new equivalent
+layout based on SiQAD coordinates is returned.
+
+Template parameter ``Lyt``:
+    Cell-level layout type based on fiction coordinates, e.g.,
+    `offset::ucoord_t` or `cube::coord_t`.
+
+Parameter ``lyt``:
+    The layout that is to be converted to a new layout based on SiQAD
+    coordinates.
+
+Returns:
+    A new equivalent layout based on SiQAD coordinates.)doc";
+
 static const char *__doc_fiction_convert_network =
 R"doc(Converts a logic network into an equivalent one of another type.
 Thereby, this function is very similar to
@@ -2433,42 +2469,6 @@ Parameter ``precision``:
 Returns:
     The distance (unit: nm) corresponding to the given electrostatic
     potential.)doc";
-
-static const char *__doc_fiction_convert_to_fiction_coordinates =
-R"doc(Converts the coordinates of a given SiDB cell-level layout (cds and
-defect surface can be layered on top) to alternative coordinates, such
-as `offset::ucoord_t` or `cube::coord_t`. Returns a new layout
-equivalent to the original layout but based on the specified
-coordinate system.
-
-Template parameter ``LytDest``:
-    Source SiDB cell-level layout type.
-
-Template parameter ``LytSrc``:
-    Target SiDB cell-level layout type.
-
-Parameter ``lyt``:
-    The layout that is to be converted to a new layout based on
-    fiction coordinates.
-
-Returns:
-    A new equivalent layout based on fiction coordinates.)doc";
-
-static const char *__doc_fiction_convert_to_siqad_coordinates =
-R"doc(Converts the coordinates of a given cell-level layout (cds and defect
-surface can be layered on top) to SiQAD coordinates. A new equivalent
-layout based on SiQAD coordinates is returned.
-
-Template parameter ``Lyt``:
-    Cell-level layout type based on fiction coordinates, e.g.,
-    `offset::ucoord_t` or `cube::coord_t`.
-
-Parameter ``lyt``:
-    The layout that is to be converted to a new layout based on SiQAD
-    coordinates.
-
-Returns:
-    A new equivalent layout based on SiQAD coordinates.)doc";
 
 static const char *__doc_fiction_coord_iterator =
 R"doc(An iterator type that allows to enumerate coordinates in order within

--- a/bindings/pyfiction/include/pyfiction/technology/charge_distribution_surface.hpp
+++ b/bindings/pyfiction/include/pyfiction/technology/charge_distribution_surface.hpp
@@ -259,7 +259,7 @@ void charge_distribution_surface_layout(pybind11::module& m, const std::string& 
              [](const py_cds& lyt)
              {
                  std::stringstream ss;
-                 print_layout(fiction::convert_to_siqad_coordinates(lyt), ss);
+                 print_layout(fiction::convert_layout_to_siqad_coordinates(lyt), ss);
                  return ss.str();
              })
 

--- a/bindings/pyfiction/include/pyfiction/utils/layout_utils.hpp
+++ b/bindings/pyfiction/include/pyfiction/utils/layout_utils.hpp
@@ -45,7 +45,7 @@ void convert_to_siqad_coordinates(pybind11::module& m)
     using namespace pybind11::literals;
 
     m.def("convert_layout_to_siqad_coordinates", &fiction::convert_layout_to_siqad_coordinates<Lyt>, "lyt"_a,
-          DOC(fiction_convert_to_siqad_coordinates));
+          DOC(fiction_convert_layout_to_siqad_coordinates));
 }
 
 template <typename Lyt>

--- a/bindings/pyfiction/include/pyfiction/utils/layout_utils.hpp
+++ b/bindings/pyfiction/include/pyfiction/utils/layout_utils.hpp
@@ -44,7 +44,7 @@ void convert_to_siqad_coordinates(pybind11::module& m)
 {
     using namespace pybind11::literals;
 
-    m.def("convert_to_siqad_coordinates", &fiction::convert_to_siqad_coordinates<Lyt>, "lyt"_a,
+    m.def("convert_layout_to_siqad_coordinates", &fiction::convert_layout_to_siqad_coordinates<Lyt>, "lyt"_a,
           DOC(fiction_convert_to_siqad_coordinates));
 }
 

--- a/docs/utils/utils.rst
+++ b/docs/utils/utils.rst
@@ -111,15 +111,15 @@ Layout Utils
         .. doxygenfunction:: fiction::relative_to_absolute_cell_position
         .. doxygenfunction:: fiction::port_direction_to_coordinate
         .. doxygenfunction:: fiction::normalize_layout_coordinates
-        .. doxygenfunction:: fiction::convert_to_siqad_coordinates
-        .. doxygenfunction:: fiction::convert_to_fiction_coordinates
+        .. doxygenfunction:: fiction::convert_layout_to_siqad_coordinates
+        .. doxygenfunction:: fiction::convert_layout_to_fiction_coordinates
         .. doxygenfunction:: fiction::random_coordinate
         .. doxygenfunction:: fiction::all_coordinates_in_spanned_area
 
     .. tab:: Python
         .. autofunction:: mnt.pyfiction.num_adjacent_coordinates
         .. autofunction:: mnt.pyfiction.normalize_layout_coordinates
-        .. autofunction:: mnt.pyfiction.convert_to_siqad_coordinates
+        .. autofunction:: mnt.pyfiction.convert_layout_to_siqad_coordinates
         .. autofunction:: mnt.pyfiction.random_coordinate
 
 

--- a/include/fiction/io/print_layout.hpp
+++ b/include/fiction/io/print_layout.hpp
@@ -359,7 +359,7 @@ void print_sidb_layout(std::ostream& os, const Lyt& lyt, const bool lat_color = 
 
     if constexpr (!has_siqad_coord_v<Lyt>)
     {
-        return print_sidb_layout(os, convert_to_siqad_coordinates(lyt), lat_color, crop_layout, draw_lattice);
+        return print_sidb_layout(os, convert_layout_to_siqad_coordinates(lyt), lat_color, crop_layout, draw_lattice);
     }
 
     if constexpr (!is_sidb_lattice_v<Lyt>)

--- a/include/fiction/utils/layout_utils.hpp
+++ b/include/fiction/utils/layout_utils.hpp
@@ -295,7 +295,7 @@ Lyt normalize_layout_coordinates(const Lyt& lyt) noexcept
  * @return A new equivalent layout based on SiQAD coordinates.
  */
 template <typename LytSrc>
-auto convert_to_siqad_coordinates(const LytSrc& lyt) noexcept
+auto convert_layout_to_siqad_coordinates(const LytSrc& lyt) noexcept
 {
     static_assert(is_cartesian_layout_v<LytSrc>, "LytSrc is not a Cartesian layout");
     static_assert(is_cell_level_layout_v<LytSrc>, "LytSrc is not a cell-level layout");
@@ -318,22 +318,24 @@ auto convert_to_siqad_coordinates(const LytSrc& lyt) noexcept
 
         if constexpr (is_charge_distribution_surface_v<LytSrc> && is_sidb_defect_surface_v<LytSrc>)
         {
-            charge_distribution_surface<decltype(sidb_defect_surface{lyt_new})> lyt_new_cds{
-                sidb_defect_surface{lyt_new}};
-
-            lyt_orig.foreach_cell(
-                [&lyt_new_cds, &lyt_orig](const auto& c)
-                {
-                    lyt_new_cds.assign_charge_state(siqad::to_siqad_coord(c), lyt_orig.get_charge_state(c),
-                                                    charge_index_mode::KEEP_CHARGE_INDEX);
-                });
-
-            lyt_new_cds.assign_physical_parameters(lyt_orig.get_simulation_params());
+            auto lyt_defect = sidb_defect_surface{lyt_new};
 
             lyt_orig.foreach_sidb_defect(
-                [&lyt_new_cds](const auto& cd)
-                { lyt_new_cds.assign_sidb_defect(siqad::to_siqad_coord(cd.first), cd.second); });
-            return lyt_new_cds;
+                [&lyt_defect](const auto& cd)
+                { lyt_defect.assign_sidb_defect(siqad::to_siqad_coord(cd.first), cd.second); });
+
+            auto lyt_cds_defect = charge_distribution_surface{lyt_defect};
+
+            lyt_orig.foreach_cell(
+                [&lyt_cds_defect, &lyt_orig](const auto& c)
+                {
+                    lyt_cds_defect.assign_charge_state(siqad::to_siqad_coord(c), lyt_orig.get_charge_state(c),
+                                                       charge_index_mode::KEEP_CHARGE_INDEX);
+                });
+
+            lyt_cds_defect.assign_physical_parameters(lyt_orig.get_simulation_params());
+
+            return lyt_cds_defect;
         }
         else if constexpr (is_sidb_defect_surface_v<LytSrc> && !is_charge_distribution_surface_v<LytSrc>)
         {
@@ -385,7 +387,7 @@ auto convert_to_siqad_coordinates(const LytSrc& lyt) noexcept
  * @return A new equivalent layout based on fiction coordinates.
  */
 template <typename LytDest, typename LytSrc>
-[[nodiscard]] LytDest convert_to_fiction_coordinates(const LytSrc& lyt) noexcept
+[[nodiscard]] LytDest convert_layout_to_fiction_coordinates(const LytSrc& lyt) noexcept
 {
     static_assert(is_cartesian_layout_v<LytSrc>, "LytSrc is not a Cartesian layout");
     static_assert(is_cell_level_layout_v<LytSrc>, "LytSrc is not a cell-level layout");
@@ -422,7 +424,7 @@ template <typename LytDest, typename LytSrc>
 
     if (are_cells_assigned_to_negative_coordinates && has_offset_ucoord_v<LytDest>)
     {
-        return convert_to_fiction_coordinates<LytDest>(normalize_layout_coordinates(lyt));
+        return convert_layout_to_fiction_coordinates<LytDest>(normalize_layout_coordinates(lyt));
     }
 
     auto process_layout = [&lyt](auto lyt_new)
@@ -444,23 +446,27 @@ template <typename LytDest, typename LytSrc>
 
             if constexpr (is_charge_distribution_surface_v<LytSrc> && is_sidb_defect_surface_v<LytSrc>)
             {
-                LytDest lyt_new_cds{sidb_defect_surface{lyt_new}};
-
-                lyt.foreach_cell(
-                    [&lyt_new_cds, &lyt](const auto& c)
-                    {
-                        lyt_new_cds.assign_charge_state(siqad::to_fiction_coord<coordinate<LytDest>>(c),
-                                                        lyt.get_charge_state(c), charge_index_mode::KEEP_CHARGE_INDEX);
-                    });
-
-                lyt_new_cds.assign_physical_parameters(lyt.get_simulation_params());
+                auto lyt_defect = sidb_defect_surface{lyt_new};
 
                 lyt.foreach_sidb_defect(
-                    [&lyt_new_cds](const auto& cd) {
-                        lyt_new_cds.assign_sidb_defect(siqad::to_fiction_coord<coordinate<LytDest>>(cd.first),
-                                                       cd.second);
+                    [&lyt_defect](const auto& cd) {
+                        lyt_defect.assign_sidb_defect(siqad::to_fiction_coord<coordinate<LytDest>>(cd.first),
+                                                      cd.second);
                     });
-                return lyt_new_cds;
+
+                auto lyt_cds_defect = charge_distribution_surface{lyt_defect};
+
+                lyt.foreach_cell(
+                    [&lyt_cds_defect, &lyt](const auto& c)
+                    {
+                        lyt_cds_defect.assign_charge_state(siqad::to_fiction_coord<coordinate<LytDest>>(c),
+                                                           lyt.get_charge_state(c),
+                                                           charge_index_mode::KEEP_CHARGE_INDEX);
+                    });
+
+                lyt_cds_defect.assign_physical_parameters(lyt.get_simulation_params());
+
+                return lyt_cds_defect;
             }
             else if constexpr (is_sidb_defect_surface_v<LytSrc> && !is_charge_distribution_surface_v<LytSrc>)
             {
@@ -507,7 +513,7 @@ template <typename LytDest, typename LytSrc>
             lyt_100.assign_physical_parameters(lyt.get_simulation_params());
 
             lyt.foreach_sidb_defect([&lyt_100](const auto& cd) { lyt_100.assign_sidb_defect(cd.first, cd.second); });
-            return convert_to_fiction_coordinates<LytDest, cds_sidb_defect_100_cell_clk_lyt_siqad>(lyt_100);
+            return convert_layout_to_fiction_coordinates<LytDest, cds_sidb_defect_100_cell_clk_lyt_siqad>(lyt_100);
         }
         else if constexpr (is_charge_distribution_surface_v<LytSrc> && !is_sidb_defect_surface_v<LytSrc>)
         {
@@ -519,7 +525,7 @@ template <typename LytDest, typename LytSrc>
 
             cds_lyt_100.assign_physical_parameters(lyt.get_simulation_params());
 
-            return convert_to_fiction_coordinates<LytDest, cds_sidb_100_cell_clk_lyt_siqad>(cds_lyt_100);
+            return convert_layout_to_fiction_coordinates<LytDest, cds_sidb_100_cell_clk_lyt_siqad>(cds_lyt_100);
         }
         else if constexpr (is_sidb_defect_surface_v<LytSrc> && !is_charge_distribution_surface_v<LytSrc>)
         {
@@ -527,11 +533,11 @@ template <typename LytDest, typename LytSrc>
             sidb_defect_surface<sidb_100_cell_clk_lyt_siqad> lyt_100_defect{lyt_100};
             lyt.foreach_sidb_defect([&lyt_100_defect, &lyt](const auto& cd)
                                     { lyt_100_defect.assign_sidb_defect(cd.first, lyt.get_sidb_defect(cd.first)); });
-            return convert_to_fiction_coordinates<LytDest>(lyt_100_defect);
+            return convert_layout_to_fiction_coordinates<LytDest>(lyt_100_defect);
         }
         else
         {
-            return convert_to_fiction_coordinates<LytDest, sidb_100_cell_clk_lyt_siqad>(
+            return convert_layout_to_fiction_coordinates<LytDest, sidb_100_cell_clk_lyt_siqad>(
                 sidb_100_cell_clk_lyt_siqad{lyt});
         }
     }

--- a/test/algorithms/iter/bdl_input_iterator.cpp
+++ b/test/algorithms/iter/bdl_input_iterator.cpp
@@ -301,7 +301,7 @@ TEST_CASE("SiQAD's AND gate iteration", "[bdl-input-iterator]")
 
     SECTION("cube coordinates")
     {
-        const auto         layout_cube = convert_to_fiction_coordinates<sidb_cell_clk_lyt_cube>(lyt);
+        const auto         layout_cube = convert_layout_to_fiction_coordinates<sidb_cell_clk_lyt_cube>(lyt);
         bdl_input_iterator bii{sidb_100_cell_clk_lyt_cube{layout_cube}};
 
         for (auto i = 0; bii < 4; ++bii, ++i)
@@ -366,7 +366,7 @@ TEST_CASE("SiQAD's AND gate iteration", "[bdl-input-iterator]")
 
     SECTION("offset coordinates")
     {
-        const auto         layout_offset = convert_to_fiction_coordinates<sidb_cell_clk_lyt_cube>(lyt);
+        const auto         layout_offset = convert_layout_to_fiction_coordinates<sidb_cell_clk_lyt_cube>(lyt);
         bdl_input_iterator bii{sidb_100_cell_clk_lyt_cube{layout_offset}};
 
         for (auto i = 0; bii < 4; ++bii, ++i)

--- a/test/algorithms/physical_design/design_sidb_gates.cpp
+++ b/test/algorithms/physical_design/design_sidb_gates.cpp
@@ -69,7 +69,7 @@ TEST_CASE("Use SiQAD XNOR skeleton and generate SiQAD XNOR gate, exhaustive", "[
     CHECK(found_gate_layouts[0].get_cell_type({10, 4, 0}) == siqad_layout::technology::NORMAL);
 
     // using cube coordinates
-    const auto lyt_in_cube_coord = convert_to_fiction_coordinates<cube_layout>(lyt);
+    const auto lyt_in_cube_coord = convert_layout_to_fiction_coordinates<cube_layout>(lyt);
     const design_sidb_gates_params<cell<cube_layout>> params_cube{
         sidb_simulation_parameters{2, -0.32},
         design_sidb_gates_params<cell<cube_layout>>::design_sidb_gates_mode::EXHAUSTIVE,
@@ -87,7 +87,7 @@ TEST_CASE("Use SiQAD XNOR skeleton and generate SiQAD XNOR gate, exhaustive", "[
           siqad_layout::technology::NORMAL);
 
     // using offset coordinates
-    const auto lyt_in_offset_coord = convert_to_fiction_coordinates<offset_layout>(lyt);
+    const auto lyt_in_offset_coord = convert_layout_to_fiction_coordinates<offset_layout>(lyt);
     const design_sidb_gates_params<cell<offset_layout>> params_offset{
         sidb_simulation_parameters{2, -0.32},
         design_sidb_gates_params<cell<offset_layout>>::design_sidb_gates_mode::EXHAUSTIVE,

--- a/test/algorithms/simulation/sidb/displacement_robustness_domain.cpp
+++ b/test/algorithms/simulation/sidb/displacement_robustness_domain.cpp
@@ -217,7 +217,7 @@ TEST_CASE("Determine the probability of fabricating an operational BDL, offset c
 {
     auto lyt = blueprints::bdl_wire<sidb_cell_clk_lyt_siqad>();
 
-    const auto lyt_offset = convert_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
+    const auto lyt_offset = convert_layout_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
 
     SECTION("one displacement variation in y-direction")
     {

--- a/test/io/print_layout.cpp
+++ b/test/io/print_layout.cpp
@@ -275,7 +275,7 @@ TEST_CASE("Print Bestagon OR-gate without defect", "[print-charge-layout]")
     layout.create_or({}, {}, {0, 0});
 
     const auto lyt =
-        convert_to_siqad_coordinates(apply_gate_library<sidb_100_cell_clk_lyt, sidb_bestagon_library>(layout));
+        convert_layout_to_siqad_coordinates(apply_gate_library<sidb_100_cell_clk_lyt, sidb_bestagon_library>(layout));
 
     charge_distribution_surface cl{lyt, sidb_simulation_parameters{3, -0.32}, sidb_charge_state::NEGATIVE};
 
@@ -434,7 +434,7 @@ TEST_CASE("Print Bestagon OR-gate with defect", "[print-charge-layout]")
     layout.create_or({}, {}, {0, 0});
 
     const auto lyt = sidb_defect_surface{
-        convert_to_siqad_coordinates(apply_gate_library<sidb_100_cell_clk_lyt, sidb_bestagon_library>(layout))};
+        convert_layout_to_siqad_coordinates(apply_gate_library<sidb_100_cell_clk_lyt, sidb_bestagon_library>(layout))};
 
     charge_distribution_surface cl{lyt, sidb_simulation_parameters{3, -0.32}, sidb_charge_state::NEGATIVE};
 
@@ -532,7 +532,7 @@ TEST_CASE("Print layout without charges but defects", "[print-charge-layout]")
 {
     const sidb_100_cell_clk_lyt layout{};
 
-    sidb_defect_surface<sidb_cell_clk_lyt_siqad> cl{convert_to_siqad_coordinates(layout)};
+    sidb_defect_surface<sidb_cell_clk_lyt_siqad> cl{convert_layout_to_siqad_coordinates(layout)};
 
     cl.assign_cell_type({0, 0, 0}, sidb_cell_clk_lyt_siqad::technology::NORMAL);
     cl.assign_cell_type({1, 0, 1}, sidb_cell_clk_lyt_siqad::technology::NORMAL);
@@ -644,7 +644,7 @@ TEST_CASE("Print Bestagon OR-gate", "[print-charge-layout]")
         layout.create_or({}, {}, {0, 0});
 
         const auto cell_layout_or       = apply_gate_library<sidb_cell_clk_lyt, sidb_bestagon_library>(layout);
-        const auto cell_layout_or_siqad = convert_to_siqad_coordinates(cell_layout_or);
+        const auto cell_layout_or_siqad = convert_layout_to_siqad_coordinates(cell_layout_or);
 
         std::stringstream print_stream{};
 
@@ -657,7 +657,7 @@ TEST_CASE("Print Bestagon OR-gate", "[print-charge-layout]")
         layout.create_or({}, {}, {0, 0});
 
         const auto cell_layout_or       = apply_gate_library<sidb_100_cell_clk_lyt, sidb_bestagon_library>(layout);
-        const auto cell_layout_or_siqad = convert_to_siqad_coordinates(cell_layout_or);
+        const auto cell_layout_or_siqad = convert_layout_to_siqad_coordinates(cell_layout_or);
 
         std::stringstream print_stream{};
 

--- a/test/utils/layout_utils.cpp
+++ b/test/utils/layout_utils.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Convert offset::ucoord_t layout (100 lattice orientation) to SiQAD co
 
         const sidb_100_cell_clk_lyt lyt{{x, y}, "test"};
 
-        auto lyt_transformed = convert_to_siqad_coordinates(lyt);
+        auto lyt_transformed = convert_layout_to_siqad_coordinates(lyt);
 
         CHECK(lyt.get_layout_name() == "test");
         CHECK(lyt_transformed.is_empty());
@@ -100,7 +100,7 @@ TEST_CASE("Convert offset::ucoord_t layout (100 lattice orientation) to SiQAD co
         lyt.assign_cell_type({5, 3}, sidb_100_cell_clk_lyt::cell_type::NORMAL);
         lyt.assign_cell_type({5, 1}, sidb_100_cell_clk_lyt::cell_type::INPUT);
 
-        auto lyt_transformed = convert_to_siqad_coordinates(lyt);
+        auto lyt_transformed = convert_layout_to_siqad_coordinates(lyt);
 
         CHECK(lyt_transformed.num_cells() == 2);
         CHECK(lyt_transformed.area() == area_with_padding(lyt.area(), x, y));
@@ -121,7 +121,7 @@ TEST_CASE("Convert offset::ucoord_t layout (100 lattice orientation) to SiQAD co
         lyt.assign_cell_name({5, 3}, "input cell");
         lyt.assign_cell_name({5, 1}, "output cell");
 
-        auto lyt_transformed = convert_to_siqad_coordinates(lyt);
+        auto lyt_transformed = convert_layout_to_siqad_coordinates(lyt);
 
         CHECK(lyt_transformed.num_cells() == 3);
         CHECK(lyt_transformed.area() == area_with_padding(lyt.area(), x, y));
@@ -142,7 +142,7 @@ TEST_CASE("Convert offset::ucoord_t layout (without lattice orientation) to SiQA
 
         const sidb_cell_clk_lyt lyt{{x, y}, "test"};
 
-        auto lyt_transformed = convert_to_siqad_coordinates(lyt);
+        auto lyt_transformed = convert_layout_to_siqad_coordinates(lyt);
 
         CHECK(lyt.get_layout_name() == "test");
         CHECK(lyt_transformed.is_empty());
@@ -159,7 +159,7 @@ TEST_CASE("Convert offset::ucoord_t layout (without lattice orientation) to SiQA
         lyt.assign_cell_type({5, 3}, sidb_cell_clk_lyt::cell_type::NORMAL);
         lyt.assign_cell_type({5, 1}, sidb_cell_clk_lyt::cell_type::INPUT);
 
-        auto lyt_transformed = convert_to_siqad_coordinates(lyt);
+        auto lyt_transformed = convert_layout_to_siqad_coordinates(lyt);
 
         CHECK(lyt_transformed.num_cells() == 2);
         CHECK(lyt_transformed.area() == area_with_padding(lyt.area(), x, y));
@@ -180,7 +180,7 @@ TEST_CASE("Convert offset::ucoord_t layout (without lattice orientation) to SiQA
         lyt.assign_cell_name({5, 3}, "input cell");
         lyt.assign_cell_name({5, 1}, "output cell");
 
-        auto lyt_transformed = convert_to_siqad_coordinates(lyt);
+        auto lyt_transformed = convert_layout_to_siqad_coordinates(lyt);
 
         CHECK(lyt_transformed.num_cells() == 3);
         CHECK(lyt_transformed.area() == area_with_padding(lyt.area(), x, y));
@@ -212,7 +212,7 @@ TEST_CASE("Convert cds/sidb_defect_surface (without lattice information) in offs
     cds.assign_sidb_defect({5, 5, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
     cds.assign_sidb_defect({1, 1, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
 
-    auto lyt_transformed = convert_to_siqad_coordinates(cds);
+    auto lyt_transformed = convert_layout_to_siqad_coordinates(cds);
     CHECK(has_assign_sidb_defect_v<decltype(lyt_transformed)>);
     CHECK(is_charge_distribution_surface_v<decltype(lyt_transformed)>);
 
@@ -241,7 +241,7 @@ TEST_CASE("Convert sidb_defect_surface (without lattice information) in offset::
     sidb_surface.assign_sidb_defect({5, 5, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
     sidb_surface.assign_sidb_defect({1, 1, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
 
-    auto lyt_transformed = convert_to_siqad_coordinates(sidb_surface);
+    auto lyt_transformed = convert_layout_to_siqad_coordinates(sidb_surface);
     CHECK(has_assign_sidb_defect_v<decltype(lyt_transformed)>);
 
     CHECK(lyt_transformed.get_cell_type({0, 0, 0}) == sidb_cell_clk_lyt::technology::cell_type::NORMAL);
@@ -268,7 +268,7 @@ TEST_CASE("Convert cds (without lattice information) in offset::ucoord_t layout 
     cds.assign_charge_state({1, 0, 0}, sidb_charge_state::POSITIVE);
     cds.assign_charge_state({0, 3, 0}, sidb_charge_state::NEGATIVE);
 
-    auto lyt_transformed = convert_to_siqad_coordinates(cds);
+    auto lyt_transformed = convert_layout_to_siqad_coordinates(cds);
     CHECK(is_charge_distribution_surface_v<decltype(lyt_transformed)>);
 
     CHECK(lyt_transformed.get_cell_type({0, 0, 0}) == sidb_cell_clk_lyt::technology::cell_type::NORMAL);
@@ -298,7 +298,7 @@ TEST_CASE("Convert cds/sidb_defect_surface (100) in SiQAD coordinates to offset:
     cds.assign_sidb_defect({5, 5, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
     cds.assign_sidb_defect({1, 1, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
 
-    auto lyt_transformed = convert_to_fiction_coordinates<cds_sidb_defect_100_cell_clk_lyt>(cds);
+    auto lyt_transformed = convert_layout_to_fiction_coordinates<cds_sidb_defect_100_cell_clk_lyt>(cds);
     CHECK(is_sidb_lattice_100_v<decltype(lyt_transformed)>);
     CHECK(has_assign_sidb_defect_v<decltype(lyt_transformed)>);
     CHECK(is_charge_distribution_surface_v<decltype(lyt_transformed)>);
@@ -333,7 +333,7 @@ TEST_CASE("Convert cds (without lattice information) in SiQAD coordinates to off
     cds.assign_charge_state({1, 0, 0}, sidb_charge_state::POSITIVE);
     cds.assign_charge_state({0, 3, 0}, sidb_charge_state::NEGATIVE);
 
-    auto lyt_transformed = convert_to_fiction_coordinates<cds_sidb_100_cell_clk_lyt>(cds);
+    auto lyt_transformed = convert_layout_to_fiction_coordinates<cds_sidb_100_cell_clk_lyt>(cds);
     CHECK(is_sidb_lattice_100_v<decltype(lyt_transformed)>);
     CHECK(is_charge_distribution_surface_v<decltype(lyt_transformed)>);
 
@@ -362,7 +362,8 @@ TEST_CASE("Convert sidb_defect_surface (without lattice information) in SiQAD co
     sidb_surface.assign_sidb_defect({5, 5, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
     sidb_surface.assign_sidb_defect({1, 1, 0}, sidb_defect{sidb_defect_type::UNKNOWN});
 
-    auto lyt_transformed = convert_to_fiction_coordinates<sidb_defect_surface<sidb_100_cell_clk_lyt>>(sidb_surface);
+    auto lyt_transformed =
+        convert_layout_to_fiction_coordinates<sidb_defect_surface<sidb_100_cell_clk_lyt>>(sidb_surface);
     CHECK(is_sidb_lattice_100_v<decltype(lyt_transformed)>);
     CHECK(has_assign_sidb_defect_v<decltype(lyt_transformed)>);
 
@@ -383,7 +384,7 @@ TEST_CASE("Convert SiQAD layout (100) to offset::ucoord_t coordinate layout", "[
     {
         const sidb_100_cell_clk_lyt_siqad lyt{{}, "layout based on siqad coordinates"};
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.is_empty());
         CHECK(lyt_transformed.area() == lyt.area());
@@ -399,7 +400,7 @@ TEST_CASE("Convert SiQAD layout (100) to offset::ucoord_t coordinate layout", "[
         CHECK(lyt.x() == 5);
         CHECK(lyt.y() == 3);
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.x() == 10);
         CHECK(lyt_transformed.y() == 9);
@@ -419,7 +420,7 @@ TEST_CASE("Convert SiQAD layout (100) to offset::ucoord_t coordinate layout", "[
         lyt.assign_cell_name({0, 0}, "input cell");
         lyt.assign_cell_name({5, 1}, "output cell");
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.num_cells() == 3);
         CHECK(lyt_transformed.area() == lyt.area());
@@ -438,7 +439,7 @@ TEST_CASE("Convert SiQAD layout (with sidb lattice layout) to offset::ucoord_t c
     {
         const sidb_100_cell_clk_lyt_siqad lyt{};
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.is_empty());
         CHECK(lyt_transformed.area() == lyt.area());
@@ -454,7 +455,7 @@ TEST_CASE("Convert SiQAD layout (with sidb lattice layout) to offset::ucoord_t c
         CHECK(lyt.x() == 5);
         CHECK(lyt.y() == 3);
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.x() == 10);
         CHECK(lyt_transformed.y() == 9);
@@ -474,7 +475,7 @@ TEST_CASE("Convert SiQAD layout (with sidb lattice layout) to offset::ucoord_t c
         lyt.assign_cell_name({0, 0}, "input cell");
         lyt.assign_cell_name({5, 1}, "output cell");
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.num_cells() == 3);
         CHECK(lyt_transformed.area() == lyt.area());
@@ -493,7 +494,7 @@ TEST_CASE("Convert SiQAD layout (without SiDB lattice layout) to offset::ucoord_
     {
         const sidb_cell_clk_lyt_siqad lyt{};
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.is_empty());
         CHECK(lyt_transformed.area() == lyt.area());
@@ -509,7 +510,7 @@ TEST_CASE("Convert SiQAD layout (without SiDB lattice layout) to offset::ucoord_
         CHECK(lyt.x() == 5);
         CHECK(lyt.y() == 3);
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.x() == 10);
         CHECK(lyt_transformed.y() == 9);
@@ -529,7 +530,7 @@ TEST_CASE("Convert SiQAD layout (without SiDB lattice layout) to offset::ucoord_
         lyt.assign_cell_name({0, 0}, "input cell");
         lyt.assign_cell_name({5, 1}, "output cell");
 
-        auto lyt_transformed = convert_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<sidb_100_cell_clk_lyt>(lyt);
 
         CHECK(lyt_transformed.num_cells() == 3);
         CHECK(lyt_transformed.area() == lyt.area());
@@ -549,7 +550,7 @@ TEMPLATE_TEST_CASE("Convert SiQAD layout to cube::coord_t coordinate layout", "[
     {
         const sidb_100_cell_clk_lyt_siqad lyt{{}, "layout based on siqad coordinates"};
 
-        auto lyt_transformed = convert_to_fiction_coordinates<TestType>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<TestType>(lyt);
 
         CHECK(lyt_transformed.is_empty());
         CHECK(lyt_transformed.area() == lyt.area());
@@ -563,7 +564,7 @@ TEMPLATE_TEST_CASE("Convert SiQAD layout to cube::coord_t coordinate layout", "[
         lyt.assign_cell_type({5, -1, 1}, sidb_cell_clk_lyt_siqad::cell_type::NORMAL);
         lyt.assign_cell_type({5, 1, 0}, sidb_cell_clk_lyt_siqad::cell_type::INPUT);
 
-        auto lyt_transformed = convert_to_fiction_coordinates<TestType>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<TestType>(lyt);
 
         CHECK(lyt_transformed.num_cells() == 2);
         CHECK(lyt_transformed.area() == lyt.area());
@@ -582,7 +583,7 @@ TEMPLATE_TEST_CASE("Convert SiQAD layout to cube::coord_t coordinate layout", "[
         lyt.assign_cell_name({0, 0}, "input cell");
         lyt.assign_cell_name({5, 3}, "output cell");
 
-        auto lyt_transformed = convert_to_fiction_coordinates<TestType>(lyt);
+        auto lyt_transformed = convert_layout_to_fiction_coordinates<TestType>(lyt);
 
         CHECK(lyt_transformed.num_cells() == 3);
         CHECK(lyt_transformed.area() == lyt.area());


### PR DESCRIPTION
## Description

This PR bumps the GCC versions on macOS CIs due to incompatibility with the latest GitHub runner software package updates.

Additionally, it introduces a workaround for a compiler error in GCC 14 that occured on the `convert_to_siqad_coordinates` function. Many thanks to @Drewniok for this fix!

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
