### PR TITLE
:memo: Fix documentation for BDL wire detection

### DIFF
--- a/bindings/pyfiction/include/pyfiction/algorithms/simulation/sidb/detect_bdl_wires.hpp
+++ b/bindings/pyfiction/include/pyfiction/algorithms/simulation/sidb/detect_bdl_wires.hpp
@@ -21,7 +21,7 @@ namespace detail
 {
 
 template <typename Lyt>
-void detect_bdl_wires(pybind11::module& m, const std::string& lattice = "")
+void detect_bdl_wires(pybind11::module& m, const std::string& lattice)
 {
     using namespace pybind11::literals;
     namespace py = pybind11;

--- a/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -934,8 +934,8 @@ static const char *__doc_fiction_bdl_wire =
 R"doc(This struct encapsulates a vector of `bdl_pair` objects, representing
 the pairs of SiDBs in the BDL wire.
 
-Template parameter ``CellType``:
-    Cell type.)doc";
+Template parameter ``Lyt``:
+    SiDB cell-level layout type.)doc";
 
 static const char *__doc_fiction_bdl_wire_add_bdl_pair =
 R"doc(Add a BDL pair to the wire.
@@ -4830,12 +4830,6 @@ R"doc(Aggregates BDL pairs of specified types into a set.
 
 Template parameter ``Lyt``:
     SiDB cell-level layout type.
-
-Parameter ``lyt``:
-    Layout type used for detection.
-
-Parameter ``params``:
-    Parameters containing BDL pairs.
 
 Returns:
     A set of BDL pairs containing all pairs of the specified types.)doc";

--- a/docs/algorithms/sidb_simulation.rst
+++ b/docs/algorithms/sidb_simulation.rst
@@ -378,6 +378,7 @@ Charge Detection
     .. tab:: Python
         .. autofunction:: mnt.pyfiction.can_positive_charges_occur
 
+
 Binary-dot Logic (BDL) Pair Detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -398,6 +399,7 @@ Binary-dot Logic (BDL) Pair Detection
             :members:
         .. autofunction:: mnt.pyfiction.detect_bdl_pairs
 
+
 Binary-dot Logic (BDL) Wire Detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -405,24 +407,24 @@ Binary-dot Logic (BDL) Wire Detection
     .. tab:: C++
         **Header:** ``fiction/algorithms/simulation/sidb/detect_bdl_wires.hpp``
 
-        .. doxygenenum:: fiction::bdl_wire_direction
         .. doxygenenum:: fiction::bdl_wire_selection
         .. doxygenstruct:: fiction::detect_bdl_wires_params
            :members:
-        .. doxygenfunction:: fiction::find_bdl_pair_in_wire_by_type
-        .. doxygenfunction:: fiction::determine_wire_direction
-        .. doxygenfunction:: fiction::find_bdl_neighbor_above
-        .. doxygenfunction:: fiction::find_bdl_neighbor_below
+        .. doxygenstruct:: fiction::bdl_wire
+           :members:
         .. doxygenfunction:: fiction::detect_bdl_wires
 
     .. tab:: Python
-        .. autoclass:: mnt.pyfiction.bdl_wire_direction
-            :members:
         .. autoclass:: mnt.pyfiction.bdl_wire_selection
             :members:
         .. autoclass:: mnt.pyfiction.detect_bdl_wires_params
             :members:
-        .. autofunction:: mnt.pyfiction.detect_bdl_wires
+        .. autoclass:: mnt.pyfiction.bdl_wire_100
+            :members:
+        .. autoclass:: mnt.pyfiction.bdl_wire_111
+            :members:
+        .. autofunction:: mnt.pyfiction.detect_bdl_wires_100
+        .. autofunction:: mnt.pyfiction.detect_bdl_wires_111
 
 
 Assess Population Stability
@@ -447,6 +449,7 @@ Assess Population Stability
         .. autoclass:: mnt.pyfiction.assess_physical_population_stability_params
             :members:
         .. autofunction:: mnt.pyfiction.assess_physical_population_stability
+
 
 Convert Potential to Distance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/include/fiction/algorithms/simulation/sidb/detect_bdl_wires.hpp
+++ b/include/fiction/algorithms/simulation/sidb/detect_bdl_wires.hpp
@@ -59,7 +59,7 @@ struct detect_bdl_wires_params
 /**
  * This struct encapsulates a vector of `bdl_pair` objects, representing the pairs of SiDBs in the BDL wire.
  *
- * @tparam CellType Cell type.
+ * @tparam Lyt SiDB cell-level layout type.
  */
 template <typename Lyt>
 struct bdl_wire
@@ -68,27 +68,26 @@ struct bdl_wire
      * Vector of BDL pairs representing the wire.
      */
     std::vector<bdl_pair<cell<Lyt>>> pairs{};
-
     /**
      * Port of the BDL wire.
      */
     port_direction port{port_direction::NONE};
-
     /**
      * First BDL pair of the wire.
      */
     std::optional<bdl_pair<cell<Lyt>>> first_bdl_pair{};
-
     /**
      * Last BDL pair of the wire.
      */
     std::optional<bdl_pair<cell<Lyt>>> last_bdl_pair{};
-
     /**
      * Default constructor for an empty BDL wire.
      */
     bdl_wire() noexcept
     {
+        static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
+        static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
+
         update_direction();
     }
 
@@ -101,6 +100,9 @@ struct bdl_wire
      */
     explicit bdl_wire(const std::vector<bdl_pair<cell<Lyt>>>& p) noexcept : pairs(p)
     {
+        static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
+        static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
+
         if (!pairs.empty())
         {
             first_bdl_pair = pairs.front();
@@ -121,7 +123,10 @@ struct bdl_wire
             port(other.port),
             first_bdl_pair(other.first_bdl_pair),
             last_bdl_pair(other.last_bdl_pair)
-    {}
+    {
+        static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
+        static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
+    }
 
     /**
      * Move constructor.
@@ -136,6 +141,9 @@ struct bdl_wire
             first_bdl_pair(std::move(other.first_bdl_pair)),
             last_bdl_pair(std::move(other.last_bdl_pair))
     {
+        static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
+        static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
+
         other.port.dir = port_direction::NONE;  // Reset the port of the moved-from object
     }
 
@@ -157,6 +165,7 @@ struct bdl_wire
             last_bdl_pair  = std::move(other.last_bdl_pair);
             other.port.dir = port_direction::NONE;  // Reset the port of the moved-from object
         }
+
         return *this;
     }
 
@@ -627,8 +636,6 @@ class detect_bdl_wires_impl
      * Aggregates BDL pairs of specified types into a set.
      *
      * @tparam Lyt SiDB cell-level layout type.
-     * @param lyt Layout type used for detection.
-     * @param params Parameters containing BDL pairs.
      * @return A set of BDL pairs containing all pairs of the specified types.
      */
     [[nodiscard]] std::set<bdl_pair<cell<Lyt>>> aggregate_bdl_pairs() const noexcept


### PR DESCRIPTION
## Description

Fixed some minor oversights in the documentation of BDL wire detection. Some documented functions did not exist anymore while other structs were not captured.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
