### PR TITLE
:memo: Fix a few oversights in the RTD documentation of SiDB simulation functionality

### DIFF
--- a/docs/algorithms/sidb_simulation.rst
+++ b/docs/algorithms/sidb_simulation.rst
@@ -299,17 +299,18 @@ Displacement Robustness Domain
     .. tab:: C++
         **Header:** ``fiction/algorithms/simulation/sidb/determine_displacement_robustness.hpp``
 
-        .. doxygenenum:: fiction::dimer_displacement_policy
-        .. doxygenstruct:: fiction::displacement_robustness_domain
-           :members:
         .. doxygenstruct:: fiction::displacement_robustness_domain_params
            :members:
         .. doxygenstruct:: fiction::displacement_robustness_domain_stats
+           :members:
+        .. doxygenstruct:: fiction::displacement_robustness_domain
            :members:
         .. doxygenfunction:: fiction::determine_displacement_robustness_domain
         .. doxygenfunction:: fiction::determine_propability_of_fabricating_operational_gate
 
     .. tab:: Python
+        .. autoclass:: mnt.pyfiction.dimer_displacement_policy
+            :members:
         .. autoclass:: mnt.pyfiction.displacement_analysis_mode
             :members:
         .. autofunction:: mnt.pyfiction.displacement_robustness_domain_params

--- a/docs/algorithms/sidb_simulation.rst
+++ b/docs/algorithms/sidb_simulation.rst
@@ -240,6 +240,8 @@ Operational Domain Computation
         .. doxygenenum:: fiction::sweep_parameter
         .. doxygenstruct:: fiction::operational_domain
            :members:
+        .. doxygenstruct:: fiction::operational_domain_value_range
+           :members:
         .. doxygenstruct:: fiction::operational_domain_params
            :members:
         .. doxygenstruct:: fiction::operational_domain_stats


### PR DESCRIPTION
## Description

`operational_domain_value_range` was missing from the C++ part of the RTD documentation. Additionally, `dimer_displacement_policy` was redundant in the C++ documentation but missing the Python one. This PR fixes these oversights.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
