### PR TITLE
🐛 Adapted optimization algorithms to handle layouts with PIs not placed at borders

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_.
 
+Unreleased
+----------
+
+Fixed
+#####
+- Adapted ``post-layout optimization`` and ``wiring reduction`` to handle layouts with PIs not placed at the borders
+
+
 v0.6.5 - 2024-10-22
 -------------------
 

--- a/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
+++ b/include/fiction/algorithms/physical_design/post_layout_optimization.hpp
@@ -1044,21 +1044,6 @@ class post_layout_optimization_impl
             }
         }
 
-        // if gate is a PI and directly connected to its fanout, no improvement is possible
-        if (lyt.is_pi_tile(old_pos))
-        {
-            for (const auto& fanout : fanouts)
-            {
-                for (const auto& outgoing_tile : lyt.outgoing_data_flow(old_pos))
-                {
-                    if (outgoing_tile == fanout)
-                    {
-                        return false;
-                    }
-                }
-            }
-        }
-
         // remove wiring
         for (const auto& tile : to_clear)
         {

--- a/include/fiction/algorithms/physical_design/wiring_reduction.hpp
+++ b/include/fiction/algorithms/physical_design/wiring_reduction.hpp
@@ -1037,12 +1037,10 @@ void delete_wires(Lyt& lyt, WiringReductionLyt& wiring_reduction_layout,
     }
 
     // calculate bounding box for optimized layout size
-    const auto bounding_box            = bounding_box_2d(lyt);
-    const auto optimized_layout_width  = bounding_box.get_x_size();
-    const auto optimized_layout_height = bounding_box.get_y_size();
+    const auto bounding_box = bounding_box_2d(lyt);
 
     // resize the layout to the optimized size
-    lyt.resize({optimized_layout_width, optimized_layout_height, lyt.z()});
+    lyt.resize({bounding_box.get_max().x, bounding_box.get_max().y, lyt.z()});
 }
 
 template <typename Lyt>

--- a/test/algorithms/physical_design/post_layout_optimization.cpp
+++ b/test/algorithms/physical_design/post_layout_optimization.cpp
@@ -123,6 +123,14 @@ TEST_CASE("Layout equivalence", "[post_layout_optimization]")
             post_layout_optimization<gate_layout>(layout_corner_case_2, {}, &stats_corner_case_2);
             check_eq(blueprints::optimization_layout_corner_case_outputs_2<gate_layout>(), layout_corner_case_2);
         }
+
+        SECTION("optimization_layout_corner_case_inputs")
+        {
+            const auto layout_corner_case_3 = blueprints::optimization_layout_corner_case_inputs<gate_layout>();
+            post_layout_optimization_stats stats_corner_case_3{};
+            post_layout_optimization<gate_layout>(layout_corner_case_3, {}, &stats_corner_case_3);
+            check_eq(blueprints::optimization_layout_corner_case_inputs<gate_layout>(), layout_corner_case_3);
+        }
     }
 
     SECTION("Maximum gate relocations")

--- a/test/algorithms/physical_design/wiring_reduction.cpp
+++ b/test/algorithms/physical_design/wiring_reduction.cpp
@@ -113,6 +113,11 @@ TEST_CASE("Layout equivalence", "[wiring_reduction]")
         wiring_reduction_stats stats_corner_case_2{};
         wiring_reduction<gate_layout>(layout_corner_case_2, {}, &stats_corner_case_2);
         check_eq(blueprints::optimization_layout_corner_case_outputs_2<gate_layout>(), layout_corner_case_2);
+
+        const auto             layout_corner_case_3 = blueprints::optimization_layout_corner_case_inputs<gate_layout>();
+        wiring_reduction_stats stats_corner_case_3{};
+        wiring_reduction<gate_layout>(layout_corner_case_3, {}, &stats_corner_case_3);
+        check_eq(blueprints::optimization_layout_corner_case_inputs<gate_layout>(), layout_corner_case_3);
     }
 
     SECTION("Timeout")

--- a/test/benchmark/post_layout_optimization.cpp
+++ b/test/benchmark/post_layout_optimization.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Benchmark Post-Layout Optimization", "[benchmark]")
     };
 }
 
-//  Mac M1, Sonoma 14.6.1, Apple clang version 15.0.0 (14.10.24)
+//  Mac M1, Sonoma 14.6.1, Apple clang version 15.0.0 (07.11.24)
 // -------------------------------------------------------------------------------
 // Benchmark Post-Layout Optimization
 // -------------------------------------------------------------------------------
@@ -63,14 +63,14 @@ TEST_CASE("Benchmark Post-Layout Optimization", "[benchmark]")
 //                                      std dev       low std dev   high std dev
 // -------------------------------------------------------------------------------
 // post_layout_optimization: full
-// optimization                                   100             1     3.08351 m
-//                                          1.80757 s     1.80401 s     1.81184 s
-//                                         19.6917 ms    16.8471 ms    23.0171 ms
+// optimization                                   100             1     2.94146 m
+//                                          1.77164 s     1.76488 s     1.78234 s
+//                                         42.7398 ms    30.7818 ms    67.1015 ms
 //
 // post_layout_optimization: wiring
-// reduction only                                 100             1     3.31998 s
-//                                         33.2883 ms    33.1682 ms    33.4216 ms
-//                                         647.063 us    559.353 us    778.412 us
+// reduction only                                 100             1     3.18196 s
+//                                         31.6457 ms    31.5807 ms    31.7191 ms
+//                                         352.788 us    307.317 us    418.116 us
 //
 //
 // ===============================================================================

--- a/test/utils/blueprints/layout_blueprints.hpp
+++ b/test/utils/blueprints/layout_blueprints.hpp
@@ -536,6 +536,20 @@ GateLyt optimization_layout_corner_case_outputs_2() noexcept
 }
 
 template <typename GateLyt>
+GateLyt optimization_layout_corner_case_inputs() noexcept
+{
+    GateLyt layout{{3, 2, 0}, fiction::twoddwave_clocking<GateLyt>()};
+
+    const auto x1 = layout.create_pi("x1", {2, 1});
+    const auto x2 = layout.create_pi("x2", {1, 2});
+
+    const auto and1 = layout.create_and(x1, x2, {2, 2});
+    layout.create_po(and1, "f1", {3, 2});
+
+    return layout;
+}
+
+template <typename GateLyt>
 GateLyt planar_unoptimized_layout() noexcept
 {
     GateLyt layout{{4, 4, 0}, fiction::twoddwave_clocking<GateLyt>()};


### PR DESCRIPTION
## Description

- changed bounding box calculation in `wiring_reduction` to take empty columns /rows to the left/top of other gates into account
- during `post-layout optimization`, PIs can be moved even if connected to its fanout directly

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
