### PR TITLE
:bug: Enforce runtime evaluation of dynamic formatting strings to fix `consteval` contexts

### DIFF
--- a/include/fiction/io/print_layout.hpp
+++ b/include/fiction/io/print_layout.hpp
@@ -7,9 +7,7 @@
 
 #include "fiction/layouts/bounding_box.hpp"
 #include "fiction/technology/cell_technologies.hpp"
-#include "fiction/technology/charge_distribution_surface.hpp"
 #include "fiction/technology/sidb_charge_state.hpp"
-#include "fiction/technology/sidb_defect_surface.hpp"
 #include "fiction/technology/sidb_defects.hpp"
 #include "fiction/technology/sidb_lattice.hpp"
 #include "fiction/technology/sidb_lattice_orientations.hpp"

--- a/include/fiction/io/write_svg_layout.hpp
+++ b/include/fiction/io/write_svg_layout.hpp
@@ -851,7 +851,7 @@ class write_qca_layout_svg_impl
                         if (lyt.is_synchronization_element(c))
                         {
                             cell_descriptions
-                                << fmt::format(desc_col.first, desc_col.second,
+                                << fmt::format(fmt::runtime(desc_col.first), desc_col.second,
                                                svg::STARTING_OFFSET_TILE_X + svg::STARTING_OFFSET_LATCH_CELL_X +
                                                    (c.x * svg::CELL_DISTANCE),
                                                svg::STARTING_OFFSET_TILE_Y + svg::STARTING_OFFSET_LATCH_CELL_Y +
@@ -863,7 +863,7 @@ class write_qca_layout_svg_impl
                     if (!is_sync_elem)
                     {
                         cell_descriptions << fmt::format(
-                            desc_col.first, desc_col.second,
+                            fmt::runtime(desc_col.first), desc_col.second,
                             svg::STARTING_OFFSET_TILE_X + svg::STARTING_OFFSET_CELL_X + (c.x * svg::CELL_DISTANCE),
                             svg::STARTING_OFFSET_TILE_Y + svg::STARTING_OFFSET_CELL_Y + (c.y * svg::CELL_DISTANCE));
                     }
@@ -959,7 +959,7 @@ class write_qca_layout_svg_impl
                         if (const auto latch_delay = lyt.get_synchronization_element(c); latch_delay > 0)
                         {
                             coord_to_latch_cells[tile_coords] = current_cells.append(
-                                fmt::format(desc_col.first, desc_col.second,
+                                fmt::format(fmt::runtime(desc_col.first), desc_col.second,
                                             svg::STARTING_OFFSET_LATCH_CELL_X + (in_tile.x * svg::CELL_DISTANCE),
                                             svg::STARTING_OFFSET_LATCH_CELL_Y + (in_tile.y * svg::CELL_DISTANCE)));
 
@@ -970,7 +970,7 @@ class write_qca_layout_svg_impl
                     if (!is_sync_elem)
                     {
                         coord_to_cells[tile_coords] = current_cells.append(
-                            fmt::format(desc_col.first, desc_col.second,
+                            fmt::format(fmt::runtime(desc_col.first), desc_col.second,
                                         svg::STARTING_OFFSET_CELL_X + (in_tile.x * svg::CELL_DISTANCE),
                                         svg::STARTING_OFFSET_CELL_Y + (in_tile.y * svg::CELL_DISTANCE)));
                     }
@@ -1031,7 +1031,7 @@ class write_qca_layout_svg_impl
             const double y_pos = svg::STARTING_OFFSET_TILE_Y + (coord.y * svg::TILE_DISTANCE);
 
             const auto c_descr =
-                fmt::format(descr, x_pos, y_pos, tile_colors[czone], cell_descriptions,
+                fmt::format(fmt::runtime(descr), x_pos, y_pos, tile_colors[czone], cell_descriptions,
                             ps.simple ? "" : text_colors[czone], ps.simple ? "" : std::to_string(czone + 1));
 
             tile_descriptions << c_descr;
@@ -1051,8 +1051,8 @@ class write_qca_layout_svg_impl
                 const double y_pos = svg::STARTING_OFFSET_LATCH_Y + (coord.y * svg::TILE_DISTANCE);
 
                 const auto t_descr =
-                    fmt::format(descr, x_pos, y_pos, tile_colors[czone_lo], tile_colors[czone_up], cell_descriptions,
-                                text_colors[czone_up], ps.simple ? "" : std::to_string(czone_up + 1),
+                    fmt::format(fmt::runtime(descr), x_pos, y_pos, tile_colors[czone_lo], tile_colors[czone_up],
+                                cell_descriptions, text_colors[czone_up], ps.simple ? "" : std::to_string(czone_up + 1),
                                 text_colors[czone_lo], ps.simple ? "" : std::to_string(czone_lo + 1));
 
                 tile_descriptions << t_descr;

--- a/include/fiction/layouts/coordinates.hpp
+++ b/include/fiction/layouts/coordinates.hpp
@@ -1082,7 +1082,7 @@ struct formatter<fiction::offset::ucoord_t>
     template <typename FormatContext>
     auto format(const fiction::offset::ucoord_t& c, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "({},{},{})", c.x, c.y, c.z);
+        return format_to(ctx.out(), runtime("({},{},{})"), c.x, c.y, c.z);
     }
 };
 // make cube::coord_t compatible with fmt::format
@@ -1098,7 +1098,7 @@ struct formatter<fiction::cube::coord_t>
     template <typename FormatContext>
     auto format(const fiction::cube::coord_t& c, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "({},{},{})", c.x, c.y, c.z);
+        return format_to(ctx.out(), runtime("({},{},{})"), c.x, c.y, c.z);
     }
 };
 // make siqad::coord_t compatible with fmt::format
@@ -1114,7 +1114,7 @@ struct formatter<fiction::siqad::coord_t>
     template <typename FormatContext>
     auto format(const fiction::siqad::coord_t& c, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "({},{},{})", c.x, c.y, c.z);
+        return format_to(ctx.out(), runtime("({},{},{})"), c.x, c.y, c.z);
     }
 };
 

--- a/include/fiction/technology/cell_ports.hpp
+++ b/include/fiction/technology/cell_ports.hpp
@@ -299,17 +299,53 @@ struct formatter<fiction::port_direction>
     template <typename FormatContext>
     auto format(const fiction::port_direction& p, FormatContext& ctx) const
     {
-        const auto dir = p.dir == fiction::port_direction::NORTH      ? "N" :
-                         p.dir == fiction::port_direction::NORTH_EAST ? "NE" :
-                         p.dir == fiction::port_direction::EAST       ? "E" :
-                         p.dir == fiction::port_direction::SOUTH_EAST ? "SE" :
-                         p.dir == fiction::port_direction::SOUTH      ? "S" :
-                         p.dir == fiction::port_direction::SOUTH_WEST ? "SW" :
-                         p.dir == fiction::port_direction::WEST       ? "W" :
-                         p.dir == fiction::port_direction::NORTH_WEST ? "NW" :
-                                                                        "?";
+        const auto* dir = "?";
 
-        return format_to(ctx.out(), runtime(dir));
+        switch (p.dir)
+        {
+            case fiction::port_direction::NORTH:
+            {
+                dir = "N";
+                break;
+            }
+            case fiction::port_direction::NORTH_EAST:
+            {
+                dir = "NE";
+                break;
+            }
+            case fiction::port_direction::EAST:
+            {
+                dir = "E";
+                break;
+            }
+            case fiction::port_direction::SOUTH_EAST:
+            {
+                dir = "SE";
+                break;
+            }
+            case fiction::port_direction::SOUTH:
+            {
+                dir = "S";
+                break;
+            }
+            case fiction::port_direction::SOUTH_WEST:
+            {
+                dir = "SW";
+                break;
+            }
+            case fiction::port_direction::WEST:
+            {
+                dir = "W";
+                break;
+            }
+            case fiction::port_direction::NORTH_WEST:
+            {
+                dir = "NW";
+                break;
+            }
+        }
+
+        return format_to(ctx.out(), dir);
     }
 };
 // make port_list compatible with fmt::format

--- a/include/fiction/technology/cell_ports.hpp
+++ b/include/fiction/technology/cell_ports.hpp
@@ -283,7 +283,7 @@ struct formatter<fiction::port_position>
     template <typename FormatContext>
     auto format(const fiction::port_position& p, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "({},{})", p.x, p.y);
+        return format_to(ctx.out(), runtime("({},{})"), p.x, p.y);
     }
 };
 // make port_direction compatible with fmt::format
@@ -299,15 +299,17 @@ struct formatter<fiction::port_direction>
     template <typename FormatContext>
     auto format(const fiction::port_direction& p, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), p.dir == fiction::port_direction::NORTH      ? "N" :
-                                    p.dir == fiction::port_direction::NORTH_EAST ? "NE" :
-                                    p.dir == fiction::port_direction::EAST       ? "E" :
-                                    p.dir == fiction::port_direction::SOUTH_EAST ? "SE" :
-                                    p.dir == fiction::port_direction::SOUTH      ? "S" :
-                                    p.dir == fiction::port_direction::SOUTH_WEST ? "SW" :
-                                    p.dir == fiction::port_direction::WEST       ? "W" :
-                                    p.dir == fiction::port_direction::NORTH_WEST ? "NW" :
-                                                                                   "?");
+        const auto dir = p.dir == fiction::port_direction::NORTH      ? "N" :
+                         p.dir == fiction::port_direction::NORTH_EAST ? "NE" :
+                         p.dir == fiction::port_direction::EAST       ? "E" :
+                         p.dir == fiction::port_direction::SOUTH_EAST ? "SE" :
+                         p.dir == fiction::port_direction::SOUTH      ? "S" :
+                         p.dir == fiction::port_direction::SOUTH_WEST ? "SW" :
+                         p.dir == fiction::port_direction::WEST       ? "W" :
+                         p.dir == fiction::port_direction::NORTH_WEST ? "NW" :
+                                                                        "?";
+
+        return format_to(ctx.out(), runtime(dir));
     }
 };
 // make port_list compatible with fmt::format
@@ -323,7 +325,7 @@ struct formatter<fiction::port_list<PortType>>
     template <typename FormatContext>
     auto format(const fiction::port_list<PortType>& pl, FormatContext& ctx) const
     {
-        return format_to(ctx.out(), "inp: {}, out: {}", join(pl.inp, ", "), join(pl.out, ", "));
+        return format_to(ctx.out(), runtime("inp: {}, out: {}"), join(pl.inp, ", "), join(pl.out, ", "));
     }
 };
 }  // namespace fmt


### PR DESCRIPTION
## Description

This PR enforces the use of `fmt::runtime` in scenarios where dynamic formatting strings are used with the `{fmt}` library in order to fix compilation errors when these functions are used in `consteval` contexts.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
