### PR TITLE
:bug: Fixed ``design_sidb_gates`` function for skeletons with east-facing I/O pins.

### DIFF
--- a/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3862,6 +3862,20 @@ static const char *__doc_fiction_design_sidb_gates_stats = R"doc(Statistics for 
 
 static const char *__doc_fiction_design_sidb_gates_stats_duration = R"doc(The total runtime of SiDB gate design process.)doc";
 
+static const char *__doc_fiction_design_sidb_gates_stats_number_of_layouts = R"doc(The number of all possible layouts.)doc";
+
+static const char *__doc_fiction_design_sidb_gates_stats_number_of_layouts_after_first_pruning =
+R"doc(The number of layouts that remain after first pruning (discarding
+layouts with potential positive SiDBs).)doc";
+
+static const char *__doc_fiction_design_sidb_gates_stats_number_of_layouts_after_second_pruning =
+R"doc(The number of layouts that remain after second pruning (discarding
+layouts that fail to satisfy the physical model).)doc";
+
+static const char *__doc_fiction_design_sidb_gates_stats_number_of_layouts_after_third_pruning =
+R"doc(The number of layouts that remain after third pruning (discarding
+layouts with unstable I/O signals).)doc";
+
 static const char *__doc_fiction_design_sidb_gates_stats_report =
 R"doc(This function outputs the total time taken for the SiDB gate design
 process to the provided output stream. If no output stream is
@@ -4718,6 +4732,12 @@ Returns:
     to conduct the final validation.)doc";
 
 static const char *__doc_fiction_detail_design_sidb_gates_impl_num_threads = R"doc(Number of threads to be used for parallel execution.)doc";
+
+static const char *__doc_fiction_detail_design_sidb_gates_impl_number_of_discarded_layouts_at_first_pruning = R"doc(Number of discarded layouts at first pruning.)doc";
+
+static const char *__doc_fiction_detail_design_sidb_gates_impl_number_of_discarded_layouts_at_second_pruning = R"doc(Number of discarded layouts at second pruning.)doc";
+
+static const char *__doc_fiction_detail_design_sidb_gates_impl_number_of_discarded_layouts_at_third_pruning = R"doc(Number of discarded layouts at third pruning.)doc";
 
 static const char *__doc_fiction_detail_design_sidb_gates_impl_number_of_input_wires = R"doc(Number of input BDL wires.)doc";
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,13 +10,37 @@ Unreleased
 
 Added
 #####
+- Algorithms:
+    - Simulation:
+        - Kink control option for critical temperature simulation of SiDB layouts
+- Python bindings:
+    - Support for Python 3.13 (including GIL-free multi-threading)
+- I/O:
+    - SVG drawer for SiDB layouts
+- Experiments:
+    - Ship the SiQAD and Bestagon gate libraries als SQD files
 - Documentation:
     - Added wiring reduction paper to publication list
+    - Added Willem Lambooy to the authors list
+- Continuous integration:
+    - Several improvements to the Docker workflow including publishing images to DockerHub
+
+Changed
+#######
+- Continuous integration:
+    - Exclude long-running tests from the Debug CI workflows
 
 Fixed
 #####
 - Adapted ``post-layout optimization`` and ``wiring reduction`` to handle layouts with PIs not placed at the borders
-
+- Fix neutral defect handling in CDS and correct gate design termination condition
+- Enforce runtime evaluation of dynamic formatting strings to fix consteval contexts
+- Microsoft logo in CI badge by replacing the logo slug with a base64 encoding of the SVG image
+- Remove explicit XCode version setup for macOS 13 CIs
+- Adjusted PyPI deployment target for macOS
+- Several bugs resulting from the new cell_type::LOGIC in the SiDB technology
+- Several compiler and linter warnings
+- Documentation for BDL wire detection
 
 v0.6.5 - 2024-10-22
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,7 @@ Changed
 
 Fixed
 #####
+- Fixed a bug in the gate design when using skeletons with I/O wires facing east.
 - Adapted ``post-layout optimization`` and ``wiring reduction`` to handle layouts with PIs not placed at the borders
 - Fix neutral defect handling in CDS and correct gate design termination condition
 - Enforce runtime evaluation of dynamic formatting strings to fix consteval contexts

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,7 +33,7 @@ Changed
 
 Fixed
 #####
-- Fixed a bug in the gate design when using skeletons with I/O wires facing east.
+- Fixed a bug in SiDB gate design when using skeletons with I/O wires facing east
 - Adapted ``post-layout optimization`` and ``wiring reduction`` to handle layouts with PIs not placed at the borders
 - Fix neutral defect handling in CDS and correct gate design termination condition
 - Enforce runtime evaluation of dynamic formatting strings to fix consteval contexts

--- a/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -916,9 +916,6 @@ class design_sidb_gates_impl
             set_charge_distribution_of_input_wires_based_on_input_pattern(cds_layout, i);
             set_charge_distribution_of_output_wires_based_on_truth_table(cds_layout, i);
 
-            // std::cout << "Input pattern: " << i << std::endl;
-            // print_sidb_layout(std::cout, cds_layout);
-
             const auto physical_validity = is_physical_validity_feasible(cds_layout, cds_canvas);
 
             if (physical_validity.has_value())

--- a/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -390,11 +390,11 @@ class design_sidb_gates_impl
         const auto            gate_candidates = run_pruning();
 
         stats.number_of_layouts_after_first_pruning =
-            all_canvas_layouts.size() - number_of_discarded_layouts_at_first_pruning;
+            all_canvas_layouts.size() - number_of_discarded_layouts_at_first_pruning.load();
         stats.number_of_layouts_after_second_pruning =
-            stats.number_of_layouts_after_first_pruning - number_of_discarded_layouts_at_second_pruning;
+            stats.number_of_layouts_after_first_pruning - number_of_discarded_layouts_at_second_pruning.load();
         stats.number_of_layouts_after_third_pruning =
-            stats.number_of_layouts_after_second_pruning - number_of_discarded_layouts_at_third_pruning;
+            stats.number_of_layouts_after_second_pruning - number_of_discarded_layouts_at_third_pruning.load();
 
         std::vector<Lyt> gate_layouts{};
         gate_layouts.reserve(gate_candidates.size());

--- a/include/fiction/algorithms/simulation/sidb/is_operational.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_operational.hpp
@@ -460,12 +460,12 @@ class is_operational_impl
     [[nodiscard]] bool check_existence_of_kinks_in_input_wires(const charge_distribution_surface<Lyt>& ground_state,
                                                                const uint64_t current_input_index) const noexcept
     {
-        return std::any_of(input_bdl_wires.rbegin(), input_bdl_wires.rend(),
-                           [&, i = 0u](const auto& wire) mutable
+        return std::any_of(input_bdl_wires.crbegin(), input_bdl_wires.crend(),
+                           [this, &ground_state, &current_input_index, i = 0u](const auto& wire) mutable
                            {
                                const auto current_bit_set = (current_input_index & (uint64_t{1ull} << i++)) != 0ull;
                                return std::any_of(wire.pairs.cbegin(), wire.pairs.cend(),
-                                                  [&](const auto& bdl)
+                                                  [this, &ground_state, &current_bit_set, &wire](const auto& bdl)
                                                   {
                                                       if (bdl.type == sidb_technology::INPUT)
                                                       {

--- a/test/algorithms/physical_design/design_sidb_gates.cpp
+++ b/test/algorithms/physical_design/design_sidb_gates.cpp
@@ -28,6 +28,47 @@
 
 using namespace fiction;
 
+TEST_CASE("Design AND gate with skeleton, where one input wire and the output wire are orientated to the east.",
+          "[design-sidb-gates]")
+{
+    const auto lyt = blueprints::two_input_one_output_skeleton_west_west<sidb_100_cell_clk_lyt_siqad>();
+
+    design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>> params{
+        is_operational_params{sidb_simulation_parameters{2, -0.31}, sidb_simulation_engine::QUICKEXACT,
+                              bdl_input_iterator_params{}, operational_condition::REJECT_KINKS},
+        design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::QUICKCELL,
+        {{25, 6, 0}, {30, 8, 0}},
+        3};
+
+    SECTION("QuickCell")
+    {
+        design_sidb_gates_stats design_gates_stats{};
+        const auto              found_gate_layouts =
+            design_sidb_gates(lyt, std::vector<tt>{create_and_tt()}, params, &design_gates_stats);
+        REQUIRE(found_gate_layouts.size() == 20);
+        const auto& first_gate = found_gate_layouts.front();
+        CHECK(is_operational(first_gate, std::vector<tt>{create_and_tt()}, params.operational_params).first ==
+              operational_status::OPERATIONAL);
+
+        CHECK(design_gates_stats.number_of_layouts == 4060);
+        CHECK(design_gates_stats.number_of_layouts_after_first_pruning == 1301);
+        CHECK(design_gates_stats.number_of_layouts_after_second_pruning == 418);
+        CHECK(design_gates_stats.number_of_layouts_after_third_pruning == 21);
+    }
+
+    SECTION("Automatic Exhaustive Gate Designer")
+    {
+        params.design_mode = design_sidb_gates_params<
+            cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER;
+
+        const auto found_gate_layouts = design_sidb_gates(lyt, std::vector<tt>{create_and_tt()}, params);
+        REQUIRE(found_gate_layouts.size() == 20);
+        const auto& first_gate = found_gate_layouts.front();
+        CHECK(is_operational(first_gate, std::vector<tt>{create_and_tt()}, params.operational_params).first ==
+              operational_status::OPERATIONAL);
+    }
+}
+
 TEST_CASE("Use SiQAD XNOR skeleton and generate SiQAD XNOR gate, exhaustive", "[design-sidb-gates]")
 {
     using offset_layout = sidb_100_cell_clk_lyt;
@@ -425,6 +466,7 @@ TEST_CASE("Design NOR Bestagon shaped gate on H-Si 111", "[design-sidb-gates]")
             CHECK(found_gate_layouts.front().num_cells() == lyt.num_cells() + 3);
         }
     }
+
 // to save runtime in the CI, this test is only run in RELEASE mode
 #ifdef NDEBUG
     SECTION("Exhaustive Generation, forbidding kinks")
@@ -534,44 +576,4 @@ TEST_CASE("Design AND gate with input left and output top-right with QuickCell (
     }
 }
 
-TEST_CASE("Design AND gate with skeleton, where one input wire and the output wire are orientated to the east.",
-          "[design-sidb-gates]")
-{
-    const auto lyt = blueprints::two_input_one_output_skeleton_west_west<sidb_100_cell_clk_lyt_siqad>();
-
-    design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>> params{
-        is_operational_params{sidb_simulation_parameters{2, -0.31}, sidb_simulation_engine::QUICKEXACT,
-                              bdl_input_iterator_params{}, operational_condition::REJECT_KINKS},
-        design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::QUICKCELL,
-        {{24, 6, 0}, {32, 10, 0}},
-        3};
-
-    SECTION("QuickCell")
-    {
-        design_sidb_gates_stats design_gates_stats{};
-        const auto              found_gate_layouts =
-            design_sidb_gates(lyt, std::vector<tt>{create_and_tt()}, params, &design_gates_stats);
-        REQUIRE(found_gate_layouts.size() == 157);
-        const auto& first_gate = found_gate_layouts.front();
-        CHECK(is_operational(first_gate, std::vector<tt>{create_and_tt()}, params.operational_params).first ==
-              operational_status::OPERATIONAL);
-
-        CHECK(design_gates_stats.number_of_layouts == 85320);
-        CHECK(design_gates_stats.number_of_layouts_after_first_pruning == 67652);
-        CHECK(design_gates_stats.number_of_layouts_after_second_pruning == 30814);
-        CHECK(design_gates_stats.number_of_layouts_after_third_pruning == 174);
-    }
-
-    SECTION("Automatic Exhaustive Gate Designer")
-    {
-        params.design_mode = design_sidb_gates_params<
-            cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER;
-
-        const auto found_gate_layouts = design_sidb_gates(lyt, std::vector<tt>{create_and_tt()}, params);
-        REQUIRE(found_gate_layouts.size() == 157);
-        const auto& first_gate = found_gate_layouts.front();
-        CHECK(is_operational(first_gate, std::vector<tt>{create_and_tt()}, params.operational_params).first ==
-              operational_status::OPERATIONAL);
-    }
-}
 #endif

--- a/test/algorithms/physical_design/design_sidb_gates.cpp
+++ b/test/algorithms/physical_design/design_sidb_gates.cpp
@@ -533,4 +533,45 @@ TEST_CASE("Design AND gate with input left and output top-right with QuickCell (
               operational_status::OPERATIONAL);
     }
 }
+
+TEST_CASE("Design AND gate with skeleton, where one input wire and the output wire are orientated to the east.",
+          "[design-sidb-gates]")
+{
+    const auto lyt = blueprints::two_input_one_output_skeleton_west_west<sidb_100_cell_clk_lyt_siqad>();
+
+    design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>> params{
+        is_operational_params{sidb_simulation_parameters{2, -0.31}, sidb_simulation_engine::QUICKEXACT,
+                              bdl_input_iterator_params{}, operational_condition::REJECT_KINKS},
+        design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::QUICKCELL,
+        {{24, 6, 0}, {32, 10, 0}},
+        3};
+
+    SECTION("QuickCell")
+    {
+        design_sidb_gates_stats design_gates_stats{};
+        const auto              found_gate_layouts =
+            design_sidb_gates(lyt, std::vector<tt>{create_and_tt()}, params, &design_gates_stats);
+        REQUIRE(found_gate_layouts.size() == 157);
+        const auto& first_gate = found_gate_layouts.front();
+        CHECK(is_operational(first_gate, std::vector<tt>{create_and_tt()}, params.operational_params).first ==
+              operational_status::OPERATIONAL);
+
+        CHECK(design_gates_stats.number_of_layouts == 85320);
+        CHECK(design_gates_stats.number_of_layouts_after_first_pruning == 67652);
+        CHECK(design_gates_stats.number_of_layouts_after_second_pruning == 30814);
+        CHECK(design_gates_stats.number_of_layouts_after_third_pruning == 1);
+    }
+
+    SECTION("Automatic Exhaustive Gate Designer")
+    {
+        params.design_mode = design_sidb_gates_params<
+            cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER;
+
+        const auto found_gate_layouts = design_sidb_gates(lyt, std::vector<tt>{create_and_tt()}, params);
+        REQUIRE(found_gate_layouts.size() == 157);
+        const auto& first_gate = found_gate_layouts.front();
+        CHECK(is_operational(first_gate, std::vector<tt>{create_and_tt()}, params.operational_params).first ==
+              operational_status::OPERATIONAL);
+    }
+}
 #endif

--- a/test/algorithms/physical_design/design_sidb_gates.cpp
+++ b/test/algorithms/physical_design/design_sidb_gates.cpp
@@ -559,7 +559,7 @@ TEST_CASE("Design AND gate with skeleton, where one input wire and the output wi
         CHECK(design_gates_stats.number_of_layouts == 85320);
         CHECK(design_gates_stats.number_of_layouts_after_first_pruning == 67652);
         CHECK(design_gates_stats.number_of_layouts_after_second_pruning == 30814);
-        CHECK(design_gates_stats.number_of_layouts_after_third_pruning == 1);
+        CHECK(design_gates_stats.number_of_layouts_after_third_pruning == 174);
     }
 
     SECTION("Automatic Exhaustive Gate Designer")

--- a/test/utils/blueprints/layout_blueprints.hpp
+++ b/test/utils/blueprints/layout_blueprints.hpp
@@ -1545,6 +1545,51 @@ Lyt bestagon_ha() noexcept
     return lyt;
 };
 
+/**
+ * This layout represents a 2-input-1-output skeleton, where one input and output wire have a port direction to the west.
+ */
+template <typename Lyt>
+Lyt two_input_one_output_skeleton_west_west() noexcept
+{
+    static_assert(fiction::is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
+    static_assert(fiction::has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
+    static_assert(fiction::has_siqad_coord_v<Lyt>, "Lyt is not based on SiQAD coordinates");
+
+    Lyt lyt{};
+
+    // input wires
+    lyt.assign_cell_type({4, 9, 1}, Lyt::cell_type::INPUT);
+    lyt.assign_cell_type({1, 9, 1}, Lyt::cell_type::INPUT);
+
+    lyt.assign_cell_type({14, 0, 0}, Lyt::cell_type::INPUT);
+    lyt.assign_cell_type({16, 1, 0}, Lyt::cell_type::INPUT);
+
+    lyt.assign_cell_type({26, 4, 0}, Lyt::cell_type::NORMAL);
+    lyt.assign_cell_type({28, 5, 0}, Lyt::cell_type::NORMAL);
+
+    lyt.assign_cell_type({19, 9, 1}, Lyt::cell_type::NORMAL);
+    lyt.assign_cell_type({16, 9, 1}, Lyt::cell_type::NORMAL);
+
+    lyt.assign_cell_type({11, 9, 1}, Lyt::cell_type::NORMAL);
+    lyt.assign_cell_type({8, 9, 1}, Lyt::cell_type::NORMAL);
+
+    lyt.assign_cell_type({36, 9, 1}, Lyt::cell_type::NORMAL);
+    lyt.assign_cell_type({39, 9, 1}, Lyt::cell_type::NORMAL);
+
+    lyt.assign_cell_type({44, 9, 1}, Lyt::cell_type::NORMAL);
+    lyt.assign_cell_type({47, 9, 1}, Lyt::cell_type::NORMAL);
+
+    lyt.assign_cell_type({22, 3, 0}, Lyt::cell_type::NORMAL);
+    lyt.assign_cell_type({20, 2, 0}, Lyt::cell_type::NORMAL);
+
+    lyt.assign_cell_type({52, 9, 1}, Lyt::cell_type::OUTPUT);
+    lyt.assign_cell_type({55, 9, 1}, Lyt::cell_type::OUTPUT);
+
+    lyt.assign_cell_type({60, 9, 1}, Lyt::cell_type::NORMAL);
+
+    return lyt;
+};
+
 }  // namespace blueprints
 
 #endif  // FICTION_LAYOUT_BLUEPRINTS_HPP


### PR DESCRIPTION
## Description

This PR fixes the following bug in the ``design_sidb_gates`` function: When using a gate skeleton with wires facing east, the gate design would not work. 

The error occurred during the second pruning step when using _QuickCell_ for designing SiDB gates. During this step, the feasibility of the physical validity is checked by toggling through different input patterns and adjusting the charge distribution of the I/O pins accordingly. However, the logic failed for I/O pins facing east because this specific case was not accounted for in the if statement. This is now fixed.
 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
