### PR TITLE
:bug: Fixed a RST documentation bug that  prevented `exact` and `exact_with_blacklist` to be rendered properly

### DIFF
--- a/docs/algorithms/exact.rst
+++ b/docs/algorithms/exact.rst
@@ -14,10 +14,8 @@ network specifications under constraints. This approach finds exact results but 
            :members:
         .. doxygenstruct:: fiction::exact_physical_design_stats
            :members:
-        .. doxygenfunction:: fiction::exact(const Ntk& ntk, const exact_physical_design_params<Lyt>& ps = {}, exact_physical_design_stats* pst = nullptr)
-        .. doxygenfunction:: exact_with_blacklist(const Ntk& ntk, const surface_black_list<Lyt, port_direction>& black_list,
-                                        exact_physical_design_params ps  = {},
-                                        exact_physical_design_stats* pst = nullptr)
+        .. doxygenfunction:: fiction::exact(const Ntk& ntk, const exact_physical_design_params& ps = {}, exact_physical_design_stats *pst = nullptr)
+        .. doxygenfunction:: fiction::exact_with_blacklist(const Ntk& ntk, const surface_black_list<Lyt, port_direction>& black_list, exact_physical_design_params ps  = {}, exact_physical_design_stats* pst = nullptr)
 
     .. tab:: Python
         .. autoclass:: mnt.pyfiction.exact_params


### PR DESCRIPTION
## Description

`exact` and `exact_with_blacklist` were not rendered properly in the RST documentation on ReadTheDocs. This PR fixes that.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
