### PR TITLE
:construction_worker: Attest build provenance to our wheels and sdist

### DIFF
--- a/.github/workflows/pyfiction-pypi-deployment.yml
+++ b/.github/workflows/pyfiction-pypi-deployment.yml
@@ -34,6 +34,11 @@ on:
     types:
       - completed
 
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -54,7 +59,7 @@ jobs:
           - { os: macos-13, arch: x64 }
           - { os: macos-14, arch: arm64 }
           - { os: windows-2019, arch: x64 }
-        python: ['cp38', 'cp39', 'cp310', 'cp311', 'cp312', 'cp313']
+        python: [ 'cp38', 'cp39', 'cp310', 'cp311', 'cp312', 'cp313' ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -162,9 +167,15 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Generate artifact attestation for sdist and wheel(s)
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/*"
+
       - name: Deploy to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_DEPLOY_TOKEN }}
+          attestations: true
           skip-existing: true
           verbose: true


### PR DESCRIPTION
## Description

This PR updates the PyPI deployment script to attest build provenance to the wheels and sdist.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
