### PR TITLE
:snake: Disable global interpreter lock for Python 3.13

### DIFF
--- a/bindings/pyfiction/pyfiction.cpp
+++ b/bindings/pyfiction/pyfiction.cpp
@@ -95,7 +95,7 @@
 
 #include <pybind11/pybind11.h>
 
-PYBIND11_MODULE(pyfiction, m)
+PYBIND11_MODULE(pyfiction, m, pybind11::mod_gil_not_used())
 {
     // docstring
     m.doc() = "Python bindings for fiction, a framework for Design Automation for Field-coupled Nanotechnologies";


### PR DESCRIPTION
## Description

This PR marks `pyfiction` as safe to run without the global interpreter lock when using CPython 3.13.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
