### PR TITLE
:snake: Drop Python 3.8 support due to its end-of-life status

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ submodules:
   recursive: true
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.12"
   apt_packages:
     - cmake
   jobs:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,7 +22,7 @@ them automatically. Should the repository have been cloned before, the commands:
   git submodule update --init --recursive
 
 will fetch the latest version of all external modules used. Additionally, only ``CMake`` and a C++17 compiler are
-required for the C++ part. If you want to work with the Python bindings, you need a Python 3.8+ installation.
+required for the C++ part. If you want to work with the Python bindings, you need a Python 3.9+ installation.
 
 At the time of writing, for parallel STL algorithms to work when using GCC, the TBB library (``libtbb-dev`` on Ubuntu) is
 needed. It is an optional dependency that can be installed for a performance boost in certain scenarios. For your

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 
 nox.options.sessions = ["lint", "tests", "minimums"]
 
-PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_ALL_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 # The following lists all the build requirements for building the package.
 # Note that this includes transitive build dependencies of package dependencies,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     'Development Status :: 4 - Beta',
     'Programming Language :: Python :: 3',
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -41,7 +40,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "z3-solver>=4.8.0"
 ]
@@ -180,7 +179,6 @@ reinstall-package = ["mnt.pyfiction"]
 [tool.mypy]
 files = ["bindings/mnt/pyfiction", "noxfile.py"]
 mypy_path = ["$MYPY_CONFIG_FILE_DIR/bindings"]
-python_version = "3.8"
 warn_unused_configs = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true


### PR DESCRIPTION
## Description

This PR removes support for Python 3.8 because that version reached end-of-life almost 3 months ago. See https://devguide.python.org/versions/ for details on Python's release schedule.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
