### PR TITLE
:art: Refactored random layout design functions

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -26,21 +26,19 @@ void random_layout_generator(pybind11::module& m)
 {
     namespace py = pybind11;
 
-    m.def("generate_random_sidb_layout", &fiction::generate_random_sidb_layout<Lyt>, py::arg("lyt_skeleton"),
+    m.def("generate_random_sidb_layout", &fiction::generate_random_sidb_layout<Lyt>,
           py::arg("params") = fiction::generate_random_sidb_layout_params<fiction::cell<Lyt>>{},
-          DOC(fiction_generate_random_sidb_layout));
+          py::arg("lyt_skeleton"), DOC(fiction_generate_random_sidb_layout));
 
     m.def("generate_multiple_random_sidb_layouts", &fiction::generate_multiple_random_sidb_layouts<Lyt>,
-          py::arg("lyt_skeleton"),
           py::arg("params") = fiction::generate_random_sidb_layout_params<fiction::cell<Lyt>>{},
-          DOC(fiction_generate_multiple_random_sidb_layouts));
+          py::arg("lyt_skeleton"), DOC(fiction_generate_multiple_random_sidb_layouts));
 }
 
 }  // namespace detail
 
 inline void random_sidb_layout_generator(pybind11::module& m)
 {
-    namespace py = pybind11;
     namespace py = pybind11;
 
     py::enum_<typename fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::positive_charges>(
@@ -58,6 +56,8 @@ inline void random_sidb_layout_generator(pybind11::module& m)
     /**
      * Parameters.
      */
+
+    // todo update docu
     py::class_<fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>>(
         m, "generate_random_sidb_layout_params", DOC(fiction_generate_random_sidb_layout_params))
         .def(py::init<>())
@@ -70,6 +70,8 @@ inline void random_sidb_layout_generator(pybind11::module& m)
         .def_readwrite("positive_sidbs",
                        &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::positive_sidbs,
                        DOC(fiction_generate_random_sidb_layout_params_positive_sidbs))
+        .def_readwrite("simulation_parameters",
+                       &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::simulation_parameters)
         .def_readwrite("maximal_attempts",
                        &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::maximal_attempts,
                        DOC(fiction_generate_random_sidb_layout_params_maximal_attempts))
@@ -83,8 +85,11 @@ inline void random_sidb_layout_generator(pybind11::module& m)
                        DOC(fiction_generate_random_sidb_layout_params_maximal_attempts_for_multiple_layouts));
 
     // NOTE be careful with the order of the following calls! Python will resolve the first matching overload!
+    detail::random_layout_generator<py_charge_distribution_surface_100>(m);
+    detail::random_layout_generator<py_charge_distribution_surface_111>(m);
     detail::random_layout_generator<py_sidb_100_lattice>(m);
     detail::random_layout_generator<py_sidb_111_lattice>(m);
+    detail::random_layout_generator<py_sidb_layout>(m);
 }
 
 }  // namespace pyfiction

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -84,8 +84,6 @@ inline void random_sidb_layout_generator(pybind11::module& m)
                        DOC(fiction_generate_random_sidb_layout_params_maximal_attempts_for_multiple_layouts));
 
     // NOTE be careful with the order of the following calls! Python will resolve the first matching overload!
-    detail::random_layout_generator<py_charge_distribution_surface_100>(m);
-    detail::random_layout_generator<py_charge_distribution_surface_111>(m);
     detail::random_layout_generator<py_sidb_100_lattice>(m);
     detail::random_layout_generator<py_sidb_111_lattice>(m);
     detail::random_layout_generator<py_sidb_layout>(m);

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -71,7 +71,8 @@ inline void random_sidb_layout_generator(pybind11::module& m)
                        &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::positive_sidbs,
                        DOC(fiction_generate_random_sidb_layout_params_positive_sidbs))
         .def_readwrite("simulation_parameters",
-                       &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::simulation_parameters)
+                       &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::simulation_parameters,
+                       DOC(fiction_generate_random_sidb_layout_params_simulation_parameters))
         .def_readwrite("maximal_attempts",
                        &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::maximal_attempts,
                        DOC(fiction_generate_random_sidb_layout_params_maximal_attempts))

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -56,8 +56,6 @@ inline void random_sidb_layout_generator(pybind11::module& m)
     /**
      * Parameters.
      */
-
-    // todo update docu
     py::class_<fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>>(
         m, "generate_random_sidb_layout_params", DOC(fiction_generate_random_sidb_layout_params))
         .def(py::init<>())

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -13476,14 +13476,15 @@ layout to which SiDBs are added to create unique SiDB layouts.
 Template parameter ``Lyt``:
     SiDB cell-level SiDB layout type.
 
-Parameter ``lyt_skeleton``:
-    A layout to which random SiDBs are added to create unique layouts.
-
 Parameter ``params``:
     The parameters for generating the random SiDB layouts.
 
+Parameter ``lyt_skeleton``:
+    A layout to which random SiDBs are added to create unique layouts.
+
 Returns:
-    A vector containing the unique randomly generated SiDB layouts.)doc";
+    A vector containing the unique randomly generated SiDB layouts. If
+    the design is impossible, `std::nullopt`)doc";
 
 static const char *__doc_fiction_generate_random_sidb_layout =
 R"doc(Generates a random layout of SiDBs by adding them to the provided
@@ -13493,15 +13494,16 @@ which SiDBs are added to create the final layout.
 Template parameter ``Lyt``:
     SiDB cell-level SiDB layout type.
 
-Parameter ``lyt_skeleton``:
-    A layout to which random cells are added to create the final
-    layout.
-
 Parameter ``params``:
     The parameters for generating the random layout.
 
+Parameter ``lyt_skeleton``:
+    Optional layout to which random cells are added to create the
+    final layout.
+
 Returns:
-    A randomly-generated layout of SiDBs.)doc";
+    A randomly-generated layout of SiDBs. If the design is impossible,
+    `std::nullopt` is returned.)doc";
 
 static const char *__doc_fiction_generate_random_sidb_layout_params =
 R"doc(This struct stores the parameters for the
@@ -13550,7 +13552,7 @@ static const char *__doc_fiction_generate_random_sidb_layout_params_positive_sid
 R"doc(If positively charged SiDBs should be prevented, SiDBs are not placed
 closer than the minimal_spacing.)doc";
 
-static const char *__doc_fiction_generate_random_sidb_layout_params_sim_params = R"doc(Simulation parameters.)doc";
+static const char *__doc_fiction_generate_random_sidb_layout_params_simulation_parameters = R"doc(Simulation parameters.)doc";
 
 static const char *__doc_fiction_geometric_temperature_schedule =
 R"doc(A logarithmically decreasing temperature schedule. The temperature is

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -13469,9 +13469,9 @@ R"doc(For each routing objective that cannot be fulfilled in the given
 layout, this counter is incremented.)doc";
 
 static const char *__doc_fiction_generate_multiple_random_sidb_layouts =
-R"doc(Generates multiple unique random SiDB layouts by adding them to the
-provided layout layout. The optional layout serves as the starting
-layout to which SiDBs are added to create unique SiDB layouts.
+R"doc(Generates multiple random layouts featuring a random arrangement of
+SiDBs. These randomly placed dots can be incorporated into an existing
+layout skeleton that may be optionally provided.
 
 Template parameter ``Lyt``:
     SiDB cell-level SiDB layout type.
@@ -13479,17 +13479,17 @@ Template parameter ``Lyt``:
 Parameter ``params``:
     The parameters for generating the random SiDB layouts.
 
-Parameter ``layout``:
-    Optional layout to which random cells are added.
+Parameter ``skeleton``:
+    Optional layout to which random dots are added.
 
 Returns:
     A vector containing the unique randomly generated SiDB layouts. If
     the design is impossible, `std::nullopt`)doc";
 
 static const char *__doc_fiction_generate_random_sidb_layout =
-R"doc(Generates a random layout of SiDBs by adding them to the provided
-layout layout. The optional layout serves as the starting layout to
-which SiDBs are added to create the final layout.
+R"doc(Generates a layout featuring a random arrangement of SiDBs. These
+randomly placed dots can be incorporated into an existing layout
+skeleton that may be optionally provided.
 
 Template parameter ``Lyt``:
     SiDB cell-level SiDB layout type.
@@ -13497,12 +13497,12 @@ Template parameter ``Lyt``:
 Parameter ``params``:
     The parameters for generating the random layout.
 
-Parameter ``layout``:
-    Optional layout to which random cells are added.
+Parameter ``skeleton``:
+    Optional layout to which random dots are added.
 
 Returns:
-    A randomly generated layout of SiDBs, or `std::nullopt` if the
-    process failed due to conflicting parameters.)doc";
+    A randomly generated SiDB layout, or `std::nullopt` if the process
+    failed due to conflicting parameters.)doc";
 
 static const char *__doc_fiction_generate_random_sidb_layout_params =
 R"doc(This struct stores the parameters for the

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -13470,7 +13470,7 @@ layout, this counter is incremented.)doc";
 
 static const char *__doc_fiction_generate_multiple_random_sidb_layouts =
 R"doc(Generates multiple unique random SiDB layouts by adding them to the
-provided layout skeleton. The layout skeleton serves as the starting
+provided layout layout. The optional layout serves as the starting
 layout to which SiDBs are added to create unique SiDB layouts.
 
 Template parameter ``Lyt``:
@@ -13479,8 +13479,8 @@ Template parameter ``Lyt``:
 Parameter ``params``:
     The parameters for generating the random SiDB layouts.
 
-Parameter ``lyt_skeleton``:
-    A layout to which random SiDBs are added to create unique layouts.
+Parameter ``layout``:
+    Optional layout to which random cells are added.
 
 Returns:
     A vector containing the unique randomly generated SiDB layouts. If
@@ -13488,7 +13488,7 @@ Returns:
 
 static const char *__doc_fiction_generate_random_sidb_layout =
 R"doc(Generates a random layout of SiDBs by adding them to the provided
-layout skeleton. The layout skeleton serves as the starting layout to
+layout layout. The optional layout serves as the starting layout to
 which SiDBs are added to create the final layout.
 
 Template parameter ``Lyt``:
@@ -13497,13 +13497,12 @@ Template parameter ``Lyt``:
 Parameter ``params``:
     The parameters for generating the random layout.
 
-Parameter ``lyt_skeleton``:
-    Optional layout to which random cells are added to create the
-    final layout.
+Parameter ``layout``:
+    Optional layout to which random cells are added.
 
 Returns:
-    A randomly-generated layout of SiDBs. If the design is impossible,
-    `std::nullopt` is returned.)doc";
+    A randomly generated layout of SiDBs, or `std::nullopt` if the
+    process failed due to conflicting parameters.)doc";
 
 static const char *__doc_fiction_generate_random_sidb_layout_params =
 R"doc(This struct stores the parameters for the

--- a/bindings/mnt/pyfiction/include/pyfiction/technology/charge_distribution_surface.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/technology/charge_distribution_surface.hpp
@@ -32,7 +32,6 @@ template <typename Lyt>
 void charge_distribution_surface_layout(pybind11::module& m, const std::string& lattice = "")
 {
     namespace py = pybind11;
-    namespace py = pybind11;
 
     using py_cds = py_charge_distribution_surface_layout<Lyt>;
 

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_random_sidb_layout_generator.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_random_sidb_layout_generator.py
@@ -73,6 +73,7 @@ class TestRandomSiDBLayoutGenerator(unittest.TestCase):
 
     def test_impossible_design_of_mutiple_layouts(self):
         params = generate_random_sidb_layout_params()
+        params.maximal_attempts_for_multiple_layouts = 5
         params.number_of_sidbs = 2
         result_lyt = generate_multiple_random_sidb_layouts(params, sidb_layout())
         self.assertIsNone(result_lyt)

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_random_sidb_layout_generator.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_random_sidb_layout_generator.py
@@ -1,10 +1,14 @@
 import unittest
 
 from mnt.pyfiction import (
+    charge_distribution_surface_100,
+    charge_distribution_surface_111,
+    generate_multiple_random_sidb_layouts,
     generate_random_sidb_layout,
     generate_random_sidb_layout_params,
     sidb_100_lattice,
     sidb_111_lattice,
+    sidb_layout,
 )
 
 
@@ -13,29 +17,65 @@ class TestRandomSiDBLayoutGenerator(unittest.TestCase):
         params = generate_random_sidb_layout_params()
         params.number_of_sidbs = 1
         params.coordinate_pair = ((10, 10), (10, 10))
-        result_lyt = generate_random_sidb_layout(sidb_100_lattice(), params)
+        result_lyt = generate_random_sidb_layout(params, sidb_100_lattice())
         self.assertEqual(result_lyt.num_cells(), 1)
         cell = (result_lyt.cells())[0]
         self.assertEqual(cell.x, 10)
         self.assertEqual(cell.y, 10)
+
+    def test_area_with_five_sidb_layout(self):
+        params = generate_random_sidb_layout_params()
+        params.number_of_sidbs = 5
+        print(params.number_of_sidbs)
+        params.coordinate_pair = ((0, 0), (10, 10))
+        result_lyt = generate_random_sidb_layout(params, sidb_layout())
+        self.assertEqual(result_lyt.num_cells(), 5)
 
     def test_area_with_five_sidb_100_lattice(self):
         params = generate_random_sidb_layout_params()
         params.number_of_sidbs = 5
         print(params.number_of_sidbs)
         params.coordinate_pair = ((0, 0), (10, 10))
-        result_lyt = generate_random_sidb_layout(sidb_100_lattice(), params)
+        result_lyt = generate_random_sidb_layout(params, sidb_100_lattice())
+        self.assertEqual(result_lyt.num_cells(), 5)
+
+    def test_area_with_five_sidbs_cds_100(self):
+        params = generate_random_sidb_layout_params()
+        params.number_of_sidbs = 5
+        print(params.number_of_sidbs)
+        params.coordinate_pair = ((0, 0), (10, 10))
+        result_lyt = generate_random_sidb_layout(params, charge_distribution_surface_100())
+        self.assertEqual(result_lyt.num_cells(), 5)
+
+    def test_area_with_five_sidbs_cds_111(self):
+        params = generate_random_sidb_layout_params()
+        params.number_of_sidbs = 5
+        print(params.number_of_sidbs)
+        params.coordinate_pair = ((0, 0), (10, 10))
+        result_lyt = generate_random_sidb_layout(params, charge_distribution_surface_111())
         self.assertEqual(result_lyt.num_cells(), 5)
 
     def test_area_with_one_coordinate_111_lattice(self):
         params = generate_random_sidb_layout_params()
         params.number_of_sidbs = 1
         params.coordinate_pair = ((10, 10), (10, 10))
-        result_lyt = generate_random_sidb_layout(sidb_111_lattice(), params)
+        result_lyt = generate_random_sidb_layout(params, sidb_111_lattice())
         self.assertEqual(result_lyt.num_cells(), 1)
         cell = (result_lyt.cells())[0]
         self.assertEqual(cell.x, 10)
         self.assertEqual(cell.y, 10)
+
+    def test_impossible_design_of_single_layout(self):
+        params = generate_random_sidb_layout_params()
+        params.number_of_sidbs = 2
+        result_lyt = generate_random_sidb_layout(params, sidb_layout())
+        self.assertIsNone(result_lyt)
+
+    def test_impossible_design_of_mutiple_layouts(self):
+        params = generate_random_sidb_layout_params()
+        params.number_of_sidbs = 2
+        result_lyt = generate_multiple_random_sidb_layouts(params, sidb_layout())
+        self.assertIsNone(result_lyt)
 
 
 if __name__ == "__main__":

--- a/experiments/random_sidb_layout_generation/random_sidb_layout_generation.cpp
+++ b/experiments/random_sidb_layout_generation/random_sidb_layout_generation.cpp
@@ -181,10 +181,15 @@ int main(int argc, const char* argv[])  // NOLINT
                 const generate_random_sidb_layout_params<offset::ucoord_t> params{
                     {{nw_x, nw_y}, {se_x, se_y}},         number_of_placed_sidbs,      charges,
                     sidb_simulation_parameters{3, -0.32}, static_cast<uint64_t>(10E6), number_of_layouts};
-                const auto unique_lyts = generate_multiple_random_sidb_layouts(sidb_100_cell_clk_lyt{}, params);
-                for (auto i = 0u; i < unique_lyts.size(); i++)
+                const auto unique_lyts = generate_multiple_random_sidb_layouts<sidb_100_cell_clk_lyt>(params);
+
+                if (unique_lyts.has_value())
                 {
-                    write_sqd_layout(unique_lyts[i], fmt::format("{}/layout_{}.sqd", dir_path_sqd.string(), i));
+                    for (auto i = 0u; i < unique_lyts.value().size(); i++)
+                    {
+                        write_sqd_layout(unique_lyts.value()[i],
+                                         fmt::format("{}/layout_{}.sqd", dir_path_sqd.string(), i));
+                    }
                 }
             }
             catch (const std::filesystem::filesystem_error& ex)

--- a/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_layouts_with_possible_positive_sidbs.cpp
+++ b/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_layouts_with_possible_positive_sidbs.cpp
@@ -52,7 +52,7 @@ int main()  // NOLINT
     {
         random_layouts_params.number_of_sidbs = num_sidbs;
 
-        const auto random_layouts = generate_multiple_random_sidb_layouts(Lyt{}, random_layouts_params);
+        const auto random_layouts = generate_multiple_random_sidb_layouts<Lyt>(random_layouts_params);
 
         double runtime_exhaustive = 0;
         double runtime_quickexact = 0;

--- a/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_layouts_with_possible_positive_sidbs.cpp
+++ b/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_layouts_with_possible_positive_sidbs.cpp
@@ -9,6 +9,7 @@
 #include <fiction/algorithms/simulation/sidb/quickexact.hpp>
 #include <fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp>
 #include <fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp>
+#include <fiction/types.hpp>
 
 #include <mockturtle/utils/stopwatch.hpp>
 

--- a/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_layouts_with_possible_positive_sidbs.cpp
+++ b/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_layouts_with_possible_positive_sidbs.cpp
@@ -60,7 +60,12 @@ int main()  // NOLINT
         std::vector<std::size_t> number_of_positive_sidbs_of_gs_per_layout{};
         number_of_positive_sidbs_of_gs_per_layout.reserve(random_layouts_params.number_of_unique_generated_layouts);
 
-        for (const auto& layout : random_layouts)
+        if (!random_layouts.has_value())
+        {
+            continue;
+        }
+
+        for (const auto& layout : random_layouts.value())
         {
             const auto exhaustive_results_layout = exhaustive_ground_state_simulation(layout, sim_params);
 
@@ -80,7 +85,7 @@ int main()  // NOLINT
                                                 number_of_positive_sidbs_of_gs_per_layout.cend(), 0u)) /
             static_cast<double>(number_of_positive_sidbs_of_gs_per_layout.size());
 
-        simulation_exp(random_layouts_params.number_of_sidbs, random_layouts.size(), runtime_exhaustive,
+        simulation_exp(random_layouts_params.number_of_sidbs, random_layouts.value().size(), runtime_exhaustive,
                        runtime_quickexact, average_pos_sibs_of_gs);
 
         simulation_exp.save();

--- a/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -328,23 +328,33 @@ class design_sidb_gates_impl
                 {
                     while (!gate_layout_is_found)
                     {
-                        auto result_lyt = generate_random_sidb_layout<Lyt>(skeleton_layout, parameter);
+                        auto result_lyt = generate_random_sidb_layout<Lyt>(parameter, skeleton_layout);
+
+                        if (!result_lyt.has_value())
+                        {
+                            continue;
+                        }
+
                         if constexpr (has_get_sidb_defect_v<Lyt>)
                         {
-                            result_lyt.foreach_sidb_defect(
+                            result_lyt.value().foreach_sidb_defect(
                                 [&result_lyt](const auto& cd)
                                 {
                                     if (is_neutrally_charged_defect(cd.second))
                                     {
-                                        result_lyt.assign_sidb_defect(cd.first, sidb_defect{sidb_defect_type::NONE});
+                                        result_lyt.value().assign_sidb_defect(cd.first,
+                                                                              sidb_defect{sidb_defect_type::NONE});
                                     }
                                 });
                         }
-                        if (const auto [status, sim_calls] = is_operational(
-                                result_lyt, truth_table, params.operational_params, input_bdl_wires, output_bdl_wires);
+
+                        if (const auto [status, sim_calls] =
+                                is_operational(result_lyt.value(), truth_table, params.operational_params,
+                                               input_bdl_wires, output_bdl_wires);
                             status == operational_status::OPERATIONAL)
                         {
                             const std::lock_guard lock{mutex_to_protect_designed_gate_layouts};
+
                             if constexpr (has_get_sidb_defect_v<Lyt>)
                             {
                                 skeleton_layout.foreach_sidb_defect(
@@ -352,12 +362,12 @@ class design_sidb_gates_impl
                                     {
                                         if (is_neutrally_charged_defect(cd.second))
                                         {
-                                            result_lyt.assign_sidb_defect(cd.first, cd.second);
+                                            result_lyt.value().assign_sidb_defect(cd.first, cd.second);
                                         }
                                     });
                             }
 
-                            randomly_designed_gate_layouts.push_back(result_lyt);
+                            randomly_designed_gate_layouts.push_back(result_lyt.value());
                             gate_layout_is_found = true;
                             break;
                         }

--- a/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -205,7 +205,7 @@ generate_multiple_random_sidb_layouts(const generate_random_sidb_layout_params<c
     {
         if (auto random_lyt = generate_random_sidb_layout(params, layout); random_lyt.has_value())
         {
-            // check if layout is unique
+            // check if the layout is unique
             const auto is_identical = std::any_of(FICTION_EXECUTION_POLICY_PAR_UNSEQ unique_lyts.cbegin(),
                                                   unique_lyts.cend(), [&](const auto& old_lyt)
                                                   { return are_cell_layouts_identical(random_lyt.value(), old_lyt); });

--- a/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -5,7 +5,6 @@
 #ifndef FICTION_RANDOM_SIDB_LAYOUT_GENERATOR_HPP
 #define FICTION_RANDOM_SIDB_LAYOUT_GENERATOR_HPP
 
-#include "fiction/algorithms/path_finding/distance.hpp"
 #include "fiction/algorithms/simulation/sidb/can_positive_charges_occur.hpp"
 #include "fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp"
 #include "fiction/technology/sidb_defects.hpp"
@@ -14,6 +13,7 @@
 #include "fiction/utils/layout_utils.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -62,7 +62,7 @@ struct generate_random_sidb_layout_params
     /**
      * Simulation parameters.
      */
-    sidb_simulation_parameters sim_params{};
+    sidb_simulation_parameters simulation_parameters{};
     /**
      * Maximum number of steps to place the specified number of SiDBs. Example: If the area, where SiDBs can be placed,
      * is small and many SiDBs are to be placed, several tries are required to generate a layout with no positively
@@ -87,27 +87,35 @@ struct generate_random_sidb_layout_params
  * The layout skeleton serves as the starting layout to which SiDBs are added to create the final layout.
  *
  * @tparam Lyt SiDB cell-level SiDB layout type.
- * @param lyt_skeleton A layout to which random cells are added to create the final layout.
  * @param params The parameters for generating the random layout.
- * @return A randomly-generated layout of SiDBs.
+ * @param lyt_skeleton Optional layout to which random cells are added to create the final layout.
+ * @return A randomly-generated layout of SiDBs. If the design is impossible, `std::nullopt` is returned.
  */
 template <typename Lyt>
-Lyt generate_random_sidb_layout(const Lyt&                                                 lyt_skeleton,
-                                const generate_random_sidb_layout_params<coordinate<Lyt>>& params)
+[[nodiscard]] std::optional<Lyt>
+generate_random_sidb_layout(const generate_random_sidb_layout_params<coordinate<Lyt>>& params,
+                            const std::optional<Lyt>& lyt_skeleton = std::nullopt) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
 
     std::unordered_set<typename Lyt::coordinate> sidbs_affected_by_defects = {};
 
-    if constexpr (has_get_sidb_defect_v<Lyt>)
+    uint64_t number_of_sidbs_of_final_layout = params.number_of_sidbs;
+
+    Lyt lyt{};
+
+    if (lyt_skeleton.has_value())
     {
-        sidbs_affected_by_defects = lyt_skeleton.all_affected_sidbs(std::make_pair(0, 0));
+        lyt = lyt_skeleton.value().clone();
+        number_of_sidbs_of_final_layout += lyt.num_cells();
+
+        if constexpr (is_sidb_defect_surface_v<Lyt>)
+        {
+            sidbs_affected_by_defects = lyt_skeleton.value().all_affected_sidbs(std::make_pair(0, 0));
+        }
     }
 
-    const uint64_t number_of_sidbs_of_final_layout = lyt_skeleton.num_cells() + params.number_of_sidbs;
-
-    Lyt lyt{lyt_skeleton.clone()};
     // counts the attempts to place the given number of SiDBs
     uint64_t attempt_counter = 0;
 
@@ -134,11 +142,18 @@ Lyt generate_random_sidb_layout(const Lyt&                                      
         // the SiDB is added to the layout
         if (!random_cell_is_identical_wih_defect && !next_to_neutral_defect)
         {
-            lyt.assign_cell_type(random_coord, technology<Lyt>::cell_type::LOGIC);
+            if (lyt_skeleton.has_value())
+            {
+                lyt.assign_cell_type(random_coord, technology<Lyt>::cell_type::LOGIC);
+            }
+            else
+            {
+                lyt.assign_cell_type(random_coord, technology<Lyt>::cell_type::NORMAL);
+            }
 
             if (params.positive_sidbs ==
                     generate_random_sidb_layout_params<coordinate<Lyt>>::positive_charges::FORBIDDEN &&
-                can_positive_charges_occur(lyt, params.sim_params))
+                can_positive_charges_occur(lyt, params.simulation_parameters))
             {
                 lyt.assign_cell_type(random_coord, technology<Lyt>::cell_type::EMPTY);
             }
@@ -147,9 +162,9 @@ Lyt generate_random_sidb_layout(const Lyt&                                      
     }
 
     if (params.positive_sidbs == generate_random_sidb_layout_params<coordinate<Lyt>>::positive_charges::MAY_OCCUR &&
-        !can_positive_charges_occur(lyt, params.sim_params))
+        !can_positive_charges_occur(lyt, params.simulation_parameters))
     {
-        return generate_random_sidb_layout(lyt_skeleton, params);
+        return generate_random_sidb_layout(params, lyt_skeleton);
     }
 
     if (lyt.num_cells() == number_of_sidbs_of_final_layout)
@@ -157,8 +172,8 @@ Lyt generate_random_sidb_layout(const Lyt&                                      
         return lyt;
     }
 
-    // if not all SiDBs can be placed, the originally given skeleton layout is returned
-    return lyt_skeleton;
+    // if not all SiDBs can be placed, std::nullopt is returned
+    return std::nullopt;
 }
 
 /**
@@ -166,44 +181,47 @@ Lyt generate_random_sidb_layout(const Lyt&                                      
  * The layout skeleton serves as the starting layout to which SiDBs are added to create unique SiDB layouts.
  *
  * @tparam Lyt SiDB cell-level SiDB layout type.
- * @param lyt_skeleton A layout to which random SiDBs are added to create unique layouts.
  * @param params The parameters for generating the random SiDB layouts.
- * @return A vector containing the unique randomly generated SiDB layouts.
+ * @param lyt_skeleton A layout to which random SiDBs are added to create unique layouts.
+ * @return A vector containing the unique randomly generated SiDB layouts. If the design is impossible, `std::nullopt`
  */
 template <typename Lyt>
-std::vector<Lyt>
-generate_multiple_random_sidb_layouts(const Lyt&                                                 lyt_skeleton,
-                                      const generate_random_sidb_layout_params<coordinate<Lyt>>& params)
+[[nodiscard]] std::optional<std::vector<Lyt>>
+generate_multiple_random_sidb_layouts(const generate_random_sidb_layout_params<coordinate<Lyt>>& params,
+                                      const std::optional<Lyt>& lyt_skeleton = std::nullopt) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
 
-    // this vector collects all unique SiDB layouts
+    // collects all unique SiDB layouts
     std::vector<Lyt> unique_lyts{};
     unique_lyts.reserve(params.number_of_unique_generated_layouts);
 
-    // counts the attempts of unsuccessful generations of an SiDB layout
+    // counter for unsuccessful generation attempts
     uint64_t unsuccessful_generation_attempt_counter = 0;
 
     while (unique_lyts.size() < params.number_of_unique_generated_layouts &&
            unsuccessful_generation_attempt_counter < params.maximal_attempts_for_multiple_layouts)
     {
-        const auto random_lyt = generate_random_sidb_layout(lyt_skeleton, params);
-
-        // indicates if a found SiDB layout is identical to an already found one.
-        const auto identical_layout =
-            std::any_of(FICTION_EXECUTION_POLICY_PAR unique_lyts.cbegin(), unique_lyts.cend(),
-                        [&](const auto& old_lyt) { return are_cell_layouts_identical(random_lyt, old_lyt); });
-
-        // if the randomly generated SiDB layout is not identical to a previously generated one, it is added to the
-        // collection of all unique SiDB layouts (unique_lyts)
-        if (!identical_layout)
+        if (auto random_lyt = generate_random_sidb_layout(params, lyt_skeleton); random_lyt.has_value())
         {
-            unique_lyts.push_back(random_lyt);
-            unsuccessful_generation_attempt_counter += 1;
+            // check if layout is unique
+            const auto is_identical = std::any_of(FICTION_EXECUTION_POLICY_PAR unique_lyts.cbegin(), unique_lyts.cend(),
+                                                  [&](const auto& old_lyt)
+                                                  { return are_cell_layouts_identical(random_lyt.value(), old_lyt); });
+
+            // add layout if unique
+            if (!is_identical)
+            {
+                unique_lyts.emplace_back(std::move(random_lyt.value()));
+                continue;
+            }
         }
+        ++unsuccessful_generation_attempt_counter;
     }
-    return unique_lyts;
+
+    // return std::nullopt if no layouts were generated
+    return unique_lyts.empty() ? std::nullopt : std::optional{std::move(unique_lyts)};
 }
 
 }  // namespace fiction

--- a/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -83,18 +83,19 @@ struct generate_random_sidb_layout_params
 };
 
 /**
- * Generates a random layout of SiDBs by adding them to the provided layout layout.
- * The optional layout serves as the starting layout to which SiDBs are added to create the final layout.
+ * Generates a layout featuring a random arrangement of SiDBs. These randomly placed dots can be incorporated into an
+ * existing layout skeleton that may be optionally provided.
  *
  * @tparam Lyt SiDB cell-level SiDB layout type.
  * @param params The parameters for generating the random layout.
- * @param layout Optional layout to which random cells are added.
- * @return A randomly generated layout of SiDBs, or `std::nullopt` if the process failed due to conflicting parameters.
+ * @param skeleton Optional layout to which random cells are added.
+ * @return A randomly generated SiDB layout, or `std::nullopt` if the process failed due to conflicting
+ * parameters.
  */
 template <typename Lyt>
 [[nodiscard]] std::optional<Lyt>
 generate_random_sidb_layout(const generate_random_sidb_layout_params<coordinate<Lyt>>& params,
-                            const std::optional<Lyt>&                                  layout = std::nullopt) noexcept
+                            const std::optional<Lyt>&                                  skeleton = std::nullopt) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
@@ -105,14 +106,14 @@ generate_random_sidb_layout(const generate_random_sidb_layout_params<coordinate<
 
     Lyt lyt{};
 
-    if (layout.has_value())
+    if (skeleton.has_value())
     {
-        lyt = layout.value().clone();
+        lyt = skeleton.value().clone();
         number_of_sidbs_of_final_layout += lyt.num_cells();
 
         if constexpr (is_sidb_defect_surface_v<Lyt>)
         {
-            sidbs_affected_by_defects = layout.value().all_affected_sidbs(std::make_pair(0, 0));
+            sidbs_affected_by_defects = skeleton.value().all_affected_sidbs(std::make_pair(0, 0));
         }
     }
 
@@ -142,7 +143,7 @@ generate_random_sidb_layout(const generate_random_sidb_layout_params<coordinate<
         // the SiDB is added to the layout
         if (!random_cell_is_identical_wih_defect && !next_to_neutral_defect)
         {
-            if (layout.has_value())
+            if (skeleton.has_value())
             {
                 lyt.assign_cell_type(random_coord, technology<Lyt>::cell_type::LOGIC);
             }
@@ -164,7 +165,7 @@ generate_random_sidb_layout(const generate_random_sidb_layout_params<coordinate<
     if (params.positive_sidbs == generate_random_sidb_layout_params<coordinate<Lyt>>::positive_charges::MAY_OCCUR &&
         !can_positive_charges_occur(lyt, params.simulation_parameters))
     {
-        return generate_random_sidb_layout(params, layout);
+        return generate_random_sidb_layout(params, skeleton);
     }
 
     if (lyt.num_cells() == number_of_sidbs_of_final_layout)
@@ -177,18 +178,18 @@ generate_random_sidb_layout(const generate_random_sidb_layout_params<coordinate<
 }
 
 /**
- * Generates multiple unique random SiDB layouts by adding them to the provided layout layout.
- * The optional layout serves as the starting layout to which SiDBs are added to create unique SiDB layouts.
+ * Generates multiple random layouts featuring a random arrangement of SiDBs. These randomly placed dots can be
+ * incorporated into an existing layout skeleton that may be optionally provided.
  *
  * @tparam Lyt SiDB cell-level SiDB layout type.
  * @param params The parameters for generating the random SiDB layouts.
- * @param layout Optional layout to which random cells are added.
+ * @param skeleton Optional layout to which random cells are added.
  * @return A vector containing the unique randomly generated SiDB layouts. If the design is impossible, `std::nullopt`
  */
 template <typename Lyt>
 [[nodiscard]] std::optional<std::vector<Lyt>>
 generate_multiple_random_sidb_layouts(const generate_random_sidb_layout_params<coordinate<Lyt>>& params,
-                                      const std::optional<Lyt>& layout = std::nullopt) noexcept
+                                      const std::optional<Lyt>& skeleton = std::nullopt) noexcept
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
@@ -203,7 +204,7 @@ generate_multiple_random_sidb_layouts(const generate_random_sidb_layout_params<c
     while (unique_lyts.size() < params.number_of_unique_generated_layouts &&
            unsuccessful_generation_attempt_counter < params.maximal_attempts_for_multiple_layouts)
     {
-        if (auto random_lyt = generate_random_sidb_layout(params, layout); random_lyt.has_value())
+        if (auto random_lyt = generate_random_sidb_layout(params, skeleton); random_lyt.has_value())
         {
             // check if the layout is unique
             const auto is_identical = std::any_of(FICTION_EXECUTION_POLICY_PAR_UNSEQ unique_lyts.cbegin(),

--- a/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -88,7 +88,7 @@ struct generate_random_sidb_layout_params
  *
  * @tparam Lyt SiDB cell-level SiDB layout type.
  * @param params The parameters for generating the random layout.
- * @param skeleton Optional layout to which random cells are added.
+ * @param skeleton Optional layout to which random dots are added.
  * @return A randomly generated SiDB layout, or `std::nullopt` if the process failed due to conflicting
  * parameters.
  */
@@ -183,7 +183,7 @@ generate_random_sidb_layout(const generate_random_sidb_layout_params<coordinate<
  *
  * @tparam Lyt SiDB cell-level SiDB layout type.
  * @param params The parameters for generating the random SiDB layouts.
- * @param skeleton Optional layout to which random cells are added.
+ * @param skeleton Optional layout to which random dots are added.
  * @return A vector containing the unique randomly generated SiDB layouts. If the design is impossible, `std::nullopt`
  */
 template <typename Lyt>

--- a/test/algorithms/simulation/sidb/random_sidb_layout_generator.cpp
+++ b/test/algorithms/simulation/sidb/random_sidb_layout_generator.cpp
@@ -3,8 +3,8 @@
 //
 
 #include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
 
-#include <fiction/algorithms/path_finding/distance.hpp>
 #include <fiction/algorithms/simulation/sidb/can_positive_charges_occur.hpp>
 #include <fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp>
 #include <fiction/layouts/cell_level_layout.hpp>
@@ -25,21 +25,24 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
     {
         const generate_random_sidb_layout_params<cube::coord_t> params{};
 
-        const auto lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_cube{}, params);
+        const auto lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_cube>(params);
 
-        CHECK(lyt.num_cells() == 0);
-        CHECK(lyt.x() == 0);
-        CHECK(lyt.y() == 0);
+        REQUIRE(lyt.has_value());
+        CHECK(lyt.value().num_cells() == 0);
+        CHECK(lyt.value().x() == 0);
+        CHECK(lyt.value().y() == 0);
     }
 
     SECTION("given corner coordinates, wrong order")
     {
         const generate_random_sidb_layout_params<cube::coord_t> params{{{5, 7, 2}, {-10, -10, 0}}};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_cube{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_cube>(params);
 
-        CHECK(result_lyt.num_cells() == 0);
-        result_lyt.foreach_cell(
+        REQUIRE(result_lyt.has_value());
+
+        CHECK(result_lyt.value().num_cells() == 0);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x == 0);
@@ -52,10 +55,11 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
     {
         const generate_random_sidb_layout_params<cube::coord_t> params{{{-10, -10, 0}, {5, 7, 2}}};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_cube{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 0);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 0);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x == 0);
@@ -68,10 +72,11 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
     {
         const generate_random_sidb_layout_params<cube::coord_t> params{{{-10, -10, 1}, {-10, -10, 1}}, 1};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_cube{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 1);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 1);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x == -10);
@@ -84,10 +89,11 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
     {
         const generate_random_sidb_layout_params<cube::coord_t> params{{{-10, -10, 0}, {5, 7, 1}}, 10};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_cube{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 10);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 10);
+        result_lyt.value().foreach_cell(
             [&](const auto& cell)
             {
                 CHECK(cell.x < 6);
@@ -106,10 +112,11 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
             100,
             generate_random_sidb_layout_params<cube::coord_t>::positive_charges::ALLOWED};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_cube{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 100);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 100);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x < 91);
@@ -124,17 +131,18 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
             50,
             generate_random_sidb_layout_params<cube::coord_t>::positive_charges::FORBIDDEN};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_cube{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 50);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 50);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x <= 200);
                 CHECK(cell.y <= 200);
             });
 
-        CHECK(!can_positive_charges_occur(result_lyt, sidb_simulation_parameters{}));
+        CHECK(!can_positive_charges_occur(result_lyt.value(), sidb_simulation_parameters{}));
     }
 
     SECTION("given previous layouts")
@@ -146,10 +154,13 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
             sidb_simulation_parameters{},
             static_cast<uint64_t>(10E6),
             3};
-        const auto result_lyts = generate_multiple_random_sidb_layouts(sidb_cell_clk_lyt_cube{}, params);
-        CHECK(result_lyts.size() == 3);
 
-        for (const auto& lyt : result_lyts)
+        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyts.has_value());
+
+        CHECK(result_lyts.value().size() == 3);
+
+        for (const auto& lyt : result_lyts.value())
         {
             lyt.foreach_cell(
                 [](const auto& cell)
@@ -172,12 +183,13 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
             static_cast<uint64_t>(10E6),
             2};
 
-        const auto result_lyts = generate_multiple_random_sidb_layouts(sidb_cell_clk_lyt_cube{}, params);
+        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyts.has_value());
 
-        REQUIRE(result_lyts.size() == 2);
+        REQUIRE(result_lyts.value().size() == 2);
 
-        const auto& first_lyt  = result_lyts.front();
-        const auto& second_lyt = result_lyts.back();
+        const auto& first_lyt  = result_lyts.value().front();
+        const auto& second_lyt = result_lyts.value().back();
 
         CHECK(!are_cell_layouts_identical(first_lyt, second_lyt));
     }
@@ -191,10 +203,12 @@ TEST_CASE("Random cube::coord_t layout generation", "[random-sidb-layout-generat
             sidb_simulation_parameters{},
             static_cast<uint64_t>(10E6),
             10};
-        const auto result_lyts = generate_multiple_random_sidb_layouts(sidb_cell_clk_lyt_cube{}, params);
-        REQUIRE(result_lyts.size() == 10);
 
-        for (const auto& lyt : result_lyts)
+        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_cell_clk_lyt_cube>(params);
+        REQUIRE(result_lyts.has_value());
+        REQUIRE(result_lyts.value().size() == 10);
+
+        for (const auto& lyt : result_lyts.value())
         {
             CHECK(!can_positive_charges_occur(lyt, sidb_simulation_parameters{}));
         }
@@ -207,21 +221,32 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
     {
         const generate_random_sidb_layout_params<offset::ucoord_t> params{};
 
-        const auto lyt = generate_random_sidb_layout(sidb_100_cell_clk_lyt{}, params);
+        const auto lyt = generate_random_sidb_layout<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(lyt.has_value());
 
-        CHECK(lyt.num_cells() == 0);
-        CHECK(lyt.x() == 0);
-        CHECK(lyt.y() == 0);
+        CHECK(lyt.value().num_cells() == 0);
+        CHECK(lyt.value().x() == 0);
+        CHECK(lyt.value().y() == 0);
+    }
+
+    SECTION("design is impossible")
+    {
+        generate_random_sidb_layout_params<offset::ucoord_t> params{};
+        params.number_of_sidbs = 2;
+
+        const auto lyt = generate_random_sidb_layout<sidb_100_cell_clk_lyt>(params);
+        CHECK(!lyt.has_value());
     }
 
     SECTION("given corner coordinates")
     {
         const generate_random_sidb_layout_params<offset::ucoord_t> params{{{1, 1, 0}, {5, 7, 2}}};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_100_cell_clk_lyt{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 0);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 0);
+        result_lyt.value().foreach_cell(
             [&](const auto& cell)
             {
                 CHECK(cell.x == 0);
@@ -234,10 +259,11 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
     {
         const generate_random_sidb_layout_params<offset::ucoord_t> params{{{5, 5, 1}, {5, 5, 1}}, 1};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_100_cell_clk_lyt{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 1);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 1);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x == 5);
@@ -250,10 +276,11 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
     {
         const generate_random_sidb_layout_params<offset::ucoord_t> params{{{1, 1, 0}, {50, 7, 1}}, 10};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_100_cell_clk_lyt{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 10);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 10);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x < 51);
@@ -272,10 +299,11 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
             100,
             generate_random_sidb_layout_params<offset::ucoord_t>::positive_charges::ALLOWED};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_100_cell_clk_lyt{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 100);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 100);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x < 91);
@@ -290,17 +318,18 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
             100,
             generate_random_sidb_layout_params<offset::ucoord_t>::positive_charges::FORBIDDEN};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_100_cell_clk_lyt{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 100);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 100);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x <= 200);
                 CHECK(cell.y <= 200);
             });
 
-        CHECK(!can_positive_charges_occur(result_lyt, sidb_simulation_parameters{}));
+        CHECK(!can_positive_charges_occur(result_lyt.value(), sidb_simulation_parameters{}));
     }
 
     SECTION("given previous layouts")
@@ -312,10 +341,12 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
             sidb_simulation_parameters{},
             static_cast<uint64_t>(10E6),
             3};
-        const auto result_lyts = generate_multiple_random_sidb_layouts(sidb_100_cell_clk_lyt{}, params);
-        CHECK(result_lyts.size() == 3);
 
-        for (const auto& lyt : result_lyts)
+        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(result_lyts.has_value());
+        CHECK(result_lyts.value().size() == 3);
+
+        for (const auto& lyt : result_lyts.value())
         {
             lyt.foreach_cell(
                 [](const auto& cell)
@@ -335,11 +366,13 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
             sidb_simulation_parameters{},
             static_cast<uint64_t>(10E6),
             2};
-        const auto result_lyts = generate_multiple_random_sidb_layouts(sidb_100_cell_clk_lyt{}, params);
-        REQUIRE(result_lyts.size() == 2);
 
-        const auto& first_lyt  = result_lyts.front();
-        const auto& second_lyt = result_lyts.back();
+        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_100_cell_clk_lyt>(params);
+        REQUIRE(result_lyts.has_value());
+        REQUIRE(result_lyts.value().size() == 2);
+
+        const auto& first_lyt  = result_lyts.value().front();
+        const auto& second_lyt = result_lyts.value().back();
 
         CHECK(!are_cell_layouts_identical(first_lyt, second_lyt));
     }
@@ -347,13 +380,16 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
     SECTION("Check correct use of skeleton layout when generating only one random layout")
     {
         const generate_random_sidb_layout_params<offset::ucoord_t> params{{{0, 0}, {9, 9}}, 10};
-        sidb_100_cell_clk_lyt                                      skeleton_layout{};
+
+        sidb_100_cell_clk_lyt skeleton_layout{};
         skeleton_layout.assign_cell_type({0, 0}, sidb_100_cell_clk_lyt::technology::NORMAL);
         skeleton_layout.assign_cell_type({9, 1}, sidb_100_cell_clk_lyt::technology::NORMAL);
         skeleton_layout.assign_cell_type({5, 0}, sidb_100_cell_clk_lyt::technology::NORMAL);
-        const auto result_lyt = generate_random_sidb_layout(skeleton_layout, params);
 
-        CHECK(result_lyt.num_cells() == 13);
+        const auto result_lyt = generate_random_sidb_layout(params, std::optional{skeleton_layout});
+
+        REQUIRE(result_lyt.has_value());
+        CHECK(result_lyt.value().num_cells() == 13);
     }
 
     SECTION("Check correct use of skeleton layout when generating multiple random layouts")
@@ -372,11 +408,22 @@ TEST_CASE("Random offset::ucoord_t layout generation", "[random-sidb-layout-gene
         skeleton_layout.assign_cell_type({3, 0}, sidb_100_cell_clk_lyt::technology::NORMAL);
         skeleton_layout.assign_cell_type({9, 1}, sidb_100_cell_clk_lyt::technology::NORMAL);
 
-        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_100_cell_clk_lyt>(skeleton_layout, params);
+        const auto result_lyts = generate_multiple_random_sidb_layouts(params, std::optional{skeleton_layout});
+        REQUIRE(result_lyts.has_value());
+        REQUIRE(result_lyts.value().size() == 2);
 
-        REQUIRE(result_lyts.size() == 2);
-        CHECK(result_lyts.front().num_cells() == 13);
-        CHECK(result_lyts.back().num_cells() == 13);
+        CHECK(result_lyts.value().front().num_cells() == 13);
+        CHECK(result_lyts.value().back().num_cells() == 13);
+    }
+
+    SECTION("Check if std::nullptr_t is returned when no layout can be designed")
+    {
+        generate_random_sidb_layout_params<offset::ucoord_t> params{};
+        params.maximal_attempts_for_multiple_layouts = 5;
+        params.number_of_sidbs                       = 2;
+
+        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_cell_clk_lyt>(params);
+        CHECK(!result_lyts.has_value());
     }
 }
 
@@ -386,21 +433,23 @@ TEST_CASE("Random siqad::coord_t layout generation", "[random-sidb-layout-genera
     {
         const generate_random_sidb_layout_params<siqad::coord_t> params{};
 
-        const auto lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_siqad{}, params);
+        const auto lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_siqad>(params);
+        REQUIRE(lyt.has_value());
 
-        CHECK(lyt.num_cells() == 0);
-        CHECK(lyt.x() == 0);
-        CHECK(lyt.y() == 0);
+        CHECK(lyt.value().num_cells() == 0);
+        CHECK(lyt.value().x() == 0);
+        CHECK(lyt.value().y() == 0);
     }
 
     SECTION("given two identical coordinates")
     {
         const generate_random_sidb_layout_params<siqad::coord_t> params{{{5, 5, 1}, {5, 5, 1}}, 1};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_siqad{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_siqad>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 1);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 1);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x == 5);
@@ -413,10 +462,11 @@ TEST_CASE("Random siqad::coord_t layout generation", "[random-sidb-layout-genera
     {
         const generate_random_sidb_layout_params<siqad::coord_t> params{{{1, 1, 0}, {5, 7, 1}}};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_siqad{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_siqad>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 0);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 0);
+        result_lyt.value().foreach_cell(
             [&](const auto& cell)
             {
                 CHECK(cell.x == 0);
@@ -429,10 +479,11 @@ TEST_CASE("Random siqad::coord_t layout generation", "[random-sidb-layout-genera
     {
         const generate_random_sidb_layout_params<siqad::coord_t> params{{{1, 1, 0}, {50, 7, 1}}, 10};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_siqad{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_siqad>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 10);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 10);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x < 51);
@@ -450,10 +501,11 @@ TEST_CASE("Random siqad::coord_t layout generation", "[random-sidb-layout-genera
             100,
             generate_random_sidb_layout_params<siqad::coord_t>::positive_charges::ALLOWED};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_siqad{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_siqad>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 100);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 100);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x < 91);
@@ -468,10 +520,10 @@ TEST_CASE("Random siqad::coord_t layout generation", "[random-sidb-layout-genera
             10,
             generate_random_sidb_layout_params<siqad::coord_t>::positive_charges::FORBIDDEN};
 
-        const auto result_lyt = generate_random_sidb_layout(sidb_cell_clk_lyt_siqad{}, params);
+        const auto result_lyt = generate_random_sidb_layout<sidb_cell_clk_lyt_siqad>(params);
 
-        CHECK(result_lyt.num_cells() == 10);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 10);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x < 91);
@@ -489,10 +541,12 @@ TEST_CASE("Random siqad::coord_t layout generation", "[random-sidb-layout-genera
             sidb_simulation_parameters{},
             static_cast<uint64_t>(10E6),
             3};
-        const auto result_lyts = generate_multiple_random_sidb_layouts(sidb_cell_clk_lyt_siqad{}, params);
-        CHECK(result_lyts.size() == 3);
 
-        for (const auto& lyt : result_lyts)
+        const auto result_lyts = generate_multiple_random_sidb_layouts<sidb_cell_clk_lyt_siqad>(params);
+        REQUIRE(result_lyts.has_value());
+        CHECK(result_lyts.value().size() == 3);
+
+        for (const auto& lyt : result_lyts.value())
         {
             lyt.foreach_cell(
                 [](const auto& cell)
@@ -514,10 +568,11 @@ TEMPLATE_TEST_CASE("Random siqad::coord_t layout generation with defects", "[ran
     {
         const generate_random_sidb_layout_params<cell<TestType>> params{{{5, 5, 1}, {5, 5, 1}}, 1};
 
-        const auto result_lyt = generate_random_sidb_layout(TestType{}, params);
+        const auto result_lyt = generate_random_sidb_layout<TestType>(params);
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 1);
-        result_lyt.foreach_cell(
+        CHECK(result_lyt.value().num_cells() == 1);
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell.x == 5);
@@ -540,10 +595,8 @@ TEMPLATE_TEST_CASE("Random siqad::coord_t layout generation with defects", "[ran
         auto defect_layout = TestType{};
         defect_layout.assign_sidb_defect({2, 1, 1}, sidb_defect{sidb_defect_type::DB, -1, 5.6, 5});
 
-        const auto result_lyt = generate_random_sidb_layout(defect_layout, params);
-
-        CHECK(result_lyt.num_cells() == 0);
-        CHECK(result_lyt.num_defects() == 1);
+        const auto result_lyt = generate_random_sidb_layout(params, std::optional{defect_layout});
+        CHECK(!result_lyt.has_value());
     }
 
     SECTION("region including only one cell and there is no defect")
@@ -561,14 +614,16 @@ TEMPLATE_TEST_CASE("Random siqad::coord_t layout generation with defects", "[ran
         defect_layout.assign_sidb_defect({3, 1, 1}, sidb_defect{sidb_defect_type::DB, -1, 5.6, 5});
         defect_layout.assign_sidb_defect({4, 1, 1}, sidb_defect{sidb_defect_type::SINGLE_DIHYDRIDE, 1, 7.6, 7});
 
-        const auto result_lyt = generate_random_sidb_layout(defect_layout, params);
+        const auto result_lyt = generate_random_sidb_layout(params, std::optional{defect_layout});
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 1);
-        CHECK(result_lyt.num_defects() == 2);
+        CHECK(result_lyt.value().num_cells() == 1);
+        CHECK(result_lyt.value().num_defects() == 2);
 
-        CHECK(result_lyt.get_cell_type({2, 1, 1}) == TestType::technology::cell_type::LOGIC);
-        CHECK(result_lyt.get_sidb_defect({3, 1, 1}) == sidb_defect{sidb_defect_type::DB, -1, 5.6, 5});
-        CHECK(result_lyt.get_sidb_defect({4, 1, 1}) == sidb_defect{sidb_defect_type::SINGLE_DIHYDRIDE, 1, 7.6, 7});
+        CHECK(result_lyt.value().get_cell_type({2, 1, 1}) == TestType::technology::cell_type::LOGIC);
+        CHECK(result_lyt.value().get_sidb_defect({3, 1, 1}) == sidb_defect{sidb_defect_type::DB, -1, 5.6, 5});
+        CHECK(result_lyt.value().get_sidb_defect({4, 1, 1}) ==
+              sidb_defect{sidb_defect_type::SINGLE_DIHYDRIDE, 1, 7.6, 7});
     }
 
     SECTION("given corner coordinates and number of placed SiDBs, and allow positive charges")
@@ -586,13 +641,14 @@ TEMPLATE_TEST_CASE("Random siqad::coord_t layout generation with defects", "[ran
         defect_layout.assign_sidb_defect({7, 1, 0}, sidb_defect{sidb_defect_type::SINGLE_DIHYDRIDE, 1, 2.6, 7});
         defect_layout.assign_sidb_defect({2, 1, 0}, sidb_defect{sidb_defect_type::SINGLE_DIHYDRIDE, 1, 7.6, 4});
 
-        const auto result_lyt = generate_random_sidb_layout(defect_layout, params);
+        const auto result_lyt = generate_random_sidb_layout(params, std::optional{defect_layout});
+        REQUIRE(result_lyt.has_value());
 
-        CHECK(result_lyt.num_cells() == 10);
-        CHECK(result_lyt.num_defects() == 5);
+        CHECK(result_lyt.value().num_cells() == 10);
+        CHECK(result_lyt.value().num_defects() == 5);
 
         // check if all cells are not closer than two cells (Euclidean distance).
-        result_lyt.foreach_cell(
+        result_lyt.value().foreach_cell(
             [](const auto& cell)
             {
                 CHECK(cell != siqad::coord_t{2, 2, 0});
@@ -628,13 +684,14 @@ TEST_CASE("Random cube::coord_t layout generation with defects", "[random-sidb-l
     layout.assign_sidb_defect(siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 1, 0}),
                               sidb_defect{sidb_defect_type::SINGLE_DIHYDRIDE, 1, 7.6, 4});
 
-    const auto result_lyt = generate_random_sidb_layout(layout, params);
+    const auto result_lyt = generate_random_sidb_layout(params, std::optional{layout});
 
-    CHECK(result_lyt.num_cells() == 10);
-    CHECK(result_lyt.num_defects() == 5);
+    REQUIRE(result_lyt.has_value());
+    CHECK(result_lyt.value().num_cells() == 10);
+    CHECK(result_lyt.value().num_defects() == 5);
 
     // check if all cells are not closer than two cells (Euclidean distance).
-    result_lyt.foreach_cell(
+    result_lyt.value().foreach_cell(
         [](const auto& cell)
         {
             CHECK(cell != siqad::to_fiction_coord<cube::coord_t>(siqad::coord_t{2, 2, 0}));


### PR DESCRIPTION
## Description

This PR refactors the functions responsible for designing random SiDB layouts. If the design process fails, ``std::nullopt`` is now returned instead of an empty layout.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
