### PR TITLE
:sparkles: Squared Euclidean and Chebyshev distance functions

### DIFF
--- a/bindings/pyfiction/include/pyfiction/algorithms/path_finding/distance.hpp
+++ b/bindings/pyfiction/include/pyfiction/algorithms/path_finding/distance.hpp
@@ -27,8 +27,12 @@ void distance(pybind11::module& m)
           DOC(fiction_manhattan_distance));
     m.def("euclidean_distance", &fiction::euclidean_distance<Lyt>, "layout"_a, "source"_a, "target"_a,
           DOC(fiction_euclidean_distance));
+    m.def("squared_euclidean_distance", &fiction::squared_euclidean_distance<Lyt>, "layout"_a, "source"_a, "target"_a,
+          DOC(fiction_squared_euclidean_distance));
     m.def("twoddwave_distance", &fiction::twoddwave_distance<Lyt>, "layout"_a, "source"_a, "target"_a,
           DOC(fiction_twoddwave_distance));
+    m.def("chebyshev_distance", &fiction::chebyshev_distance<Lyt>, "layout"_a, "source"_a, "target"_a,
+          DOC(fiction_chebyshev_distance));
 }
 
 }  // namespace detail

--- a/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -1968,6 +1968,44 @@ Parameter ``cs``:
 Returns:
     Integer representing the SiDB's charge state.)doc";
 
+static const char *__doc_fiction_chebyshev_distance =
+R"doc(The Chebyshev distance :math:`D` between two layout coordinates
+:math:`(x_1, y_1)` and :math:`(x_2, y_2)` given by
+
+:math:`D = \max(|x_2 - x_1|, |y_2 - y_1|)`
+
+In contrast to the Manhattan distance, this function assumes the same
+cost for diagonal moves as it does for horizontal and vertical ones.
+
+Template parameter ``Lyt``:
+    Coordinate layout type.
+
+Template parameter ``Dist``:
+    Integral type for the distance.
+
+Parameter ``lyt``:
+    Layout.
+
+Parameter ``source``:
+    Source coordinate.
+
+Parameter ``target``:
+    Target coordinate.
+
+Returns:
+    Chebyshev distance between `source` and `target`.)doc";
+
+static const char *__doc_fiction_chebyshev_distance_functor =
+R"doc(A pre-defined distance functor that uses the Chebyshev distance.
+
+Template parameter ``Lyt``:
+    Coordinate layout type.
+
+Template parameter ``Dist``:
+    Integral distance type.)doc";
+
+static const char *__doc_fiction_chebyshev_distance_functor_chebyshev_distance_functor = R"doc()doc";
+
 static const char *__doc_fiction_check_simulation_results_for_equivalence =
 R"doc(This function compares two SiDB simulation results for equivalence.
 Two results are considered equivalent if they have the same number of
@@ -16095,6 +16133,48 @@ Parameter ``sdm``:
 static const char *__doc_fiction_sqd_parsing_error = R"doc(Exception thrown when an error occurs during parsing of an SQD file.)doc";
 
 static const char *__doc_fiction_sqd_parsing_error_sqd_parsing_error = R"doc()doc";
+
+static const char *__doc_fiction_squared_euclidean_distance =
+R"doc(The squared Euclidean distance :math:`D` between two layout
+coordinates :math:`(x_1, y_1)` and :math:`(x_2, y_2)` given by
+
+:math:`D = \sqrt{(x_1 - x_2)^2 + (y_1 - y_2)^2}^2 = (x_1 - x_2)^2 +
+(y_1 - y_2)^2`
+
+In contrast to the regular Euclidean distance, this function is
+differentiable and can be used in optimization algorithms that require
+gradients. Additionally, it is computationally cheaper by omitting the
+square root operation.
+
+Template parameter ``Lyt``:
+    Coordinate layout type.
+
+Template parameter ``Dist``:
+    Integral type for the distance.
+
+Parameter ``lyt``:
+    Layout.
+
+Parameter ``source``:
+    Source coordinate.
+
+Parameter ``target``:
+    Target coordinate.
+
+Returns:
+    Squared euclidean distance between `source` and `target`.)doc";
+
+static const char *__doc_fiction_squared_euclidean_distance_functor =
+R"doc(A pre-defined distance functor that uses the squared Euclidean
+distance.
+
+Template parameter ``Lyt``:
+    Coordinate layout type.
+
+Template parameter ``Dist``:
+    Integral distance type.)doc";
+
+static const char *__doc_fiction_squared_euclidean_distance_functor_squared_euclidean_distance_functor = R"doc()doc";
 
 static const char *__doc_fiction_sweep_parameter = R"doc(Possible sweep parameters for the operational domain computation.)doc";
 

--- a/bindings/pyfiction/test/algorithms/path_finding/test_distance.py
+++ b/bindings/pyfiction/test/algorithms/path_finding/test_distance.py
@@ -35,6 +35,20 @@ class TestDistance(unittest.TestCase):
             self.assertAlmostEqual(euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(4, 4)),
                                    4 * 2 ** 0.5)
 
+    def test_squared_euclidean(self):
+        for lyt in [cartesian_layout((4, 4)), clocked_cartesian_layout((4, 4), "2DDWave"),
+                    cartesian_gate_layout((4, 4), "2DDWave", "Layout"), shifted_cartesian_layout((4, 4)),
+                    clocked_shifted_cartesian_layout((4, 4), "2DDWave"),
+                    shifted_cartesian_gate_layout((4, 4), "2DDWave", "Layout"), hexagonal_layout((4, 4)),
+                    clocked_hexagonal_layout((4, 4), "2DDWave"), hexagonal_gate_layout((4, 4), "2DDWave", "Layout")]:
+            self.assertEqual(squared_euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(0, 0)), 0)
+            self.assertEqual(squared_euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(1, 0)), 1)
+            self.assertEqual(squared_euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(0, 1)), 1)
+            self.assertEqual(squared_euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(1, 1)), 2)
+            self.assertEqual(squared_euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(2, 2)), 8)
+            self.assertEqual(squared_euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(3, 3)), 18)
+            self.assertEqual(squared_euclidean_distance(lyt, offset_coordinate(0, 0), offset_coordinate(4, 4)), 32)
+
     def test_twoddwave(self):
         for lyt in [cartesian_layout((4, 4)), clocked_cartesian_layout((4, 4), "2DDWave"),
                     cartesian_gate_layout((4, 4), "2DDWave", "Layout"), shifted_cartesian_layout((4, 4)),
@@ -49,6 +63,21 @@ class TestDistance(unittest.TestCase):
             self.assertEqual(twoddwave_distance(lyt, offset_coordinate(0, 0), offset_coordinate(2, 2)), 4)
             self.assertEqual(twoddwave_distance(lyt, offset_coordinate(0, 0), offset_coordinate(3, 3)), 6)
             self.assertEqual(twoddwave_distance(lyt, offset_coordinate(0, 0), offset_coordinate(4, 4)), 8)
+
+    def test_chebyshev(self):
+        for lyt in [cartesian_layout((4, 4)), clocked_cartesian_layout((4, 4), "2DDWave"),
+                    cartesian_gate_layout((4, 4), "2DDWave", "Layout"), shifted_cartesian_layout((4, 4)),
+                    clocked_shifted_cartesian_layout((4, 4), "2DDWave"),
+                    shifted_cartesian_gate_layout((4, 4), "2DDWave", "Layout"),
+                    hexagonal_layout((4, 4)), clocked_hexagonal_layout((4, 4), "2DDWave"),
+                    hexagonal_gate_layout((4, 4), "2DDWave", "Layout")]:
+            self.assertEqual(chebyshev_distance(lyt, offset_coordinate(0, 0), offset_coordinate(0, 0)), 0)
+            self.assertEqual(chebyshev_distance(lyt, offset_coordinate(0, 0), offset_coordinate(1, 0)), 1)
+            self.assertEqual(chebyshev_distance(lyt, offset_coordinate(0, 0), offset_coordinate(0, 1)), 1)
+            self.assertEqual(chebyshev_distance(lyt, offset_coordinate(0, 0), offset_coordinate(1, 1)), 1)
+            self.assertEqual(chebyshev_distance(lyt, offset_coordinate(0, 0), offset_coordinate(2, 2)), 2)
+            self.assertEqual(chebyshev_distance(lyt, offset_coordinate(0, 0), offset_coordinate(3, 3)), 3)
+            self.assertEqual(chebyshev_distance(lyt, offset_coordinate(0, 0), offset_coordinate(4, 4)), 4)
 
 
 if __name__ == '__main__':

--- a/docs/algorithms/path_finding.rst
+++ b/docs/algorithms/path_finding.rst
@@ -9,18 +9,24 @@ Distance functions compute (an approximation for) the distance between two coord
 
         .. doxygenfunction:: fiction::manhattan_distance
         .. doxygenfunction:: fiction::euclidean_distance
+        .. doxygenfunction:: fiction::squared_euclidean_distance
         .. doxygenfunction:: fiction::twoddwave_distance
+        .. doxygenfunction:: fiction::chebyshev_distance
 
         .. doxygenclass:: fiction::distance_functor
            :members:
         .. doxygenclass:: fiction::manhattan_distance_functor
         .. doxygenclass:: fiction::euclidean_distance_functor
+        .. doxygenclass:: fiction::squared_euclidean_distance_functor
         .. doxygenclass:: fiction::twoddwave_distance_functor
+        .. doxygenclass:: fiction::chebyshev_distance_functor
 
     .. tab:: Python
         .. autofunction:: mnt.pyfiction.manhattan_distance
         .. autofunction:: mnt.pyfiction.euclidean_distance
+        .. autofunction:: mnt.pyfiction.squared_euclidean_distance
         .. autofunction:: mnt.pyfiction.twoddwave_distance
+        .. autofunction:: mnt.pyfiction.chebyshev_distance
 
 Distance Maps
 -------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_.
 
+Unreleased
+----------
+
+Added
+#####
+- Algorithms:
+    - Path-finding:
+        - Squared Euclidean distance function
+        - Chebyshev distance function
+
 v0.6.3 - 2024-08-21
 -------------------
 

--- a/include/fiction/algorithms/path_finding/distance.hpp
+++ b/include/fiction/algorithms/path_finding/distance.hpp
@@ -63,10 +63,37 @@ template <typename Lyt, typename Dist = double>
     return static_cast<Dist>(std::hypot(x, y));
 }
 /**
+ * The squared Euclidean distance \f$D\f$ between two layout coordinates \f$(x_1, y_1)\f$ and \f$(x_2, y_2)\f$ given by
+ *
+ * \f$D = \sqrt{(x_1 - x_2)^2 + (y_1 - y_2)^2}^2 = (x_1 - x_2)^2 + (y_1 - y_2)^2\f$
+ *
+ * In contrast to the regular Euclidean distance, this function is differentiable and can be used in optimization
+ * algorithms that require gradients. Additionally, it is computationally cheaper by omitting the square root operation.
+ *
+ * @tparam Lyt Coordinate layout type.
+ * @tparam Dist Integral type for the distance.
+ * @param lyt Layout.
+ * @param source Source coordinate.
+ * @param target Target coordinate.
+ * @return Squared euclidean distance between `source` and `target`.
+ */
+template <typename Lyt, typename Dist = uint64_t>
+[[nodiscard]] constexpr Dist squared_euclidean_distance([[maybe_unused]] const Lyt& lyt, const coordinate<Lyt>& source,
+                                                        const coordinate<Lyt>& target) noexcept
+{
+    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
+    static_assert(std::is_integral_v<Dist>, "Dist is not an integral type");
+
+    const auto x = static_cast<double>(source.x) - static_cast<double>(target.x);
+    const auto y = static_cast<double>(source.y) - static_cast<double>(target.y);
+
+    return static_cast<Dist>(x * x + y * y);
+}
+/**
  * The 2DDWave distance \f$D\f$ between two layout coordinates \f$s = (x_1, y_1)\f$ and \f$t = (x_2, y_2)\f$ given
  * by
  *
- *  \f$D = |x_1 - x_2| + |y_1 - y_2|\f$ iff \f$s \leq t\f$ and \f$\infty\f$, otherwise.
+ * \f$D = |x_1 - x_2| + |y_1 - y_2|\f$ iff \f$s \leq t\f$ and \f$\infty\f$, otherwise.
  *
  * Thereby, \f$s \leq t\f$ iff \f$x_1 \leq x_2\f$ and \f$y_1 \leq y_2\f$.
  *
@@ -89,6 +116,31 @@ template <typename Lyt, typename Dist = uint64_t>
 
     return source.x <= target.x && source.y <= target.y ? manhattan_distance<Lyt, Dist>(lyt, source, target) :
                                                           static_cast<Dist>(std::numeric_limits<uint32_t>::max());
+}
+/**
+ * The Chebyshev distance \f$D\f$ between two layout coordinates \f$(x_1, y_1)\f$ and \f$(x_2, y_2)\f$ given by
+ *
+ * \f$D = \max(|x_2 - x_1|, |y_2 - y_1|)\f$
+ *
+ * In contrast to the Manhattan distance, this function assumes the same cost for diagonal moves as it does for
+ * horizontal and vertical ones.
+ *
+ * @tparam Lyt Coordinate layout type.
+ * @tparam Dist Integral type for the distance.
+ * @param lyt Layout.
+ * @param source Source coordinate.
+ * @param target Target coordinate.
+ * @return Chebyshev distance between `source` and `target`.
+ */
+template <typename Lyt, typename Dist = uint64_t>
+[[nodiscard]] constexpr Dist chebyshev_distance([[maybe_unused]] const Lyt& lyt, const coordinate<Lyt>& source,
+                                                const coordinate<Lyt>& target) noexcept
+{
+    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
+    static_assert(std::is_integral_v<Dist>, "Dist is not an integral type");
+
+    return static_cast<Dist>(std::max(std::abs(static_cast<int64_t>(source.x) - static_cast<int64_t>(target.x)),
+                                      std::abs(static_cast<int64_t>(source.y) - static_cast<int64_t>(target.y))));
 }
 
 // NOLINTBEGIN(*-special-member-functions): virtual destructor is prudent
@@ -168,6 +220,18 @@ class euclidean_distance_functor : public distance_functor<Lyt, Dist>
     euclidean_distance_functor() : distance_functor<Lyt, Dist>(&euclidean_distance<Lyt, Dist>) {}
 };
 /**
+ * A pre-defined distance functor that uses the squared Euclidean distance.
+ *
+ * @tparam Lyt Coordinate layout type.
+ * @tparam Dist Integral distance type.
+ */
+template <typename Lyt, typename Dist = uint64_t>
+class squared_euclidean_distance_functor : public distance_functor<Lyt, Dist>
+{
+  public:
+    squared_euclidean_distance_functor() : distance_functor<Lyt, Dist>(&squared_euclidean_distance<Lyt, Dist>) {}
+};
+/**
  * A pre-defined distance functor that uses the 2DDWave distance.
  *
  * @tparam Lyt Coordinate layout type.
@@ -178,6 +242,18 @@ class twoddwave_distance_functor : public distance_functor<Lyt, Dist>
 {
   public:
     twoddwave_distance_functor() : distance_functor<Lyt, Dist>(&twoddwave_distance<Lyt, Dist>) {}
+};
+/**
+ * A pre-defined distance functor that uses the Chebyshev distance.
+ *
+ * @tparam Lyt Coordinate layout type.
+ * @tparam Dist Integral distance type.
+ */
+template <typename Lyt, typename Dist = uint64_t>
+class chebyshev_distance_functor : public distance_functor<Lyt, Dist>
+{
+  public:
+    chebyshev_distance_functor() : distance_functor<Lyt, Dist>(&chebyshev_distance<Lyt, Dist>) {}
 };
 
 }  // namespace fiction

--- a/include/fiction/algorithms/path_finding/distance.hpp
+++ b/include/fiction/algorithms/path_finding/distance.hpp
@@ -7,6 +7,7 @@
 
 #include "fiction/traits.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <functional>

--- a/test/algorithms/path_finding/distance.cpp
+++ b/test/algorithms/path_finding/distance.cpp
@@ -9,6 +9,7 @@
 #include <fiction/algorithms/path_finding/distance.hpp>
 #include <fiction/layouts/cartesian_layout.hpp>
 #include <fiction/layouts/clocked_layout.hpp>
+#include <fiction/layouts/clocking_scheme.hpp>
 #include <fiction/layouts/coordinates.hpp>
 
 #include <cmath>
@@ -213,6 +214,84 @@ TEST_CASE("Euclidean distance functor", "[distance]")
     }
 }
 
+TEST_CASE("Squared Euclidean distance", "[distance]")
+{
+    SECTION("Unsigned Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<offset::ucoord_t>;
+
+        const cart_lyt layout{};
+
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 0}, {1, 1}) == 2);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {9, 1}, {6, 2}) == 10);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {6, 2}, {0, 4}) == 40);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 4}, {9, 1}) == 90);
+
+        // ignore z-axis
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {6, 2, 1}, {0, 4, 0}) == 40);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {6, 2, 0}, {0, 4, 1}) == 40);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 4, 1}, {9, 1, 1}) == 90);
+    }
+    SECTION("Signed Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<cube::coord_t>;
+
+        const cart_lyt layout{};
+
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 0}, {1, 1}) == 2);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {9, 1}, {6, 2}) == 10);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {6, 2}, {0, 4}) == 40);
+        CHECK(squared_euclidean_distance<cart_lyt>(layout, {0, 4}, {9, 1}) == 90);
+    }
+}
+
+TEST_CASE("Squared Euclidean distance functor", "[distance]")
+{
+    SECTION("Unsigned Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<offset::ucoord_t>;
+
+        const cart_lyt layout{};
+
+        const squared_euclidean_distance_functor<cart_lyt> distance{};
+
+        CHECK(distance(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(distance(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(distance(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(distance(layout, {0, 0}, {1, 1}) == 2);
+        CHECK(distance(layout, {9, 1}, {6, 2}) == 10);
+        CHECK(distance(layout, {6, 2}, {0, 4}) == 40);
+        CHECK(distance(layout, {0, 4}, {9, 1}) == 90);
+
+        // ignore z-axis
+        CHECK(distance(layout, {6, 2, 1}, {0, 4, 0}) == 40);
+        CHECK(distance(layout, {6, 2, 0}, {0, 4, 1}) == 40);
+        CHECK(distance(layout, {0, 4, 1}, {9, 1, 1}) == 90);
+    }
+    SECTION("Signed Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<cube::coord_t>;
+
+        const cart_lyt layout{};
+
+        const squared_euclidean_distance_functor<cart_lyt> distance{};
+
+        CHECK(distance(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(distance(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(distance(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(distance(layout, {0, 0}, {1, 1}) == 2);
+        CHECK(distance(layout, {9, 1}, {6, 2}) == 10);
+        CHECK(distance(layout, {6, 2}, {0, 4}) == 40);
+        CHECK(distance(layout, {0, 4}, {9, 1}) == 90);
+    }
+}
+
 TEST_CASE("2DDWave distance", "[distance]")
 {
     SECTION("Unsigned Cartesian layout")
@@ -313,6 +392,90 @@ TEST_CASE("2DDWave distance functor", "[distance]")
     }
 }
 
+TEST_CASE("Chebyshev distance", "[distance]")
+{
+    SECTION("Unsigned Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<offset::ucoord_t>;
+
+        const cart_lyt layout{};
+
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {1, 1}) == 1);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {1, 2}, {3, 3}) == 2);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {4, 4}) == 4);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {4, 4}, {0, 0}) == 4);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {2, 1}, {0, 2}) == 2);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {1, 0}, {0, 1}) == 1);
+
+        // ignore z-axis
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0, 1}, {8, 9, 0}) == 9);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0, 1}, {8, 9, 1}) == 9);
+    }
+    SECTION("Signed Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<cube::coord_t>;
+
+        const cart_lyt layout{};
+
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {1, 1}) == 1);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {1, 2}, {3, 3}) == 2);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {0, 0}, {4, 4}) == 4);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {4, 4}, {0, 0}) == 4);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {2, 1}, {0, 2}) == 2);
+        CHECK(chebyshev_distance<cart_lyt>(layout, {1, 0}, {0, 1}) == 1);
+    }
+}
+
+TEST_CASE("Chebyshev distance functor", "[distance]")
+{
+    SECTION("Unsigned Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<offset::ucoord_t>;
+
+        const cart_lyt layout{};
+
+        const chebyshev_distance_functor<cart_lyt> distance{};
+
+        CHECK(distance(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(distance(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(distance(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(distance(layout, {0, 0}, {1, 1}) == 1);
+        CHECK(distance(layout, {1, 2}, {3, 3}) == 2);
+        CHECK(distance(layout, {0, 0}, {4, 4}) == 4);
+        CHECK(distance(layout, {4, 4}, {0, 0}) == 4);
+        CHECK(distance(layout, {2, 1}, {0, 2}) == 2);
+        CHECK(distance(layout, {1, 0}, {0, 1}) == 1);
+
+        // ignore z-axis
+        CHECK(distance(layout, {0, 0, 1}, {8, 9, 0}) == 9);
+        CHECK(distance(layout, {0, 0, 1}, {8, 9, 1}) == 9);
+    }
+    SECTION("Signed Cartesian layout")
+    {
+        using cart_lyt = cartesian_layout<cube::coord_t>;
+
+        const cart_lyt layout{};
+
+        const chebyshev_distance_functor<cart_lyt> distance{};
+
+        CHECK(distance(layout, {0, 0}, {0, 0}) == 0);
+        CHECK(distance(layout, {1, 1}, {1, 1}) == 0);
+        CHECK(distance(layout, {0, 0}, {0, 1}) == 1);
+        CHECK(distance(layout, {0, 0}, {1, 1}) == 1);
+        CHECK(distance(layout, {1, 2}, {3, 3}) == 2);
+        CHECK(distance(layout, {0, 0}, {4, 4}) == 4);
+        CHECK(distance(layout, {4, 4}, {0, 0}) == 4);
+        CHECK(distance(layout, {2, 1}, {0, 2}) == 2);
+        CHECK(distance(layout, {1, 0}, {0, 1}) == 1);
+    }
+}
+
 TEST_CASE("A* distance", "[distance]")
 {
     SECTION("Unsigned Cartesian layout")
@@ -385,7 +548,7 @@ TEST_CASE("A* distance", "[distance]")
     }
 }
 
-TEST_CASE("a_star distance functor", "[distance]")
+TEST_CASE("A* distance functor", "[distance]")
 {
     SECTION("Unsigned Cartesian layout")
     {


### PR DESCRIPTION
## Description

This PR adds the [squared Euclidean](https://en.wikipedia.org/wiki/Euclidean_distance#Squared_Euclidean_distance) and the [Chebyshev](https://en.wikipedia.org/wiki/Chebyshev_distance) distance functions to the list of pre-defined ones.

Squared Euclidean is useful when formulating optimization problems that require gradient computation due to its differentiability. Chebyshev on the other hand does not over-account for diagonal moves on non-Cartesian grids.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
