### PR TITLE
🐛 Number of crossings calculation

### DIFF
--- a/include/fiction/layouts/gate_level_layout.hpp
+++ b/include/fiction/layouts/gate_level_layout.hpp
@@ -771,7 +771,9 @@ class gate_level_layout : public ClockedLayout
                         strg->data.num_crossings--;
                     }
 
-                    if (ClockedLayout::is_ground_layer(t) && ClockedLayout::is_crossing_layer(ClockedLayout::above(t)) && !is_empty_tile(ClockedLayout::above(t)))
+                    if (ClockedLayout::is_ground_layer(t) &&
+                        ClockedLayout::is_crossing_layer(ClockedLayout::above(t)) &&
+                        !is_empty_tile(ClockedLayout::above(t)))
                     {
                         strg->data.num_crossings--;
                     }
@@ -1696,7 +1698,8 @@ class gate_level_layout : public ClockedLayout
                     strg->data.num_crossings++;
                 }
 
-                if (ClockedLayout::is_ground_layer(t) && ClockedLayout::is_crossing_layer(ClockedLayout::above(t)) && !is_empty_tile(ClockedLayout::above(t)))
+                if (ClockedLayout::is_ground_layer(t) && ClockedLayout::is_crossing_layer(ClockedLayout::above(t)) &&
+                    !is_empty_tile(ClockedLayout::above(t)))
                 {
                     strg->data.num_crossings++;
                 }

--- a/include/fiction/layouts/gate_level_layout.hpp
+++ b/include/fiction/layouts/gate_level_layout.hpp
@@ -771,6 +771,11 @@ class gate_level_layout : public ClockedLayout
                         strg->data.num_crossings--;
                     }
 
+                    if (ClockedLayout::is_ground_layer(t) && ClockedLayout::is_crossing_layer(ClockedLayout::above(t)) && !is_empty_tile(ClockedLayout::above(t)))
+                    {
+                        strg->data.num_crossings--;
+                    }
+
                     // find PO entry and remove it if present
                     if (const auto po_it =
                             std::find_if(strg->outputs.cbegin(), strg->outputs.cend(),
@@ -1687,6 +1692,11 @@ class gate_level_layout : public ClockedLayout
                 strg->data.num_wires++;
 
                 if (ClockedLayout::is_crossing_layer(t) && !is_empty_tile(ClockedLayout::below(t)))
+                {
+                    strg->data.num_crossings++;
+                }
+
+                if (ClockedLayout::is_ground_layer(t) && ClockedLayout::is_crossing_layer(ClockedLayout::above(t)) && !is_empty_tile(ClockedLayout::above(t)))
                 {
                     strg->data.num_crossings++;
                 }

--- a/test/layouts/gate_level_layout.cpp
+++ b/test/layouts/gate_level_layout.cpp
@@ -1201,6 +1201,36 @@ TEST_CASE("Move crossing", "[gate-level-layout]")
     CHECK(layout.num_crossings() == 0);
     CHECK(layout.num_pis() == 4);
     CHECK(layout.num_pos() == 2);
+
+    crossing = layout.get_node({3, 0});
+
+    // move crossing back
+    layout.move_node(crossing, {2, 1, 1}, {});
+    CHECK(layout.num_gates() == 2);
+    CHECK(layout.num_wires() == 9);
+    CHECK(layout.num_crossings() == 1);
+    CHECK(layout.num_pis() == 4);
+    CHECK(layout.num_pos() == 2);
+
+    auto underneath_crossing = layout.get_node({2, 1, 0});
+
+    // move crossing to empty location
+    layout.move_node(underneath_crossing, {3, 0}, {});
+    CHECK(layout.num_gates() == 2);
+    CHECK(layout.num_wires() == 9);
+    CHECK(layout.num_crossings() == 0);
+    CHECK(layout.num_pis() == 4);
+    CHECK(layout.num_pos() == 2);
+
+    underneath_crossing = layout.get_node({3, 0});
+
+    // move crossing back
+    layout.move_node(underneath_crossing, {2, 1, 0}, {});
+    CHECK(layout.num_gates() == 2);
+    CHECK(layout.num_wires() == 9);
+    CHECK(layout.num_crossings() == 1);
+    CHECK(layout.num_pis() == 4);
+    CHECK(layout.num_pos() == 2);
 }
 
 TEST_CASE("Clear tiles", "[gate-level-layout]")


### PR DESCRIPTION
## Description

Deleting a wire can decrease the number of crossings in two ways:
1. Deleted wire was in the crossing layer and had a wire in the ground layer
2. Deleted wire was in the ground layer and had a wire in the crossing layer

Similar adding a wire can increase the number of crossings in two ways:
1. Added wire is in the crossing layer and there is already a wire in the ground layer
2. Added wire is in the ground layer and there is already a wire in the crossing layer

The previous implementation only covered the first cases.
Thanks a lot to @Drewniok and @samuelshng for spotting this bug.

## Checklist:
- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
