### PR TITLE
:art: Refactored ``QuickSim`` to remove magic number for upper limit calculation

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/technology/charge_distribution_surface.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/technology/charge_distribution_surface.hpp
@@ -90,9 +90,9 @@ void charge_distribution_surface_layout(pybind11::module& m, const std::string& 
             "erase_defect", [](py_cds& cds, fiction::cell<py_cds> c) { return cds.erase_defect(c); }, py::arg("c"))
 
         .def(
-            "assign_charge_state_by_cell_index",
+            "assign_charge_state_by_index",
             [](py_cds& cds, uint64_t index, fiction::sidb_charge_state cs, fiction::charge_index_mode index_mode)
-            { return cds.assign_charge_state_by_cell_index(index, cs, index_mode); }, py::arg("index"), py::arg("cs"),
+            { return cds.assign_charge_state_by_index(index, cs, index_mode); }, py::arg("index"), py::arg("cs"),
             py::arg("index_mode") = fiction::charge_index_mode::UPDATE_CHARGE_INDEX)
         .def(
             "get_charge_state", [](py_cds& cds, fiction::cell<py_cds> c) { return cds.get_charge_state(c); },

--- a/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
+++ b/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
@@ -60,11 +60,12 @@ int main()  // NOLINT
     const quickexact_params<siqad::coord_t> qe_params{sim_params};
     const time_to_solution_params           tts_params{};
 
-    double total_runtime_exhaustive      = 0.0;
-    double total_runtime_quickexact      = 0.0;
-    double average_accuracy_quicksim     = 0.0;
-    double total_single_rumtime_quicksim = 0.0;
-    double total_tts_quicksim            = 0.0;
+    double      total_runtime_exhaustive      = 0.0;
+    double      total_runtime_quickexact      = 0.0;
+    double      average_accuracy_quicksim     = 0.0;
+    double      total_single_rumtime_quicksim = 0.0;
+    double      total_tts_quicksim            = 0.0;
+    std::size_t total_number_of_instances     = 0;
 
     for (const auto& [gate, truth_table] : gates)
     {
@@ -87,6 +88,7 @@ int main()  // NOLINT
         runtime_quickexact += mockturtle::to_seconds(quickexact_results_layout.simulation_runtime);
         tts_quicksim += stats.time_to_solution;
         instances += 1;
+        total_number_of_instances += 1;
         quicksim_accuracy_mean += stats.acc;
         quicksim_single_runtime += stats.mean_single_runtime;
 
@@ -106,6 +108,7 @@ int main()  // NOLINT
             tts_quicksim += stats.time_to_solution;
 
             instances += 1;
+            total_number_of_instances += 1;
             quicksim_accuracy_mean += stats.acc;
             quicksim_single_runtime += stats.mean_single_runtime;
         }
@@ -123,7 +126,7 @@ int main()  // NOLINT
         simulation_exp.table();
     }
 
-    simulation_exp("Overall", 0, total_runtime_exhaustive, total_runtime_quickexact,
+    simulation_exp("Overall", total_number_of_instances, total_runtime_exhaustive, total_runtime_quickexact,
                    average_accuracy_quicksim / gates.size(), total_single_rumtime_quicksim, total_tts_quicksim);
     simulation_exp.save();
     simulation_exp.table();

--- a/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
+++ b/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
@@ -78,7 +78,7 @@ int main()  // NOLINT
         double      quicksim_single_runtime = 0.0;
 
         // simulate layout with no input pattern
-        const auto             exhaustive_results_layout = exhaustive_ground_state_simulation(*bii, sim_params);
+        const auto             exhaustive_results_layout = exhaustive_ground_state_simulation(layout, sim_params);
         time_to_solution_stats stats{};
         time_to_solution(layout, qs_params, tts_params, &stats);
         const auto quickexact_results_layout = quickexact(layout, qe_params);

--- a/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
+++ b/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
@@ -78,7 +78,7 @@ int main()  // NOLINT
         double      quicksim_single_runtime = 0.0;
 
         // simulate layout with no input pattern
-        const auto             exhaustive_results_layout = sidb_simulation_result<sidb_100_cell_clk_lyt_siqad>{};
+        const auto             exhaustive_results_layout = exhaustive_ground_state_simulation(*bii, sim_params);
         time_to_solution_stats stats{};
         time_to_solution(layout, qs_params, tts_params, &stats);
         const auto quickexact_results_layout = quickexact(layout, qe_params);
@@ -96,7 +96,7 @@ int main()  // NOLINT
 
         for (auto i = 0u; i < num_input_patterns; ++i, ++bii)
         {
-            const auto             exhaustive_results = sidb_simulation_result<sidb_100_cell_clk_lyt_siqad>{};
+            const auto             exhaustive_results = exhaustive_ground_state_simulation(*bii, sim_params);
             time_to_solution_stats tts_stats{};
             time_to_solution(*bii, qs_params, tts_params, &tts_stats);
             const auto quickexact_results = quickexact(*bii, qe_params);

--- a/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
+++ b/experiments/sidb_simulation/electrostatic_ground_state/runtime_analysis_bestagon_gates.cpp
@@ -126,7 +126,7 @@ int main()  // NOLINT
         simulation_exp.table();
     }
 
-    simulation_exp("Overall", total_number_of_instances, total_runtime_exhaustive, total_runtime_quickexact,
+    simulation_exp("Total", total_number_of_instances, total_runtime_exhaustive, total_runtime_quickexact,
                    average_accuracy_quicksim / gates.size(), total_single_rumtime_quicksim, total_tts_quicksim);
     simulation_exp.save();
     simulation_exp.table();

--- a/include/fiction/algorithms/simulation/sidb/clustercomplete.hpp
+++ b/include/fiction/algorithms/simulation/sidb/clustercomplete.hpp
@@ -366,9 +366,9 @@ class clustercomplete_impl
         for (const auto& pst : clustering_state.proj_states)
         {
             const uint64_t sidb_ix = get_singleton_sidb_ix(pst->cluster);
-            charge_layout_copy.assign_charge_state_by_cell_index(
-                sidb_ix, singleton_multiset_conf_to_charge_state(pst->multiset_conf),
-                charge_index_mode::KEEP_CHARGE_INDEX);
+            charge_layout_copy.assign_charge_state_by_index(sidb_ix,
+                                                            singleton_multiset_conf_to_charge_state(pst->multiset_conf),
+                                                            charge_index_mode::KEEP_CHARGE_INDEX);
 
             charge_layout_copy.assign_local_potential_by_index(
                 sidb_ix, -clustering_state.pot_bounds.get<bound_direction::LOWER>(sidb_ix));

--- a/include/fiction/algorithms/simulation/sidb/quickexact.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quickexact.hpp
@@ -197,7 +197,7 @@ class quickexact_impl
     /**
      * Indices of all SiDBs that are pre-assigned to be negatively charged in a physically valid layout.
      */
-    std::vector<int64_t> preassigned_negative_sidb_indices{};
+    std::vector<uint64_t> preassigned_negative_sidb_indices{};
     /**
      * All SiDBs that are pre-assigned to be negatively charged in a physically valid layout.
      */
@@ -495,12 +495,12 @@ class quickexact_impl
     {
         for (const auto& index : preassigned_negative_sidb_indices)
         {
-            const auto cell = charge_lyt.index_to_cell(static_cast<uint64_t>(index));
+            const auto cell = charge_lyt.index_to_cell(index);
             preassigned_negative_sidbs.push_back(cell);
             layout.assign_cell_type(cell, Lyt::cell_type::EMPTY);
         }
 
-        // All pre-assigned negatively-charged SiDBs are erased from the
+        // all pre-assigned negatively charged SiDBs are erased from the
         // all_sidbs_in_lyt_without_negative_preassigned_ones vector.
         all_sidbs_in_lyt_without_negative_preassigned_ones.erase(
             std::remove_if(all_sidbs_in_lyt_without_negative_preassigned_ones.begin(),

--- a/include/fiction/algorithms/simulation/sidb/quicksim.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quicksim.hpp
@@ -123,7 +123,8 @@ sidb_simulation_result<Lyt> quicksim(const Lyt& lyt, const quicksim_params& ps =
             if (std::find(predefined_negative_sidbs_indices.cbegin(), predefined_negative_sidbs_indices.cend(),
                           charge_lyt.cell_to_index(cell)) == predefined_negative_sidbs_indices.cend())
             {
-                all_sidbs_indices_with_unknow_charge_state.push_back(charge_lyt.cell_to_index(cell));
+                all_sidbs_indices_with_unknow_charge_state.push_back(
+                    static_cast<uint64_t>(charge_lyt.cell_to_index(cell)));
             }
         }
 

--- a/include/fiction/algorithms/simulation/sidb/quicksim.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quicksim.hpp
@@ -93,7 +93,7 @@ sidb_simulation_result<Lyt> quicksim(const Lyt& lyt, const quicksim_params& ps =
         charge_lyt.assign_base_number(2);
         charge_lyt.assign_all_charge_states(sidb_charge_state::NEGATIVE);
         charge_lyt.update_after_charge_change(dependent_cell_mode::VARIABLE);
-        const auto negative_sidb_indices = charge_lyt.negative_sidb_detection();
+        const auto predefined_negative_sidbs_indices = charge_lyt.negative_sidb_detection();
 
         // Check that the layout with all SiDBs negatively charged is physically valid.
         if (charge_lyt.is_physically_valid())
@@ -105,7 +105,7 @@ sidb_simulation_result<Lyt> quicksim(const Lyt& lyt, const quicksim_params& ps =
         charge_lyt.assign_all_charge_states(sidb_charge_state::NEUTRAL);
         charge_lyt.update_after_charge_change();
 
-        if (!negative_sidb_indices.empty())
+        if (!predefined_negative_sidbs_indices.empty())
         {
             if (charge_lyt.is_physically_valid())
             {
@@ -115,18 +115,28 @@ sidb_simulation_result<Lyt> quicksim(const Lyt& lyt, const quicksim_params& ps =
 
         // Check if the layout where all SiDBs that need to be negatively charged are negatively charged and the rest
         // are neutrally charged is physically valid.
-        for (const auto& index : negative_sidb_indices)
+        std::vector<uint64_t> all_sidbs_indices_with_unknow_charge_state{};
+        all_sidbs_indices_with_unknow_charge_state.reserve(charge_lyt.num_cells());
+
+        for (const auto& cell : charge_lyt.get_sidb_order())
         {
-            charge_lyt.assign_charge_state_by_cell_index(static_cast<uint64_t>(index), sidb_charge_state::NEGATIVE);
+            if (std::find(predefined_negative_sidbs_indices.cbegin(), predefined_negative_sidbs_indices.cend(),
+                          charge_lyt.cell_to_index(cell)) == predefined_negative_sidbs_indices.cend())
+            {
+                all_sidbs_indices_with_unknow_charge_state.push_back(charge_lyt.cell_to_index(cell));
+            }
         }
+
+        for (const auto& negative_sidb_index : predefined_negative_sidbs_indices)
+        {
+            charge_lyt.assign_charge_state_by_index(negative_sidb_index, sidb_charge_state::NEGATIVE);
+        }
+
         charge_lyt.update_after_charge_change();
         if (charge_lyt.is_physically_valid())
         {
             st.charge_distributions.push_back(charge_distribution_surface<Lyt>{charge_lyt});
         }
-
-        charge_lyt.assign_all_charge_states(sidb_charge_state::NEUTRAL);
-        charge_lyt.update_after_charge_change();
 
         // If the number of threads is initially set to zero, the simulation is run with one thread.
         const uint64_t num_threads = std::max(ps.number_threads, uint64_t{1});
@@ -146,32 +156,30 @@ sidb_simulation_result<Lyt> quicksim(const Lyt& lyt, const quicksim_params& ps =
             threads.emplace_back(
                 [&]
                 {
-                    charge_distribution_surface<Lyt> charge_lyt_copy{charge_lyt};
+                    // all SiDBs are negatively charged
+                    if (predefined_negative_sidbs_indices.size() == charge_lyt.num_cells())
+                    {
+                        return;
+                    }
+
+                    charge_distribution_surface<Lyt> charge_lyt_copy{charge_lyt.clone()};
 
                     for (uint64_t l = 0ul; l < iter_per_thread; ++l)
                     {
-                        for (uint64_t i = 0ul; i < charge_lyt.num_cells(); ++i)
+                        for (const auto& sidb_index_with_unknown_charge_state :
+                             all_sidbs_indices_with_unknow_charge_state)
                         {
-                            {
-                                if (std::find(negative_sidb_indices.cbegin(), negative_sidb_indices.cend(), i) !=
-                                    negative_sidb_indices.cend())
-                                {
-                                    continue;
-                                }
-                            }
-
-                            std::vector<uint64_t> index_start{i};
-
                             charge_lyt_copy.assign_all_charge_states(sidb_charge_state::NEUTRAL);
 
-                            for (const auto& index : negative_sidb_indices)
+                            auto negative_sidbs_indices = predefined_negative_sidbs_indices;
+                            negative_sidbs_indices.push_back(sidb_index_with_unknown_charge_state);
+
+                            for (const auto& negative_sidb_index : negative_sidbs_indices)
                             {
-                                charge_lyt_copy.assign_charge_state_by_cell_index(static_cast<uint64_t>(index),
-                                                                                  sidb_charge_state::NEGATIVE);
-                                index_start.push_back(static_cast<uint64_t>(index));
+                                charge_lyt_copy.assign_charge_state_by_index(negative_sidb_index,
+                                                                             sidb_charge_state::NEGATIVE);
                             }
 
-                            charge_lyt_copy.assign_charge_state_by_cell_index(i, sidb_charge_state::NEGATIVE);
                             charge_lyt_copy.update_after_charge_change();
 
                             if (charge_lyt_copy.is_physically_valid())
@@ -180,13 +188,11 @@ sidb_simulation_result<Lyt> quicksim(const Lyt& lyt, const quicksim_params& ps =
                                 st.charge_distributions.push_back(charge_distribution_surface<Lyt>{charge_lyt_copy});
                             }
 
-                            const auto upper_limit =
-                                std::min(static_cast<uint64_t>(static_cast<double>(charge_lyt_copy.num_cells()) / 1.5),
-                                         charge_lyt.num_cells() - negative_sidb_indices.size());
+                            const auto upper_limit = all_sidbs_indices_with_unknow_charge_state.size() - 1;
 
                             for (uint64_t num = 0ul; num < upper_limit; num++)
                             {
-                                charge_lyt_copy.adjacent_search(ps.alpha, index_start);
+                                charge_lyt_copy.adjacent_search(ps.alpha, negative_sidbs_indices);
                                 charge_lyt_copy.validity_check();
 
                                 if (charge_lyt_copy.is_physically_valid())

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -668,7 +668,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      * This function can be used to detect which SiDBs must be negatively charged due to their location. Important:
      * This function must be applied to a charge layout where all SiDBs are negatively initialized.
      *
-     * @return Vector of SiDBs that must be negatively charged to fulfill the population stability.
+     * @return Vector of SiDB indices that must be negatively charged to fulfill the population stability.
      */
     [[nodiscard]] std::vector<uint64_t> negative_sidb_detection() const noexcept
     {

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -686,7 +686,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
                 {
                     const auto cell_index = cell_to_index(cell);
                     assert(cell_index != -1 && "Cell is not part of the layout");
-                    negative_sidbs.push_back(cell_index);
+                    negative_sidbs.push_back(static_cast<uint64_t>(cell_index));
                 }
             }
         }

--- a/test/algorithms/simulation/sidb/quicksim.cpp
+++ b/test/algorithms/simulation/sidb/quicksim.cpp
@@ -725,11 +725,10 @@ TEMPLATE_TEST_CASE("Edge case with four SiDBs", "[quicksim]", (sidb_100_cell_clk
 {
     TestType lyt{};
 
-    lyt.assign_cell_type({0, 1, 0}, TestType::cell_type::NORMAL);
-    lyt.assign_cell_type({3, 1, 0}, TestType::cell_type::NORMAL);
-
-    lyt.assign_cell_type({6, 1, 1}, TestType::cell_type::NORMAL);
-    lyt.assign_cell_type({8, 0, 1}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({0, 1, 1}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({3, 2, 0}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({3, 0, 1}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({7, 0, 0}, TestType::cell_type::NORMAL);
 
     quicksim_params quicksim_params{};
 

--- a/test/algorithms/simulation/sidb/quicksim.cpp
+++ b/test/algorithms/simulation/sidb/quicksim.cpp
@@ -720,6 +720,33 @@ TEMPLATE_TEST_CASE("QuickSim simulation of an layout comprising of 13 SiDBs, all
     }
 }
 
+TEMPLATE_TEST_CASE("Edge case with four SiDBs", "[quicksim]", (sidb_100_cell_clk_lyt_siqad),
+                   (cds_sidb_100_cell_clk_lyt_siqad))
+{
+    TestType lyt{};
+
+    lyt.assign_cell_type({0, 1, 0}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({3, 1, 0}, TestType::cell_type::NORMAL);
+
+    lyt.assign_cell_type({6, 1, 1}, TestType::cell_type::NORMAL);
+    lyt.assign_cell_type({8, 0, 1}, TestType::cell_type::NORMAL);
+
+    quicksim_params quicksim_params{};
+
+    SECTION("alpha = 1.0 does not work")
+    {
+        quicksim_params.alpha         = 1.0;
+        const auto simulation_results = quicksim<TestType>(lyt, quicksim_params);
+        CHECK(simulation_results.charge_distributions.size() == 0);
+    }
+    SECTION("alpha = 0.7 works")
+    {
+        quicksim_params.alpha         = 0.7;
+        const auto simulation_results = quicksim<TestType>(lyt, quicksim_params);
+        CHECK(simulation_results.charge_distributions.size() > 0);
+    }
+}
+
 TEMPLATE_TEST_CASE("QuickSim simulation of a Y-shaped SiDB OR gate with input 01", "[ExGS]",
                    (sidb_100_cell_clk_lyt_siqad), (charge_distribution_surface<sidb_100_cell_clk_lyt_siqad>))
 {

--- a/test/benchmark/simulation.cpp
+++ b/test/benchmark/simulation.cpp
@@ -89,31 +89,38 @@ TEST_CASE("Benchmark simulators", "[benchmark]")
 }
 //      Mac M1, Sequoia 15.2, Apple clang version 14.0.3 (16.12.24)
 //
-//      Before PR #602:
-//      benchmark name      samples             iterations              est run time
-//                          mean                low mean                high mean
-//                          std dev             low std dev             high std dev
-//      -----------------------------------------------------------------------------
-//      QuickExact          100                 1                       1.69216 m
-//                          1.01658 s           1.01384 s               1.02149 s
-//                          18.1717 ms          11.4147 ms              28.4481 ms
-//
-//      QuickSim            100                 1                       492.005 ms
-//                          4.85343 ms          4.80376 ms              4.98192 ms
-//                          381.332 us          184.008 us              801.102 us
-//
-//      PR #602:
+//      Before PR #679:
 //      benchmark name      samples             iterations              est run time
 //                          mean                low mean                high mean
 //                          std dev             low std dev             high std dev
 //    -------------------------------------------------------------------------------
-//      QuickExact          100                 1                       1.68503 m
-//                          1.01966 s           1.01725 s               1.02271 s
-//                          13.7569 ms          11.465 ms               18.3512 ms
+//      QuickExact          100                 1                       1.7844 m
+//                          1.07493 s           1.07269 s               1.07752 s
+//                          12.2561 ms          10.7246 ms              13.8817 ms
 //
-//      QuickSim            100                 1                       445.639 ms
-//                          4.50754 ms          4.47813 ms              4.54016 ms
-//                          158.347 us          137.998 us              187.498 us
+//      QuickSim            100                 1                       445.05 ms
+//                          4.43629 ms          4.41687 ms              4.46476 ms
+//                          118.778 us          88.1746 us              158.552 us
+//
+//       ClusterComplete    100                 1                       299.125 ms
+//                          3.00976 ms          2.98784 ms              3.03247 ms
+//                          113.591 us          101.271 us              128.938 us
+//      After PR #679:
+//      benchmark name      samples             iterations              est run time
+//                          mean                low mean                high mean
+//                          std dev             low std dev             high std dev
+//    -------------------------------------------------------------------------------
+//      QuickExact          100                 1                       1.78579 m
+//                          1.06699 s           1.06575 s               1.06858 s
+//                          7.12851 ms          5.64407 ms              10.528 ms
+//
+//      QuickSim            100                 1                       551.093 ms
+//                          5.54284 ms          5.52032 ms              5.57622 ms
+//                          137.976 us          100.606 us              201.053 us
+//
+//      ClusterComplete     100                 1                       298.05 ms
+//                          3.01338 ms          2.98089 ms              3.12774 ms
+//                          278.749 us          79.1939 us              640.667 us
 
 //      AMD Ryzen Threadripper PRO 5955X, Ubuntu 20.04, Ubuntu clang version 18.1.3 (15.01.2025)
 //

--- a/test/technology/charge_distribution_surface.cpp
+++ b/test/technology/charge_distribution_surface.cpp
@@ -408,9 +408,9 @@ TEMPLATE_TEST_CASE("Assign and delete charge states without defects", "[charge-d
 
         CHECK(charge_layout.get_charge_state({7, 6}) == sidb_charge_state::NONE);
 
-        charge_layout.assign_charge_state_by_cell_index(0, sidb_charge_state::NEUTRAL);
-        charge_layout.assign_charge_state_by_cell_index(1, sidb_charge_state::POSITIVE);
-        charge_layout.assign_charge_state_by_cell_index(2, sidb_charge_state::POSITIVE);
+        charge_layout.assign_charge_state_by_index(0, sidb_charge_state::NEUTRAL);
+        charge_layout.assign_charge_state_by_index(1, sidb_charge_state::POSITIVE);
+        charge_layout.assign_charge_state_by_index(2, sidb_charge_state::POSITIVE);
         CHECK(charge_layout.get_charge_state_by_index(0) == sidb_charge_state::NEUTRAL);
         CHECK(charge_layout.get_charge_state_by_index(1) == sidb_charge_state::POSITIVE);
         CHECK(charge_layout.get_charge_state_by_index(2) == sidb_charge_state::POSITIVE);


### PR DESCRIPTION
## Description

This PR introduces a minor refactor of _QuickSim_. The key update involves removing the hardcoded number ``1.5`` in the upper limit calculation, which was originally implemented to accelerate the simulation of SiDB gates. While this approach proved effective in most scenarios, it could lead to rare edge cases causing unexpected behavior. To enhance reliability, this adjustment eliminates the magic number. Importantly, the overall performance remains significantly improved compared to the results presented in _QuickSim: Efficient and Accurate Physical Simulation of Silicon Dangling Bond Logic_ (https://ieeexplore.ieee.org/document/10231266).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
