### PR TITLE
:snake: Fixed python bindings for critical temperature domain

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -49,21 +49,23 @@ void critical_temperature_domain(pybind11::module& m)
 {
     namespace py = pybind11;
 
-    m.def("critical_temperature_domain_grid_search", &fiction::operational_domain_grid_search<Lyt, py_tt>,
+    // todo update docu
+
+    m.def("critical_temperature_domain_grid_search", &fiction::critical_temperature_domain_grid_search<Lyt, py_tt>,
           py::arg("lyt"), py::arg("spec"), py::arg("params") = fiction::operational_domain_params{},
-          py::arg("stats") = nullptr, DOC(fiction_operational_domain_grid_search));
+          py::arg("stats") = nullptr);
 
-    m.def("critical_temperature_domain_random_sampling", &fiction::operational_domain_random_sampling<Lyt, py_tt>,
+    m.def("critical_temperature_domain_random_sampling",
+          &fiction::critical_temperature_domain_random_sampling<Lyt, py_tt>, py::arg("lyt"), py::arg("spec"),
+          py::arg("samples"), py::arg("params") = fiction::operational_domain_params{}, py::arg("stats") = nullptr);
+
+    m.def("critical_temperature_domain_flood_fill", &fiction::critical_temperature_domain_flood_fill<Lyt, py_tt>,
           py::arg("lyt"), py::arg("spec"), py::arg("samples"), py::arg("params") = fiction::operational_domain_params{},
-          py::arg("stats") = nullptr, DOC(fiction_operational_domain_random_sampling));
+          py::arg("stats") = nullptr);
 
-    m.def("critical_temperature_domain_flood_fill", &fiction::operational_domain_flood_fill<Lyt, py_tt>, py::arg("lyt"),
-          py::arg("spec"), py::arg("samples"), py::arg("params") = fiction::operational_domain_params{},
-          py::arg("stats") = nullptr, DOC(fiction_operational_domain_flood_fill));
-
-    m.def("critical_temperature_domain_contour_tracing", &fiction::operational_domain_contour_tracing<Lyt, py_tt>,
-          py::arg("lyt"), py::arg("spec"), py::arg("samples"), py::arg("params") = fiction::operational_domain_params{},
-          py::arg("stats") = nullptr, DOC(fiction_operational_domain_contour_tracing));
+    m.def("critical_temperature_domain_contour_tracing",
+          &fiction::critical_temperature_domain_contour_tracing<Lyt, py_tt>, py::arg("lyt"), py::arg("spec"),
+          py::arg("samples"), py::arg("params") = fiction::operational_domain_params{}, py::arg("stats") = nullptr);
 }
 
 }  // namespace detail

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -49,8 +49,6 @@ void critical_temperature_domain(pybind11::module& m)
 {
     namespace py = pybind11;
 
-    // todo update docu
-
     m.def("critical_temperature_domain_grid_search", &fiction::critical_temperature_domain_grid_search<Lyt, py_tt>,
           py::arg("lyt"), py::arg("spec"), py::arg("params") = fiction::operational_domain_params{},
           py::arg("stats") = nullptr, DOC(fiction_critical_temperature_domain_grid_search));

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -53,19 +53,21 @@ void critical_temperature_domain(pybind11::module& m)
 
     m.def("critical_temperature_domain_grid_search", &fiction::critical_temperature_domain_grid_search<Lyt, py_tt>,
           py::arg("lyt"), py::arg("spec"), py::arg("params") = fiction::operational_domain_params{},
-          py::arg("stats") = nullptr);
+          py::arg("stats") = nullptr, DOC(fiction_critical_temperature_domain_grid_search));
 
     m.def("critical_temperature_domain_random_sampling",
           &fiction::critical_temperature_domain_random_sampling<Lyt, py_tt>, py::arg("lyt"), py::arg("spec"),
-          py::arg("samples"), py::arg("params") = fiction::operational_domain_params{}, py::arg("stats") = nullptr);
+          py::arg("samples"), py::arg("params") = fiction::operational_domain_params{}, py::arg("stats") = nullptr,
+          DOC(fiction_critical_temperature_domain_random_sampling));
 
     m.def("critical_temperature_domain_flood_fill", &fiction::critical_temperature_domain_flood_fill<Lyt, py_tt>,
           py::arg("lyt"), py::arg("spec"), py::arg("samples"), py::arg("params") = fiction::operational_domain_params{},
-          py::arg("stats") = nullptr);
+          py::arg("stats") = nullptr, DOC(fiction_critical_temperature_domain_flood_fill));
 
     m.def("critical_temperature_domain_contour_tracing",
           &fiction::critical_temperature_domain_contour_tracing<Lyt, py_tt>, py::arg("lyt"), py::arg("spec"),
-          py::arg("samples"), py::arg("params") = fiction::operational_domain_params{}, py::arg("stats") = nullptr);
+          py::arg("samples"), py::arg("params") = fiction::operational_domain_params{}, py::arg("stats") = nullptr,
+          DOC(fiction_critical_temperature_domain_contour_tracing));
 }
 
 }  // namespace detail

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3625,7 +3625,7 @@ Parameter ``stats``:
     Operational domain computation statistics.
 
 Returns:
-    The (partial) operational domain of the layout.
+    The critical temperature domain of the layout.
 
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
@@ -3690,7 +3690,7 @@ Parameter ``stats``:
     Operational domain computation statistics.
 
 Returns:
-    The (partial) operational domain of the layout.
+    The critical temperature domain of the layout.
 
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
@@ -3751,7 +3751,7 @@ Parameter ``stats``:
     Operational domain computation statistics.
 
 Returns:
-    The operational domain of the layout.
+    The critical temperature domain of the layout.
 
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
@@ -3795,7 +3795,7 @@ Parameter ``stats``:
     Operational domain computation statistics.
 
 Returns:
-    The (partial) operational domain of the layout.
+    The critical temperature domain of the layout.
 
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
@@ -16715,7 +16715,7 @@ Parameter ``stats``:
     Operational domain computation statistics.
 
 Returns:
-    The (partial) operational domain of the layout.
+    The operational domain of the layout.
 
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
@@ -16779,7 +16779,7 @@ Parameter ``stats``:
     Operational domain computation statistics.
 
 Returns:
-    The (partial) operational domain of the layout.
+    The operational domain of the layout.
 
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
@@ -16909,7 +16909,7 @@ Parameter ``stats``:
     Operational domain computation statistics.
 
 Returns:
-    The (partial) operational domain of the layout.
+    The operational domain of the layout.
 
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
@@ -29,7 +29,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 
 class TestOperationalDomain(unittest.TestCase):
-    def test_xor_gate_100_lattice(self):
+    def test_operational_domain_XOR_gate_100_lattice(self):
         lyt = read_sqd_layout_100(dir_path + "/../../../resources/hex_21_inputsdbp_xor_v1.sqd")
 
         params = operational_domain_params()
@@ -57,7 +57,7 @@ class TestOperationalDomain(unittest.TestCase):
         operational_domain_contour_tracing(lyt, [create_xor_tt()], 100, params, stats_contour_tracing)
         self.assertGreater(stats_contour_tracing.num_operational_parameter_combinations, 0)
 
-    def test_critical_temperature_domain_xor_gate_100_lattice(self):
+    def test_critical_temperature_domain_XOR_gate_100_lattice(self):
         lyt = read_sqd_layout_100(dir_path + "/../../../resources/hex_21_inputsdbp_xor_v1.sqd")
 
         params = operational_domain_params()
@@ -70,22 +70,39 @@ class TestOperationalDomain(unittest.TestCase):
         ]
 
         stats_grid = operational_domain_stats()
-        critical_temperature_domain_grid_search(lyt, [create_xor_tt()], params, stats_grid)
+        ct_domain_grid = critical_temperature_domain_grid_search(lyt, [create_xor_tt()], params, stats_grid)
+        self.assertGreater(ct_domain_grid.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_grid.contains(parameter_point([5.60, 5.00]))[1], 30)
         self.assertGreater(stats_grid.num_operational_parameter_combinations, 0)
 
         stats_flood_fill = operational_domain_stats()
-        critical_temperature_domain_flood_fill(lyt, [create_xor_tt()], 100, params, stats_flood_fill)
+        ct_domain_flood = critical_temperature_domain_flood_fill(lyt, [create_xor_tt()], 100, params, stats_flood_fill)
+        self.assertGreater(ct_domain_flood.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_flood.contains(parameter_point([5.60, 5.00]))[1], 30)
         self.assertGreater(stats_flood_fill.num_operational_parameter_combinations, 0)
 
-        stats_random_sampling = operational_domain_stats()
-        critical_temperature_domain_random_sampling(lyt, [create_xor_tt()], 100, params, stats_random_sampling)
-        self.assertGreater(stats_random_sampling.num_operational_parameter_combinations, 0)
-
         stats_contour_tracing = operational_domain_stats()
-        critical_temperature_domain_contour_tracing(lyt, [create_xor_tt()], 100, params, stats_contour_tracing)
+        ct_domain_contour = critical_temperature_domain_contour_tracing(
+            lyt, [create_xor_tt()], 100, params, stats_contour_tracing
+        )
+        self.assertGreater(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[1], 30)
         self.assertGreater(stats_contour_tracing.num_operational_parameter_combinations, 0)
 
-    def test_and_gate_111_lattice(self):
+        params.sweep_dimensions = [
+            operational_domain_value_range(sweep_parameter.EPSILON_R, 5.60, 5.60, 0.01),
+            operational_domain_value_range(sweep_parameter.LAMBDA_TF, 5.00, 5.00, 0.01),
+        ]
+
+        stats_random_sampling = operational_domain_stats()
+        ct_domain_random = critical_temperature_domain_random_sampling(
+            lyt, [create_xor_tt()], 1000, params, stats_random_sampling
+        )
+        self.assertGreater(ct_domain_random.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_random.contains(parameter_point([5.60, 5.00]))[1], 30)
+        self.assertGreater(stats_random_sampling.num_operational_parameter_combinations, 0)
+
+    def test_operational_domain_AND_gate_111_lattice(self):
         lyt = read_sqd_layout_111(dir_path + "/../../../resources/AND_mu_032_111_surface.sqd")
 
         params = operational_domain_params()

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
@@ -83,7 +83,7 @@ class TestOperationalDomain(unittest.TestCase):
 
         stats_contour_tracing = operational_domain_stats()
         ct_domain_contour = critical_temperature_domain_contour_tracing(
-            lyt, [create_xor_tt()], 100, params, stats_contour_tracing
+            lyt, [create_xor_tt()], 1000, params, stats_contour_tracing
         )
         self.assertEqual(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
         self.assertGreater(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[1], 30)
@@ -127,7 +127,7 @@ class TestOperationalDomain(unittest.TestCase):
         self.assertGreater(stats_random_sampling.num_operational_parameter_combinations, 0)
 
         stats_contour_tracing = operational_domain_stats()
-        operational_domain_contour_tracing(lyt, [create_and_tt()], 100, params, stats_contour_tracing)
+        operational_domain_contour_tracing(lyt, [create_and_tt()], 1000, params, stats_contour_tracing)
         self.assertGreater(stats_contour_tracing.num_operational_parameter_combinations, 0)
 
     def test_temperature_operational_domain(self):

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
@@ -71,13 +71,13 @@ class TestOperationalDomain(unittest.TestCase):
 
         stats_grid = operational_domain_stats()
         ct_domain_grid = critical_temperature_domain_grid_search(lyt, [create_xor_tt()], params, stats_grid)
-        self.assertGreater(ct_domain_grid.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertEqual(ct_domain_grid.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
         self.assertGreater(ct_domain_grid.contains(parameter_point([5.60, 5.00]))[1], 30)
         self.assertGreater(stats_grid.num_operational_parameter_combinations, 0)
 
         stats_flood_fill = operational_domain_stats()
         ct_domain_flood = critical_temperature_domain_flood_fill(lyt, [create_xor_tt()], 100, params, stats_flood_fill)
-        self.assertGreater(ct_domain_flood.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertEqual(ct_domain_flood.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
         self.assertGreater(ct_domain_flood.contains(parameter_point([5.60, 5.00]))[1], 30)
         self.assertGreater(stats_flood_fill.num_operational_parameter_combinations, 0)
 
@@ -85,7 +85,7 @@ class TestOperationalDomain(unittest.TestCase):
         ct_domain_contour = critical_temperature_domain_contour_tracing(
             lyt, [create_xor_tt()], 100, params, stats_contour_tracing
         )
-        self.assertGreater(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertEqual(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
         self.assertGreater(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[1], 30)
         self.assertGreater(stats_contour_tracing.num_operational_parameter_combinations, 0)
 
@@ -98,7 +98,7 @@ class TestOperationalDomain(unittest.TestCase):
         ct_domain_random = critical_temperature_domain_random_sampling(
             lyt, [create_xor_tt()], 1000, params, stats_random_sampling
         )
-        self.assertGreater(ct_domain_random.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
+        self.assertEqual(ct_domain_random.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
         self.assertGreater(ct_domain_random.contains(parameter_point([5.60, 5.00]))[1], 30)
         self.assertGreater(stats_random_sampling.num_operational_parameter_combinations, 0)
 

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -1705,7 +1705,7 @@ template <typename Lyt, typename TT>
  * @param samples Number of samples to perform.
  * @param params Operational domain computation parameters.
  * @param stats Operational domain computation statistics.
- * @return The (partial) operational domain of the layout.
+ * @return The operational domain of the layout.
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
@@ -1762,7 +1762,7 @@ template <typename Lyt, typename TT>
  * @param samples Number of samples to perform.
  * @param params Operational domain computation parameters.
  * @param stats Operational domain computation statistics.
- * @return The (partial) operational domain of the layout.
+ * @return The operational domain of the layout.
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
@@ -1826,7 +1826,7 @@ operational_domain_flood_fill(const Lyt& lyt, const std::vector<TT>& spec, const
  * @param samples Number of samples to perform.
  * @param params Operational domain computation parameters.
  * @param stats Operational domain computation statistics.
- * @return The (partial) operational domain of the layout.
+ * @return The operational domain of the layout.
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
@@ -1877,7 +1877,7 @@ template <typename Lyt, typename TT>
  * function.
  * @param params Operational domain computation parameters.
  * @param stats Operational domain computation statistics.
- * @return The operational domain of the layout.
+ * @return The critical temperature domain of the layout.
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
@@ -1923,11 +1923,11 @@ critical_temperature_domain_grid_search(const Lyt& lyt, const std::vector<TT>& s
  * @param samples Number of samples to perform.
  * @param params Operational domain computation parameters.
  * @param stats Operational domain computation statistics.
- * @return The (partial) operational domain of the layout.
+ * @return The critical temperature domain of the layout.
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
-[[nodiscard]] operational_domain
+[[nodiscard]] critical_temperature_domain
 critical_temperature_domain_random_sampling(const Lyt& lyt, const std::vector<TT>& spec, const std::size_t samples,
                                             const operational_domain_params& params = {},
                                             operational_domain_stats*        stats  = nullptr)
@@ -1939,8 +1939,8 @@ critical_temperature_domain_random_sampling(const Lyt& lyt, const std::vector<TT
     // this may throw an `std::invalid_argument` exception
     detail::validate_sweep_parameters(params);
 
-    operational_domain_stats                                     st{};
-    detail::operational_domain_impl<Lyt, TT, operational_domain> p{lyt, spec, params, st};
+    operational_domain_stats                                              st{};
+    detail::operational_domain_impl<Lyt, TT, critical_temperature_domain> p{lyt, spec, params, st};
 
     const auto result = p.random_sampling(samples);
 
@@ -1975,7 +1975,7 @@ critical_temperature_domain_random_sampling(const Lyt& lyt, const std::vector<TT
  * @param samples Number of samples to perform.
  * @param params Operational domain computation parameters.
  * @param stats Operational domain computation statistics.
- * @return The (partial) operational domain of the layout.
+ * @return The critical temperature domain of the layout.
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
@@ -2035,7 +2035,7 @@ critical_temperature_domain_flood_fill(const Lyt& lyt, const std::vector<TT>& sp
  * @param samples Number of samples to perform.
  * @param params Operational domain computation parameters.
  * @param stats Operational domain computation statistics.
- * @return The (partial) operational domain of the layout.
+ * @return The critical temperature domain of the layout.
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>


### PR DESCRIPTION
## Description

This PR corrects the python bindings for the critical temperature domain computation. Previously, the operational domain functions were mistakenly used instead of the appropriate critical temperature domain functions.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
