### PR TITLE
:bug: Fixed disappearing clocking schemes when applying a gate library

### DIFF
--- a/bindings/pyfiction/include/pyfiction/inout/write_svg_layout.hpp
+++ b/bindings/pyfiction/include/pyfiction/inout/write_svg_layout.hpp
@@ -31,7 +31,7 @@ inline void write_svg_layout(pybind11::module& m)
         ;
 
     void (*write_svg_layout_function_pointer)(const py_qca_layout&, const std::string_view&,
-                                              fiction::write_qca_layout_svg_params) =
+                                              const fiction::write_qca_layout_svg_params&) =
         &fiction::write_qca_layout_svg<py_qca_layout>;
 
     m.def("write_qca_layout_svg", write_svg_layout_function_pointer, "layout"_a, "filename"_a,

--- a/cli/cmd/physical_design/ortho.hpp
+++ b/cli/cmd/physical_design/ortho.hpp
@@ -7,11 +7,15 @@
 
 #include <fiction/algorithms/physical_design/orthogonal.hpp>
 #include <fiction/traits.hpp>
+#include <fiction/types.hpp>
+#include <fiction/utils/network_utils.hpp>
 
 #include <alice/alice.hpp>
+#include <mockturtle/utils/stopwatch.hpp>
 #include <mockturtle/views/names_view.hpp>
 #include <nlohmann/json.hpp>
 
+#include <cstdint>
 #include <memory>
 
 namespace alice

--- a/docs/algorithms/sidb_simulation.rst
+++ b/docs/algorithms/sidb_simulation.rst
@@ -240,6 +240,8 @@ Operational Domain Computation
         .. doxygenenum:: fiction::sweep_parameter
         .. doxygenstruct:: fiction::operational_domain
            :members:
+        .. doxygenstruct:: fiction::operational_domain_value_range
+           :members:
         .. doxygenstruct:: fiction::operational_domain_params
            :members:
         .. doxygenstruct:: fiction::operational_domain_stats
@@ -297,17 +299,18 @@ Displacement Robustness Domain
     .. tab:: C++
         **Header:** ``fiction/algorithms/simulation/sidb/determine_displacement_robustness.hpp``
 
-        .. doxygenenum:: fiction::dimer_displacement_policy
-        .. doxygenstruct:: fiction::displacement_robustness_domain
-           :members:
         .. doxygenstruct:: fiction::displacement_robustness_domain_params
            :members:
         .. doxygenstruct:: fiction::displacement_robustness_domain_stats
+           :members:
+        .. doxygenstruct:: fiction::displacement_robustness_domain
            :members:
         .. doxygenfunction:: fiction::determine_displacement_robustness_domain
         .. doxygenfunction:: fiction::determine_probability_of_fabricating_operational_gate
 
     .. tab:: Python
+        .. autoclass:: mnt.pyfiction.dimer_displacement_policy
+            :members:
         .. autoclass:: mnt.pyfiction.displacement_analysis_mode
             :members:
         .. autofunction:: mnt.pyfiction.displacement_robustness_domain_params

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -44,9 +44,23 @@ class apply_gate_library_impl
     {
         cell_lyt.resize(aspect_ratio<CellLyt>{((gate_lyt.x() + 1) * GateLibrary::gate_x_size()) - 1,
                                               ((gate_lyt.y() + 1) * GateLibrary::gate_y_size()) - 1, gate_lyt.z()});
-        cell_lyt.replace_clocking_scheme(gate_lyt.get_clocking_scheme());
         cell_lyt.set_tile_size_x(GateLibrary::gate_x_size());
         cell_lyt.set_tile_size_y(GateLibrary::gate_y_size());
+
+        // if GateLyt and CellLyt are based on the same coordinate type, copy the clocking scheme over
+        if constexpr (std::is_same_v<coordinate<CellLyt>, coordinate<GateLyt>>)
+        {
+            cell_lyt.replace_clocking_scheme(gate_lyt.get_clocking_scheme());
+        }
+        // otherwise, try to find a matching clocking scheme (this will discard overwritten clock numbers)
+        else
+        {
+            if (const auto clk_scheme = get_clocking_scheme<CellLyt>(gate_lyt.get_clocking_scheme().name);
+                clk_scheme.has_value())
+            {
+                cell_lyt.replace_clocking_scheme(clk_scheme.value());
+            }
+        }
     }
 
     /**

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -44,6 +44,7 @@ class apply_gate_library_impl
     {
         cell_lyt.resize(aspect_ratio<CellLyt>{((gate_lyt.x() + 1) * GateLibrary::gate_x_size()) - 1,
                                               ((gate_lyt.y() + 1) * GateLibrary::gate_y_size()) - 1, gate_lyt.z()});
+        cell_lyt.replace_clocking_scheme(gate_lyt.get_clocking_scheme());
         cell_lyt.set_tile_size_x(GateLibrary::gate_x_size());
         cell_lyt.set_tile_size_y(GateLibrary::gate_y_size());
     }

--- a/include/fiction/layouts/clocked_layout.hpp
+++ b/include/fiction/layouts/clocked_layout.hpp
@@ -23,10 +23,10 @@ namespace fiction
 {
 
 /**
- * A layout type to layer on top of a coordinate layout, e.g., cartesian_layout, hexagonal_layout, or tile_based_layout.
- * This type extends the layout by providing a notion of FCN clocking. To this end, it utilizes a clocking scheme that
- * assigns each coordinate in the extended coordinate layout a clock number. These clock numbers can be manually
- * overwritten if necessary.
+ * A layout type to layer on top of a coordinate layout, e.g., `cartesian_layout`, `hexagonal_layout`, or
+ * `tile_based_layout`. This type extends the layout by providing a notion of FCN clocking. To this end, it utilizes a
+ * clocking scheme that assigns each coordinate in the extended coordinate layout a clock number. These clock numbers
+ * can be manually overwritten if necessary.
  *
  * In the context of this layout type, coordinates are renamed as clock zones.
  *

--- a/include/fiction/layouts/clocking_scheme.hpp
+++ b/include/fiction/layouts/clocking_scheme.hpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <exception>
 #include <functional>
 #include <optional>
 #include <string>


### PR DESCRIPTION
## Description

#317 broke `apply_gate_library` as it would no longer copy the clocking scheme from the given `gate_level_layout` to the newly created `cell_level_layout`. This PR fixes the breaking change and also cleans up some related code that I came across while debugging.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
