### PR TITLE
:green_heart: Remove explicit XCode version setup for macOS 13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,11 +79,6 @@ jobs:
       - name: Setup TBB
         run: brew install tbb
 
-      - name: Setup XCode version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "^14.2"
-
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -79,6 +79,12 @@ jobs:
       - name: Setup TBB
         run: brew install tbb
 
+      - name: Setup XCode version
+        if: matrix.os == 'macos-13'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "^14.2"
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:


### PR DESCRIPTION
## Description

This fixed a CI issue where the XCode version setup led to an error because it was no longer available on the macOS 14 runners. Since macOS didn't require this explicit version setup anyway, this PR removes it accordingly. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
