### PR TITLE
:bug: Fixed layout resizing in `apply_gate_library`

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -4638,9 +4638,7 @@ Parameter ``n``:
 
 static const char *__doc_fiction_detail_apply_gate_library_impl_cell_lyt = R"doc(Cell-level layout.)doc";
 
-static const char *__doc_fiction_detail_apply_gate_library_impl_gate_lyt = R"doc(Gate-level layout.)doc";
-
-static const char *__doc_fiction_detail_apply_gate_library_impl_get_aspect_ratio_for_cell_level_layout =
+static const char *__doc_fiction_detail_apply_gate_library_impl_determine_aspect_ratio_for_cell_level_layout =
 R"doc(Computes the (inclusively) bounding coordinate for a cell-level layout
 that is derived from the dimensions of the given gate-level layout,
 while respecting tiling geometry in which even and odd rows/columns do
@@ -4652,6 +4650,8 @@ Parameter ``gate_lyt``:
 Returns:
     Aspect ratio for a cell-level layout that corresponds to the
     dimensions of the given gate-level layout.)doc";
+
+static const char *__doc_fiction_detail_apply_gate_library_impl_gate_lyt = R"doc(Gate-level layout.)doc";
 
 static const char *__doc_fiction_detail_apply_gate_library_impl_run_parameterized_gate_library =
 R"doc(Run the cell layout generation process.

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -4640,6 +4640,19 @@ static const char *__doc_fiction_detail_apply_gate_library_impl_cell_lyt = R"doc
 
 static const char *__doc_fiction_detail_apply_gate_library_impl_gate_lyt = R"doc(Gate-level layout.)doc";
 
+static const char *__doc_fiction_detail_apply_gate_library_impl_get_aspect_ratio_for_cell_level_layout =
+R"doc(Computes the (inclusively) bounding coordinate for a cell-level layout
+that is derived from the dimensions of the given gate-level layout,
+while respecting tiling geometry in which even and odd rows/columns do
+not line up.
+
+Parameter ``gate_lyt``:
+    Gate-level layout of which the dimensions are read.
+
+Returns:
+    Aspect ratio for a cell-level layout that corresponds to the
+    dimensions of the given gate-level layout.)doc";
+
 static const char *__doc_fiction_detail_apply_gate_library_impl_run_parameterized_gate_library =
 R"doc(Run the cell layout generation process.
 

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -1,4 +1,4 @@
-asdf//
+//
 // Created by marcel on 28.06.21.
 //
 

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -40,7 +40,7 @@ class apply_gate_library_impl
   public:
     explicit apply_gate_library_impl(const GateLyt& lyt) :
             gate_lyt{lyt},
-            cell_lyt{get_aspect_ratio_for_cell_level_layout(gate_lyt)}
+            cell_lyt{determine_aspect_ratio_for_cell_level_layout(gate_lyt)}
     {
         cell_lyt.set_tile_size_x(GateLibrary::gate_x_size());
         cell_lyt.set_tile_size_y(GateLibrary::gate_y_size());

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -221,7 +221,7 @@ class apply_gate_library_impl
         const std::function<cell<CellLyt>(GateLyt, tile<GateLyt>, cell<CellLyt>)> rel_to_abs_cell_pos =
             relative_to_absolute_cell_position<GateLibrary::gate_x_size(), GateLibrary::gate_y_size(), GateLyt,
                                                CellLyt>;
-      
+
         const cell<CellLyt> max_rel_coord = {GateLibrary::gate_x_size() - 1, GateLibrary::gate_y_size() - 1};
 
         const cell<CellLyt> first_odd_tile = {gate_lyt.x() != 0 ? 1 : 0, gate_lyt.y() != 0 ? 1 : 0};

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -1,4 +1,4 @@
-//
+asdf//
 // Created by marcel on 28.06.21.
 //
 

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -18,6 +18,7 @@
 #include <mockturtle/traits.hpp>
 
 #include <algorithm>
+#include <functional>
 #include <type_traits>
 
 // data types cannot properly be converted to bit field types
@@ -217,9 +218,10 @@ class apply_gate_library_impl
      */
     static aspect_ratio<CellLyt> determine_aspect_ratio_for_cell_level_layout(const GateLyt& gate_lyt) noexcept
     {
-        using rel_to_abs_cell_pos = relative_to_absolute_cell_position<GateLibrary::gate_x_size(),
-                                                                       GateLibrary::gate_y_size(), GateLyt, CellLyt>;
-
+        const std::function<cell<CellLyt>(GateLyt, tile<GateLyt>, cell<CellLyt>)> rel_to_abs_cell_pos =
+            relative_to_absolute_cell_position<GateLibrary::gate_x_size(), GateLibrary::gate_y_size(), GateLyt,
+                                               CellLyt>;
+      
         const cell<CellLyt> max_rel_coord = {GateLibrary::gate_x_size() - 1, GateLibrary::gate_y_size() - 1};
 
         const cell<CellLyt> first_odd_tile = {gate_lyt.x() != 0 ? 1 : 0, gate_lyt.y() != 0 ? 1 : 0};

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -17,6 +17,8 @@
 #endif
 #include <mockturtle/traits.hpp>
 
+#include <algorithm>
+#include <functional>
 #include <type_traits>
 
 // data types cannot properly be converted to bit field types
@@ -37,10 +39,10 @@ template <typename CellLyt, typename GateLibrary, typename GateLyt>
 class apply_gate_library_impl
 {
   public:
-    explicit apply_gate_library_impl(const GateLyt& lyt) : gate_lyt{lyt}, cell_lyt{}
+    explicit apply_gate_library_impl(const GateLyt& lyt) :
+            gate_lyt{lyt},
+            cell_lyt{get_aspect_ratio_for_cell_level_layout(gate_lyt)}
     {
-        cell_lyt.resize(aspect_ratio<CellLyt>{((gate_lyt.x() + 1) * GateLibrary::gate_x_size()) - 1,
-                                              ((gate_lyt.y() + 1) * GateLibrary::gate_y_size()) - 1, gate_lyt.z()});
         cell_lyt.set_tile_size_x(GateLibrary::gate_x_size());
         cell_lyt.set_tile_size_y(GateLibrary::gate_y_size());
 
@@ -206,6 +208,30 @@ class apply_gate_library_impl
                 }
             }
         }
+    }
+    /**
+     * Computes the (inclusively) bounding coordinate for a cell-level layout that is derived from the dimensions of the
+     * given gate-level layout, while respecting tiling geometry in which even and odd rows/columns do not line up.
+     *
+     * @param gate_lyt Gate-level layout of which the dimensions are read.
+     * @return Aspect ratio for a cell-level layout that corresponds to the dimensions of the given gate-level layout.
+     */
+    static aspect_ratio<CellLyt> get_aspect_ratio_for_cell_level_layout(const GateLyt& gate_lyt) noexcept
+    {
+        const std::function<cell<CellLyt>(GateLyt, tile<GateLyt>, cell<CellLyt>)> rel_to_abs_cell_pos =
+            relative_to_absolute_cell_position<GateLibrary::gate_x_size(), GateLibrary::gate_y_size(), GateLyt,
+                                               CellLyt>;
+
+        const cell<CellLyt> max_rel_coord = {GateLibrary::gate_x_size() - 1, GateLibrary::gate_y_size() - 1};
+
+        const cell<CellLyt> first_odd_tile = {gate_lyt.x() != 0 ? 1 : 0, gate_lyt.y() != 0 ? 1 : 0};
+
+        const auto max_coord_even_x = rel_to_abs_cell_pos(gate_lyt, {0, gate_lyt.y()}, max_rel_coord);
+        const auto max_coord_odd_x  = rel_to_abs_cell_pos(gate_lyt, {first_odd_tile.x, gate_lyt.y()}, max_rel_coord);
+        const auto max_coord_even_y = rel_to_abs_cell_pos(gate_lyt, {gate_lyt.x(), 0}, max_rel_coord);
+        const auto max_coord_odd_y  = rel_to_abs_cell_pos(gate_lyt, {gate_lyt.x(), first_odd_tile.y}, max_rel_coord);
+
+        return {std::max(max_coord_even_y.x, max_coord_odd_y.x), std::max(max_coord_even_x.y, max_coord_odd_x.y)};
     }
 };
 

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -215,7 +215,7 @@ class apply_gate_library_impl
      * @param gate_lyt Gate-level layout of which the dimensions are read.
      * @return Aspect ratio for a cell-level layout that corresponds to the dimensions of the given gate-level layout.
      */
-    static aspect_ratio<CellLyt> get_aspect_ratio_for_cell_level_layout(const GateLyt& gate_lyt) noexcept
+    static aspect_ratio<CellLyt> determine_aspect_ratio_for_cell_level_layout(const GateLyt& gate_lyt) noexcept
     {
         using rel_to_abs_cell_pos = relative_to_absolute_cell_position<GateLibrary::gate_x_size(),
                                                                        GateLibrary::gate_y_size(), GateLyt, CellLyt>;

--- a/include/fiction/algorithms/physical_design/apply_gate_library.hpp
+++ b/include/fiction/algorithms/physical_design/apply_gate_library.hpp
@@ -18,7 +18,6 @@
 #include <mockturtle/traits.hpp>
 
 #include <algorithm>
-#include <functional>
 #include <type_traits>
 
 // data types cannot properly be converted to bit field types
@@ -218,9 +217,8 @@ class apply_gate_library_impl
      */
     static aspect_ratio<CellLyt> get_aspect_ratio_for_cell_level_layout(const GateLyt& gate_lyt) noexcept
     {
-        const std::function<cell<CellLyt>(GateLyt, tile<GateLyt>, cell<CellLyt>)> rel_to_abs_cell_pos =
-            relative_to_absolute_cell_position<GateLibrary::gate_x_size(), GateLibrary::gate_y_size(), GateLyt,
-                                               CellLyt>;
+        using rel_to_abs_cell_pos = relative_to_absolute_cell_position<GateLibrary::gate_x_size(),
+                                                                       GateLibrary::gate_y_size(), GateLyt, CellLyt>;
 
         const cell<CellLyt> max_rel_coord = {GateLibrary::gate_x_size() - 1, GateLibrary::gate_y_size() - 1};
 


### PR DESCRIPTION
## Description

When applying a gate library to a hexagonal gate-level layout, the resulting cell-level layout would not have the right sizing.

The implemented fix now supports tiling geometries in which all even rows/columns are aligned and all odd rows/columns are aligned.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
