### PR TITLE
:whale: Unify Dockerfile labels to conform to the Open Container Initiative (OCI) standard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,16 @@ FROM ubuntu:24.04
 # Optional argument to run the "make" command in parallel with the specified NUMBER_OF_JOBS
 ARG NUMBER_OF_JOBS=4
 
-# Metadata labels
-LABEL maintainer="Marcel Walter <marcel.walter@tum.de>"
-LABEL organization="Chair for Design Automation, Technical University of Munich"
-LABEL description="Docker image for fiction, an open-source design automation framework for Field-coupled Nanotechnologies."
-LABEL license="MIT"
-LABEL url="https://www.cda.cit.tum.de/research/nanotech/"
-LABEL vcs-url="https://github.com/cda-tum/fiction"
+# Unified metadata labels for DockerHub and the Open Container Initiative (OCI)
+LABEL maintainer="Marcel Walter <marcel.walter@tum.de>" \
+      org.opencontainers.image.title="fiction" \
+      org.opencontainers.image.description="Docker image for fiction, an open-source design automation framework for Field-coupled Nanotechnologies." \
+      org.opencontainers.image.authors="Marcel Walter <marcel.walter@tum.de>, Jan Drewniok <jan.drewniok@tum.de>, Simon Hofmann <simon.t.hofmann@tum.de>, Benjamin Hien <benjamin.hien@tum.de>, Willem Lambooy <willem.lambooy@tum.de>" \
+      org.opencontainers.image.url="https://www.cda.cit.tum.de/research/nanotech/" \
+      org.opencontainers.image.source="https://github.com/cda-tum/fiction" \
+      org.opencontainers.image.documentation="https://fiction.readthedocs.io/" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Chair for Design Automation, Technical University of Munich (TUM)"
 
 
 # Configure apt and install required packages


### PR DESCRIPTION
## Description

This PR streamlines the `Dockerfile` metadata labels to be compatible with the [Open Container Initiative (OCI)](https://opencontainers.org/) standard tags found here: https://github.com/opencontainers/image-spec/blob/main/annotations.md

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
