### PR TITLE
🐛 Exclude ClusterComplete from simulation engine selection when ALGLIB is disabled

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
@@ -41,8 +41,10 @@ inline void sidb_simulation_engine(pybind11::module& m)
         .value("QUICKSIM", fiction::sidb_simulation_engine::QUICKSIM, DOC(fiction_sidb_simulation_engine_QUICKSIM))
         .value("QUICKEXACT", fiction::sidb_simulation_engine::QUICKEXACT,
                DOC(fiction_sidb_simulation_engine_QUICKEXACT))
+#if (FICTION_ALGLIB_ENABLED)
         .value("CLUSTERCOMPLETE", fiction::sidb_simulation_engine::CLUSTERCOMPLETE,
                DOC(fiction_sidb_simulation_engine_CLUSTERCOMPLETE))
+#endif  // FICTION_ALGLIB_ENABLED
 
         ;
 
@@ -51,8 +53,10 @@ inline void sidb_simulation_engine(pybind11::module& m)
         .value("EXGS", fiction::exact_sidb_simulation_engine::EXGS, DOC(fiction_exact_sidb_simulation_engine_EXGS))
         .value("QUICKEXACT", fiction::exact_sidb_simulation_engine::QUICKEXACT,
                DOC(fiction_exact_sidb_simulation_engine_QUICKEXACT))
+#if (FICTION_ALGLIB_ENABLED)
         .value("CLUSTERCOMPLETE", fiction::exact_sidb_simulation_engine::CLUSTERCOMPLETE,
                DOC(fiction_exact_sidb_simulation_engine_CLUSTERCOMPLETE))
+#endif  // FICTION_ALGLIB_ENABLED
 
         ;
 

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -5684,7 +5684,8 @@ static const char *__doc_fiction_detail_critical_temperature_impl_gate_based_sim
 R"doc(*Gate-based Critical Temperature* Simulation of a SiDB layout for a
 given Boolean function.
 
-tparam TT Type of the truth table.
+Template parameter ``TT``:
+    Type of the truth table.
 
 Parameter ``spec``:
     Expected Boolean function of the layout given as a multi-output

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3884,6 +3884,62 @@ Returns:
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
 
+static const char *__doc_fiction_critical_temperature_gate_based =
+R"doc(This algorithm performs temperature-aware SiDB simulation as proposed
+in \"Temperature Behavior of Silicon Dangling Bond Logic\" by J.
+Drewniok, M. Walter, and R. Wille in IEEE NANO 2023
+(https://ieeexplore.ieee.org/document/10231259). It comes in two
+flavors: gate-based and non-gate based.
+
+For *Gate-based Critical Temperature* Simulation, the Critical
+Temperature is defined as follows: The temperature at which the
+erroneous charge distributions are populated by more than :math:`1 -
+\eta`, where :math:`\eta \in [0,1]`.
+
+Template parameter ``Lyt``:
+    SiDB cell-level layout type.
+
+Template parameter ``TT``:
+    Type of the truth table.
+
+Parameter ``lyt``:
+    The layout to simulate.
+
+Parameter ``spec``:
+    Expected Boolean function of the layout given as a multi-output
+    truth table.
+
+Parameter ``params``:
+    Simulation and physical parameters.
+
+Parameter ``pst``:
+    Statistics.
+
+Returns:
+    The critical temperature (unit: K).)doc";
+
+static const char *__doc_fiction_critical_temperature_non_gate_based =
+R"doc(For *Non-gate-based Critical Temperature* simulation, the Critical
+Temperature is defined as follows: The temperature at which the
+excited charge distributions are populated by more than :math:`1 -
+\eta`, where :math:`\eta \in [0,1]` is the confidence level for the
+presence of a working gate.
+
+Template parameter ``Lyt``:
+    SiDB cell-level layout type.
+
+Parameter ``lyt``:
+    The layout to simulate.
+
+Parameter ``params``:
+    Simulation and physical parameters.
+
+Parameter ``pst``:
+    Statistics.
+
+Returns:
+    The critical temperature (unit: K))doc";
+
 static const char *__doc_fiction_critical_temperature_params =
 R"doc(This struct stores the parameters for the *Critical Temperature*`
 algorithm.)doc";
@@ -5609,43 +5665,20 @@ static const char *__doc_fiction_detail_critical_path_length_and_throughput_impl
 
 static const char *__doc_fiction_detail_critical_path_length_and_throughput_impl_signal_delay = R"doc()doc";
 
-static const char *__doc_fiction_detail_critical_temperature_gate_based =
-R"doc(This algorithm performs temperature-aware SiDB simulation as proposed
-in \"Temperature Behavior of Silicon Dangling Bond Logic\" by J.
-Drewniok, M. Walter, and R. Wille in IEEE NANO 2023
-(https://ieeexplore.ieee.org/document/10231259). It comes in two
-flavors: gate-based and non-gate based.
-
-For *Gate-based Critical Temperature* Simulation, the Critical
-Temperature is defined as follows: The temperature at which the
-erroneous charge distributions are populated by more than :math:`1 -
-\eta`, where :math:`\eta \in [0,1]`.
-
-Template parameter ``Lyt``:
-    SiDB cell-level layout type.
-
-Template parameter ``TT``:
-    Type of the truth table.
-
-Parameter ``lyt``:
-    The layout to simulate.
-
-Parameter ``spec``:
-    Expected Boolean function of the layout given as a multi-output
-    truth table.
-
-Parameter ``params``:
-    Simulation and physical parameters.
-
-Parameter ``pst``:
-    Statistics.
-
-Returns:
-    The critical temperature (unit: K).)doc";
-
 static const char *__doc_fiction_detail_critical_temperature_impl = R"doc()doc";
 
+static const char *__doc_fiction_detail_critical_temperature_impl_bii = R"doc(Iterator that iterates over all possible input states.)doc";
+
+static const char *__doc_fiction_detail_critical_temperature_impl_critical_temperature = R"doc(Critical temperature [K].)doc";
+
 static const char *__doc_fiction_detail_critical_temperature_impl_critical_temperature_impl = R"doc()doc";
+
+static const char *__doc_fiction_detail_critical_temperature_impl_determine_critical_temperature =
+R"doc(The *Critical Temperature* is determined.
+
+Parameter ``energy_state_type``:
+    All energies of all physically valid charge distributions with the
+    corresponding state type (i.e. transparent, erroneous).)doc";
 
 static const char *__doc_fiction_detail_critical_temperature_impl_gate_based_simulation =
 R"doc(*Gate-based Critical Temperature* Simulation of a SiDB layout for a
@@ -5657,31 +5690,51 @@ Parameter ``spec``:
     Expected Boolean function of the layout given as a multi-output
     truth table.)doc";
 
+static const char *__doc_fiction_detail_critical_temperature_impl_get_critical_temperature =
+R"doc(Returns the critical temperature.
+
+Returns:
+    The critical temperature (unit: K).)doc";
+
+static const char *__doc_fiction_detail_critical_temperature_impl_is_ground_state_transparent =
+R"doc(The energy difference between the ground state and the first erroneous
+state is determined. Additionally, the state type of the ground state
+is determined and returned.
+
+Parameter ``energy_and_state_type``:
+    All energies of all physically valid charge distributions with the
+    corresponding state type (i.e. transparent, erroneous).
+
+Parameter ``min_energy``:
+    Minimal energy of all physically valid charge distributions of a
+    given layout (unit: eV).
+
+Returns:
+    State type (i.e. transparent, erroneous) of the ground state is
+    returned.)doc";
+
+static const char *__doc_fiction_detail_critical_temperature_impl_layout = R"doc(SiDB cell-level layout.)doc";
+
 static const char *__doc_fiction_detail_critical_temperature_impl_non_gate_based_simulation =
 R"doc(*Gate-based Critical Temperature* Simulation of a SiDB layout for a
 given Boolean function.)doc";
 
-static const char *__doc_fiction_detail_critical_temperature_non_gate_based =
-R"doc(For *Non-gate-based Critical Temperature* simulation, the Critical
-Temperature is defined as follows: The temperature at which the
-excited charge distributions are populated by more than :math:`1 -
-\eta`, where :math:`\eta \in [0,1]` is the confidence level for the
-presence of a working gate.
+static const char *__doc_fiction_detail_critical_temperature_impl_params = R"doc(Parameters for the critical_temperature algorithm.)doc";
 
-Template parameter ``Lyt``:
-    SiDB cell-level layout type.
+static const char *__doc_fiction_detail_critical_temperature_impl_physical_simulation_of_bdl_iterator =
+R"doc(This function conducts physical simulation of the given layout (gate
+layout with certain input combination). The simulation results are
+stored in the `sim_result_100` variable.
 
-Parameter ``lyt``:
-    The layout to simulate.
-
-Parameter ``params``:
-    Simulation and physical parameters.
-
-Parameter ``pst``:
-    Statistics.
+Parameter ``bdl_iterator``:
+    A reference to a BDL input iterator representing the gate layout
+    at a given input combination. The simulation is performed based on
+    the configuration represented by the iterator.
 
 Returns:
-    The critical temperature (unit: K))doc";
+    Simulation results.)doc";
+
+static const char *__doc_fiction_detail_critical_temperature_impl_stats = R"doc(Statistics.)doc";
 
 static const char *__doc_fiction_detail_defect_influence_impl = R"doc()doc";
 

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3884,62 +3884,6 @@ Returns:
 Throws:
     std::invalid_argument if the given sweep parameters are invalid.)doc";
 
-static const char *__doc_fiction_critical_temperature_gate_based =
-R"doc(This algorithm performs temperature-aware SiDB simulation as proposed
-in \"Temperature Behavior of Silicon Dangling Bond Logic\" by J.
-Drewniok, M. Walter, and R. Wille in IEEE NANO 2023
-(https://ieeexplore.ieee.org/document/10231259). It comes in two
-flavors: gate-based and non-gate based.
-
-For *Gate-based Critical Temperature* Simulation, the Critical
-Temperature is defined as follows: The temperature at which the
-erroneous charge distributions are populated by more than :math:`1 -
-\eta`, where :math:`\eta \in [0,1]`.
-
-Template parameter ``Lyt``:
-    SiDB cell-level layout type.
-
-Template parameter ``TT``:
-    Type of the truth table.
-
-Parameter ``lyt``:
-    The layout to simulate.
-
-Parameter ``spec``:
-    Expected Boolean function of the layout given as a multi-output
-    truth table.
-
-Parameter ``params``:
-    Simulation and physical parameters.
-
-Parameter ``pst``:
-    Statistics.
-
-Returns:
-    The critical temperature (unit: K).)doc";
-
-static const char *__doc_fiction_critical_temperature_non_gate_based =
-R"doc(For *Non-gate-based Critical Temperature* simulation, the Critical
-Temperature is defined as follows: The temperature at which the
-excited charge distributions are populated by more than :math:`1 -
-\eta`, where :math:`\eta \in [0,1]` is the confidence level for the
-presence of a working gate.
-
-Template parameter ``Lyt``:
-    SiDB cell-level layout type.
-
-Parameter ``lyt``:
-    The layout to simulate.
-
-Parameter ``params``:
-    Simulation and physical parameters.
-
-Parameter ``pst``:
-    Statistics.
-
-Returns:
-    The critical temperature (unit: K))doc";
-
 static const char *__doc_fiction_critical_temperature_params =
 R"doc(This struct stores the parameters for the *Critical Temperature*`
 algorithm.)doc";
@@ -5665,20 +5609,43 @@ static const char *__doc_fiction_detail_critical_path_length_and_throughput_impl
 
 static const char *__doc_fiction_detail_critical_path_length_and_throughput_impl_signal_delay = R"doc()doc";
 
+static const char *__doc_fiction_detail_critical_temperature_gate_based =
+R"doc(This algorithm performs temperature-aware SiDB simulation as proposed
+in \"Temperature Behavior of Silicon Dangling Bond Logic\" by J.
+Drewniok, M. Walter, and R. Wille in IEEE NANO 2023
+(https://ieeexplore.ieee.org/document/10231259). It comes in two
+flavors: gate-based and non-gate based.
+
+For *Gate-based Critical Temperature* Simulation, the Critical
+Temperature is defined as follows: The temperature at which the
+erroneous charge distributions are populated by more than :math:`1 -
+\eta`, where :math:`\eta \in [0,1]`.
+
+Template parameter ``Lyt``:
+    SiDB cell-level layout type.
+
+Template parameter ``TT``:
+    Type of the truth table.
+
+Parameter ``lyt``:
+    The layout to simulate.
+
+Parameter ``spec``:
+    Expected Boolean function of the layout given as a multi-output
+    truth table.
+
+Parameter ``params``:
+    Simulation and physical parameters.
+
+Parameter ``pst``:
+    Statistics.
+
+Returns:
+    The critical temperature (unit: K).)doc";
+
 static const char *__doc_fiction_detail_critical_temperature_impl = R"doc()doc";
 
-static const char *__doc_fiction_detail_critical_temperature_impl_bii = R"doc(Iterator that iterates over all possible input states.)doc";
-
-static const char *__doc_fiction_detail_critical_temperature_impl_critical_temperature = R"doc(Critical temperature [K].)doc";
-
 static const char *__doc_fiction_detail_critical_temperature_impl_critical_temperature_impl = R"doc()doc";
-
-static const char *__doc_fiction_detail_critical_temperature_impl_determine_critical_temperature =
-R"doc(The *Critical Temperature* is determined.
-
-Parameter ``energy_state_type``:
-    All energies of all physically valid charge distributions with the
-    corresponding state type (i.e. transparent, erroneous).)doc";
 
 static const char *__doc_fiction_detail_critical_temperature_impl_gate_based_simulation =
 R"doc(*Gate-based Critical Temperature* Simulation of a SiDB layout for a
@@ -5690,51 +5657,31 @@ Parameter ``spec``:
     Expected Boolean function of the layout given as a multi-output
     truth table.)doc";
 
-static const char *__doc_fiction_detail_critical_temperature_impl_get_critical_temperature =
-R"doc(Returns the critical temperature.
-
-Returns:
-    The critical temperature (unit: K).)doc";
-
-static const char *__doc_fiction_detail_critical_temperature_impl_is_ground_state_transparent =
-R"doc(The energy difference between the ground state and the first erroneous
-state is determined. Additionally, the state type of the ground state
-is determined and returned.
-
-Parameter ``energy_and_state_type``:
-    All energies of all physically valid charge distributions with the
-    corresponding state type (i.e. transparent, erroneous).
-
-Parameter ``min_energy``:
-    Minimal energy of all physically valid charge distributions of a
-    given layout (unit: eV).
-
-Returns:
-    State type (i.e. transparent, erroneous) of the ground state is
-    returned.)doc";
-
-static const char *__doc_fiction_detail_critical_temperature_impl_layout = R"doc(SiDB cell-level layout.)doc";
-
 static const char *__doc_fiction_detail_critical_temperature_impl_non_gate_based_simulation =
 R"doc(*Gate-based Critical Temperature* Simulation of a SiDB layout for a
 given Boolean function.)doc";
 
-static const char *__doc_fiction_detail_critical_temperature_impl_params = R"doc(Parameters for the critical_temperature algorithm.)doc";
+static const char *__doc_fiction_detail_critical_temperature_non_gate_based =
+R"doc(For *Non-gate-based Critical Temperature* simulation, the Critical
+Temperature is defined as follows: The temperature at which the
+excited charge distributions are populated by more than :math:`1 -
+\eta`, where :math:`\eta \in [0,1]` is the confidence level for the
+presence of a working gate.
 
-static const char *__doc_fiction_detail_critical_temperature_impl_physical_simulation_of_bdl_iterator =
-R"doc(This function conducts physical simulation of the given layout (gate
-layout with certain input combination). The simulation results are
-stored in the `sim_result_100` variable.
+Template parameter ``Lyt``:
+    SiDB cell-level layout type.
 
-Parameter ``bdl_iterator``:
-    A reference to a BDL input iterator representing the gate layout
-    at a given input combination. The simulation is performed based on
-    the configuration represented by the iterator.
+Parameter ``lyt``:
+    The layout to simulate.
+
+Parameter ``params``:
+    Simulation and physical parameters.
+
+Parameter ``pst``:
+    Statistics.
 
 Returns:
-    Simulation results.)doc";
-
-static const char *__doc_fiction_detail_critical_temperature_impl_stats = R"doc(Statistics.)doc";
+    The critical temperature (unit: K))doc";
 
 static const char *__doc_fiction_detail_defect_influence_impl = R"doc()doc";
 

--- a/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
+++ b/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
@@ -136,8 +136,7 @@ class critical_temperature_impl
     /**
      * *Gate-based Critical Temperature* Simulation of a SiDB layout for a given Boolean function.
      *
-
-     * tparam TT Type of the truth table.
+     * @tparam TT Type of the truth table.
      * @param spec Expected Boolean function of the layout given as a multi-output truth table.
      */
     template <typename TT>

--- a/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
+++ b/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
@@ -254,234 +254,234 @@ class critical_temperature_impl
             // All physically valid charge configurations are determined for the given layout (`ClusterComplete`
             // simulation is used to provide 100 % accuracy for the Critical Temperature).
             simulation_results = clustercomplete(layout, cc_params);
+        }
 #endif  // FICTION_ALGLIB_ENABLED
-            else if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
-            {
-                const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
-                                                params.alpha};
+        else if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
+        {
+            const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
+                                            params.alpha};
 
-                // All physically valid charge configurations are determined for the given layout (probabilistic ground
-                // state simulation is used).
-                if (const auto result = quicksim(layout, qs_params); result.has_value())
-                {
-                    simulation_results = result.value();
-                }
-                else
-                {
-                    return;
-                }
+            // All physically valid charge configurations are determined for the given layout (probabilistic ground
+            // state simulation is used).
+            if (const auto result = quicksim(layout, qs_params); result.has_value())
+            {
+                simulation_results = result.value();
             }
             else
             {
-                assert(false && "unsupported simulation engine");
-            }
-
-            // The number of physically valid charge configurations is stored.
-            stats.num_valid_lyt = simulation_results.charge_distributions.size();
-
-            const auto distribution = energy_distribution(simulation_results.charge_distributions);
-
-            // if there is more than one metastable state
-            if (distribution.size() > 1)
-            {
-                const auto ground_state_energy        = distribution.cbegin()->first;
-                const auto first_excited_state_energy = std::next(distribution.cbegin())->first;
-
-                // The energy difference between the first excited and the ground state in meV.
-                if (stats.energy_between_ground_state_and_first_erroneous >
-                    (first_excited_state_energy - ground_state_energy) * 1000)
-                {
-                    stats.energy_between_ground_state_and_first_erroneous =
-                        (first_excited_state_energy - ground_state_energy) * 1000;
-                }
-            }
-
-            std::vector<double> temp_values{};  // unit: K
-
-            // Calculate the number of iterations as an integer
-            const auto num_iterations = static_cast<uint64_t>(std::round(params.max_temperature * 100));
-            // Reserve space for the vector
-            temp_values.reserve(num_iterations);
-            for (uint64_t i = 1; i <= num_iterations; i++)
-            {
-                temp_values.emplace_back(static_cast<double>(i) / 100.0);
-            }
-
-            // This function determines the critical temperature for a given confidence level.
-            for (const auto& temp : temp_values)
-            {
-                // If the occupation probability of excited states exceeds the given threshold.
-                if (occupation_probability_non_gate_based(distribution, temp) > (1 - params.confidence_level) &&
-                    (temp < critical_temperature))
-                {
-                    // The current temperature is stored as the critical temperature.
-                    critical_temperature = temp;
-
-                    break;
-                }
-
-                if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
-                {
-                    // Maximal temperature is stored as the Critical Temperature.
-                    critical_temperature = params.max_temperature;
-                }
+                return;
             }
         }
-        /**
-         * Returns the critical temperature.
-         *
-         * @return The critical temperature (unit: K).
-         */
-        [[nodiscard]] double get_critical_temperature() const noexcept
+        else
         {
-            return critical_temperature;
-        }
-
-      private:
-        /**
-         * The energy difference between the ground state and the first erroneous state is determined. Additionally, the
-         * state type of the ground state is determined and returned.
-         *
-         * @param energy_and_state_type All energies of all physically valid charge distributions with the corresponding
-         * state type (i.e. transparent, erroneous).
-         * @param min_energy Minimal energy of all physically valid charge distributions of a given layout (unit: eV).
-         * @return State type (i.e. transparent, erroneous) of the ground state is returned.
-         */
-        bool is_ground_state_transparent(const sidb_energy_and_state_type& energy_and_state_type,
-                                         const double                      min_energy) noexcept
-        {
-            bool ground_state_is_transparent = false;
-
-            for (const auto& [energy, state_type] : energy_and_state_type)
-            {
-                // Check if there is at least one ground state that satisfies the logic (transparent). Round the energy
-                // value of the given valid_layout to six decimal places to overcome possible rounding errors and for
-                // comparability with the min_energy.
-                if (std::abs(round_to_n_decimal_places(energy, 6) - round_to_n_decimal_places(min_energy, 6)) <
-                        constants::ERROR_MARGIN &&
-                    state_type)
-                {
-                    ground_state_is_transparent = true;
-                }
-
-                if (!state_type && (energy > min_energy) && ground_state_is_transparent &&
-                    (((energy - min_energy) * 1000) < stats.energy_between_ground_state_and_first_erroneous))
-                {
-                    // The energy difference is stored in meV.
-                    stats.energy_between_ground_state_and_first_erroneous = (energy - min_energy) * 1000;
-                    break;
-                }
-            }
-            return ground_state_is_transparent;
-        };
-        /**
-         * The *Critical Temperature* is determined.
-         *
-         * @param energy_state_type All energies of all physically valid charge distributions with the corresponding
-         * state type (i.e. transparent, erroneous).
-         */
-        void determine_critical_temperature(const sidb_energy_and_state_type& energy_state_type) noexcept
-        {
-            // Vector with temperature values from 0.01 to max_temperature * 100 K in 0.01 K steps is generated.
-            std::vector<double> temp_values{};
-            temp_values.reserve(static_cast<uint64_t>(params.max_temperature * 100));
-
-            for (uint64_t i = 1; i <= static_cast<uint64_t>(params.max_temperature * 100); i++)
-            {
-                temp_values.emplace_back(static_cast<double>(i) / 100.0);
-            }
-            // This function determines the Critical Temperature for a given confidence level.
-            for (const auto& temp : temp_values)
-            {
-                // If the occupation probability of erroneous states exceeds the given threshold...
-                if (occupation_probability_gate_based(energy_state_type, temp) > (1 - params.confidence_level) &&
-                    (temp < critical_temperature))
-                {
-                    // The current temperature is stored as Critical Temperature.
-                    critical_temperature = temp;
-                    break;
-                }
-                if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
-                {
-                    // Maximal temperature is stored as Critical Temperature.
-                    critical_temperature = params.max_temperature;
-                }
-            }
-        }
-
-        /**
-         * SiDB cell-level layout.
-         */
-        Lyt layout;
-        /**
-         * Parameters for the critical_temperature algorithm.
-         */
-        const critical_temperature_params& params;
-        /**
-         * Statistics.
-         */
-        critical_temperature_stats & stats;
-        /**
-         * Iterator that iterates over all possible input states.
-         */
-        bdl_input_iterator<Lyt> bii;
-        /**
-         * Critical temperature [K].
-         */
-        double critical_temperature;
-        /**
-         * This function conducts physical simulation of the given layout (gate layout with certain input combination).
-         * The simulation results are stored in the `sim_result_100` variable.
-         *
-         * @param bdl_iterator A reference to a BDL input iterator representing the gate layout at a given input
-         * combination. The simulation is performed based on the configuration represented by the iterator.
-         * @return Simulation results.
-         */
-        [[nodiscard]] sidb_simulation_result<Lyt> physical_simulation_of_bdl_iterator(
-            const bdl_input_iterator<Lyt>& bdl_iterator) noexcept
-        {
-            if (params.operational_params.sim_engine == sidb_simulation_engine::EXGS)
-            {
-                // perform exhaustive ground state simulation
-                return exhaustive_ground_state_simulation(*bdl_iterator,
-                                                          params.operational_params.simulation_parameters);
-            }
-            if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKEXACT)
-            {
-                // perform QuickExact exact simulation
-                const quickexact_params<cell<Lyt>> qe_params{
-                    params.operational_params.simulation_parameters,
-                    fiction::quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
-                return quickexact(*bdl_iterator, qe_params);
-            }
-#if (FICTION_ALGLIB_ENABLED)
-            if (params.operational_params.sim_engine == sidb_simulation_engine::CLUSTERCOMPLETE)
-            {
-                // perform ClusterComplete exact simulation
-                const clustercomplete_params<cell<Lyt>> cc_params{params.operational_params.simulation_parameters};
-                return clustercomplete(*bdl_iterator, cc_params);
-            }
-#endif  // FICTION_ALGLIB_ENABLED
-            if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
-            {
-                assert(params.operational_params.simulation_parameters.base == 2 &&
-                       "QuickSim does not support base-3 simulation");
-
-                const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
-                                                params.alpha};
-
-                if (const auto result = quicksim<Lyt>(*bdl_iterator, qs_params))
-                {
-                    return result.value();
-                }
-                return sidb_simulation_result<Lyt>{};  // return empty result if no valid charge distribution was found
-            }
-
             assert(false && "unsupported simulation engine");
-
-            return sidb_simulation_result<Lyt>{};
         }
+
+        // The number of physically valid charge configurations is stored.
+        stats.num_valid_lyt = simulation_results.charge_distributions.size();
+
+        const auto distribution = energy_distribution(simulation_results.charge_distributions);
+
+        // if there is more than one metastable state
+        if (distribution.size() > 1)
+        {
+            const auto ground_state_energy        = distribution.cbegin()->first;
+            const auto first_excited_state_energy = std::next(distribution.cbegin())->first;
+
+            // The energy difference between the first excited and the ground state in meV.
+            if (stats.energy_between_ground_state_and_first_erroneous >
+                (first_excited_state_energy - ground_state_energy) * 1000)
+            {
+                stats.energy_between_ground_state_and_first_erroneous =
+                    (first_excited_state_energy - ground_state_energy) * 1000;
+            }
+        }
+
+        std::vector<double> temp_values{};  // unit: K
+
+        // Calculate the number of iterations as an integer
+        const auto num_iterations = static_cast<uint64_t>(std::round(params.max_temperature * 100));
+        // Reserve space for the vector
+        temp_values.reserve(num_iterations);
+        for (uint64_t i = 1; i <= num_iterations; i++)
+        {
+            temp_values.emplace_back(static_cast<double>(i) / 100.0);
+        }
+
+        // This function determines the critical temperature for a given confidence level.
+        for (const auto& temp : temp_values)
+        {
+            // If the occupation probability of excited states exceeds the given threshold.
+            if (occupation_probability_non_gate_based(distribution, temp) > (1 - params.confidence_level) &&
+                (temp < critical_temperature))
+            {
+                // The current temperature is stored as the critical temperature.
+                critical_temperature = temp;
+
+                break;
+            }
+
+            if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
+            {
+                // Maximal temperature is stored as the Critical Temperature.
+                critical_temperature = params.max_temperature;
+            }
+        }
+    }
+    /**
+     * Returns the critical temperature.
+     *
+     * @return The critical temperature (unit: K).
+     */
+    [[nodiscard]] double get_critical_temperature() const noexcept
+    {
+        return critical_temperature;
+    }
+
+  private:
+    /**
+     * The energy difference between the ground state and the first erroneous state is determined. Additionally, the
+     * state type of the ground state is determined and returned.
+     *
+     * @param energy_and_state_type All energies of all physically valid charge distributions with the corresponding
+     * state type (i.e. transparent, erroneous).
+     * @param min_energy Minimal energy of all physically valid charge distributions of a given layout (unit: eV).
+     * @return State type (i.e. transparent, erroneous) of the ground state is returned.
+     */
+    bool is_ground_state_transparent(const sidb_energy_and_state_type& energy_and_state_type,
+                                     const double                      min_energy) noexcept
+    {
+        bool ground_state_is_transparent = false;
+
+        for (const auto& [energy, state_type] : energy_and_state_type)
+        {
+            // Check if there is at least one ground state that satisfies the logic (transparent). Round the energy
+            // value of the given valid_layout to six decimal places to overcome possible rounding errors and for
+            // comparability with the min_energy.
+            if (std::abs(round_to_n_decimal_places(energy, 6) - round_to_n_decimal_places(min_energy, 6)) <
+                    constants::ERROR_MARGIN &&
+                state_type)
+            {
+                ground_state_is_transparent = true;
+            }
+
+            if (!state_type && (energy > min_energy) && ground_state_is_transparent &&
+                (((energy - min_energy) * 1000) < stats.energy_between_ground_state_and_first_erroneous))
+            {
+                // The energy difference is stored in meV.
+                stats.energy_between_ground_state_and_first_erroneous = (energy - min_energy) * 1000;
+                break;
+            }
+        }
+        return ground_state_is_transparent;
     };
+    /**
+     * The *Critical Temperature* is determined.
+     *
+     * @param energy_state_type All energies of all physically valid charge distributions with the corresponding
+     * state type (i.e. transparent, erroneous).
+     */
+    void determine_critical_temperature(const sidb_energy_and_state_type& energy_state_type) noexcept
+    {
+        // Vector with temperature values from 0.01 to max_temperature * 100 K in 0.01 K steps is generated.
+        std::vector<double> temp_values{};
+        temp_values.reserve(static_cast<uint64_t>(params.max_temperature * 100));
+
+        for (uint64_t i = 1; i <= static_cast<uint64_t>(params.max_temperature * 100); i++)
+        {
+            temp_values.emplace_back(static_cast<double>(i) / 100.0);
+        }
+        // This function determines the Critical Temperature for a given confidence level.
+        for (const auto& temp : temp_values)
+        {
+            // If the occupation probability of erroneous states exceeds the given threshold...
+            if (occupation_probability_gate_based(energy_state_type, temp) > (1 - params.confidence_level) &&
+                (temp < critical_temperature))
+            {
+                // The current temperature is stored as Critical Temperature.
+                critical_temperature = temp;
+                break;
+            }
+            if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
+            {
+                // Maximal temperature is stored as Critical Temperature.
+                critical_temperature = params.max_temperature;
+            }
+        }
+    }
+
+    /**
+     * SiDB cell-level layout.
+     */
+    Lyt layout;
+    /**
+     * Parameters for the critical_temperature algorithm.
+     */
+    const critical_temperature_params& params;
+    /**
+     * Statistics.
+     */
+    critical_temperature_stats& stats;
+    /**
+     * Iterator that iterates over all possible input states.
+     */
+    bdl_input_iterator<Lyt> bii;
+    /**
+     * Critical temperature [K].
+     */
+    double critical_temperature;
+    /**
+     * This function conducts physical simulation of the given layout (gate layout with certain input combination).
+     * The simulation results are stored in the `sim_result_100` variable.
+     *
+     * @param bdl_iterator A reference to a BDL input iterator representing the gate layout at a given input
+     * combination. The simulation is performed based on the configuration represented by the iterator.
+     * @return Simulation results.
+     */
+    [[nodiscard]] sidb_simulation_result<Lyt>
+    physical_simulation_of_bdl_iterator(const bdl_input_iterator<Lyt>& bdl_iterator) noexcept
+    {
+        if (params.operational_params.sim_engine == sidb_simulation_engine::EXGS)
+        {
+            // perform exhaustive ground state simulation
+            return exhaustive_ground_state_simulation(*bdl_iterator, params.operational_params.simulation_parameters);
+        }
+        if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKEXACT)
+        {
+            // perform QuickExact exact simulation
+            const quickexact_params<cell<Lyt>> qe_params{
+                params.operational_params.simulation_parameters,
+                fiction::quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
+            return quickexact(*bdl_iterator, qe_params);
+        }
+#if (FICTION_ALGLIB_ENABLED)
+        if (params.operational_params.sim_engine == sidb_simulation_engine::CLUSTERCOMPLETE)
+        {
+            // perform ClusterComplete exact simulation
+            const clustercomplete_params<cell<Lyt>> cc_params{params.operational_params.simulation_parameters};
+            return clustercomplete(*bdl_iterator, cc_params);
+        }
+#endif  // FICTION_ALGLIB_ENABLED
+        if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
+        {
+            assert(params.operational_params.simulation_parameters.base == 2 &&
+                   "QuickSim does not support base-3 simulation");
+
+            const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
+                                            params.alpha};
+
+            if (const auto result = quicksim<Lyt>(*bdl_iterator, qs_params))
+            {
+                return result.value();
+            }
+            return sidb_simulation_result<Lyt>{};  // return empty result if no valid charge distribution was found
+        }
+
+        assert(false && "unsupported simulation engine");
+
+        return sidb_simulation_result<Lyt>{};
+    }
+};
 
 }  // namespace detail
 

--- a/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
+++ b/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
@@ -254,237 +254,234 @@ class critical_temperature_impl
             // All physically valid charge configurations are determined for the given layout (`ClusterComplete`
             // simulation is used to provide 100 % accuracy for the Critical Temperature).
             simulation_results = clustercomplete(layout, cc_params);
-#else  // FICTION_ALGLIB_ENABLED
-    }
-    else if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
-    {
-        const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
-                                        params.alpha};
-
-        // All physically valid charge configurations are determined for the given layout (probabilistic ground
-        // state simulation is used).
-        if (const auto result = quicksim(layout, qs_params); result.has_value())
-        {
-            simulation_results = result.value();
-        }
-        else
-        {
-            return;
-        }
-    }
-    else
-    {
-        assert(false && "unsupported simulation engine");
-    }
-
-    // The number of physically valid charge configurations is stored.
-    stats.num_valid_lyt = simulation_results.charge_distributions.size();
-
-    const auto distribution = energy_distribution(simulation_results.charge_distributions);
-
-    // if there is more than one metastable state
-    if (distribution.size() > 1)
-    {
-        const auto ground_state_energy        = distribution.cbegin()->first;
-        const auto first_excited_state_energy = std::next(distribution.cbegin())->first;
-
-        // The energy difference between the first excited and the ground state in meV.
-        if (stats.energy_between_ground_state_and_first_erroneous >
-            (first_excited_state_energy - ground_state_energy) * 1000)
-        {
-            stats.energy_between_ground_state_and_first_erroneous =
-                (first_excited_state_energy - ground_state_energy) * 1000;
-        }
-    }
-
-    std::vector<double> temp_values{};  // unit: K
-
-    // Calculate the number of iterations as an integer
-    const auto num_iterations = static_cast<uint64_t>(std::round(params.max_temperature * 100));
-    // Reserve space for the vector
-    temp_values.reserve(num_iterations);
-    for (uint64_t i = 1; i <= num_iterations; i++)
-    {
-        temp_values.emplace_back(static_cast<double>(i) / 100.0);
-    }
-
-    // This function determines the critical temperature for a given confidence level.
-    for (const auto& temp : temp_values)
-    {
-        // If the occupation probability of excited states exceeds the given threshold.
-        if (occupation_probability_non_gate_based(distribution, temp) > (1 - params.confidence_level) &&
-            (temp < critical_temperature))
-        {
-            // The current temperature is stored as the critical temperature.
-            critical_temperature = temp;
-
-            break;
-        }
-
-        if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
-        {
-            // Maximal temperature is stored as the Critical Temperature.
-            critical_temperature = params.max_temperature;
-        }
-    }
-}
-/**
- * Returns the critical temperature.
- *
- * @return The critical temperature (unit: K).
- */
-[[nodiscard]] double
-get_critical_temperature() const noexcept
-{
-    return critical_temperature;
-}
-
-private:
-/**
- * The energy difference between the ground state and the first erroneous state is determined. Additionally, the
- * state type of the ground state is determined and returned.
- *
- * @param energy_and_state_type All energies of all physically valid charge distributions with the corresponding
- * state type (i.e. transparent, erroneous).
- * @param min_energy Minimal energy of all physically valid charge distributions of a given layout (unit: eV).
- * @return State type (i.e. transparent, erroneous) of the ground state is returned.
- */
-bool is_ground_state_transparent(const sidb_energy_and_state_type& energy_and_state_type,
-                                 const double                      min_energy) noexcept
-{
-    bool ground_state_is_transparent = false;
-
-    for (const auto& [energy, state_type] : energy_and_state_type)
-    {
-        // Check if there is at least one ground state that satisfies the logic (transparent). Round the energy
-        // value of the given valid_layout to six decimal places to overcome possible rounding errors and for
-        // comparability with the min_energy.
-        if (std::abs(round_to_n_decimal_places(energy, 6) - round_to_n_decimal_places(min_energy, 6)) <
-                constants::ERROR_MARGIN &&
-            state_type)
-        {
-            ground_state_is_transparent = true;
-        }
-
-        if (!state_type && (energy > min_energy) && ground_state_is_transparent &&
-            (((energy - min_energy) * 1000) < stats.energy_between_ground_state_and_first_erroneous))
-        {
-            // The energy difference is stored in meV.
-            stats.energy_between_ground_state_and_first_erroneous = (energy - min_energy) * 1000;
-            break;
-        }
-    }
-    return ground_state_is_transparent;
-};
-/**
- * The *Critical Temperature* is determined.
- *
- * @param energy_state_type All energies of all physically valid charge distributions with the corresponding state
- * type (i.e. transparent, erroneous).
- */
-void determine_critical_temperature(const sidb_energy_and_state_type& energy_state_type) noexcept
-{
-    // Vector with temperature values from 0.01 to max_temperature * 100 K in 0.01 K steps is generated.
-    std::vector<double> temp_values{};
-    temp_values.reserve(static_cast<uint64_t>(params.max_temperature * 100));
-
-    for (uint64_t i = 1; i <= static_cast<uint64_t>(params.max_temperature * 100); i++)
-    {
-        temp_values.emplace_back(static_cast<double>(i) / 100.0);
-    }
-    // This function determines the Critical Temperature for a given confidence level.
-    for (const auto& temp : temp_values)
-    {
-        // If the occupation probability of erroneous states exceeds the given threshold...
-        if (occupation_probability_gate_based(energy_state_type, temp) > (1 - params.confidence_level) &&
-            (temp < critical_temperature))
-        {
-            // The current temperature is stored as Critical Temperature.
-            critical_temperature = temp;
-            break;
-        }
-        if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
-        {
-            // Maximal temperature is stored as Critical Temperature.
-            critical_temperature = params.max_temperature;
-        }
-    }
-}
-
-/**
- * SiDB cell-level layout.
- */
-Lyt layout;
-/**
- * Parameters for the critical_temperature algorithm.
- */
-const critical_temperature_params& params;
-/**
- * Statistics.
- */
-critical_temperature_stats & stats;
-/**
- * Iterator that iterates over all possible input states.
- */
-bdl_input_iterator<Lyt> bii;
-/**
- * Critical temperature [K].
- */
-double critical_temperature;
-/**
- * This function conducts physical simulation of the given layout (gate layout with certain input combination). The
- * simulation results are stored in the `sim_result_100` variable.
- *
- * @param bdl_iterator A reference to a BDL input iterator representing the gate layout at a given input
- * combination. The simulation is performed based on the configuration represented by the iterator.
- * @return Simulation results.
- */
-[[nodiscard]] sidb_simulation_result<Lyt>
-physical_simulation_of_bdl_iterator(const bdl_input_iterator<Lyt>& bdl_iterator) noexcept
-{
-    if (params.operational_params.sim_engine == sidb_simulation_engine::EXGS)
-    {
-        // perform exhaustive ground state simulation
-        return exhaustive_ground_state_simulation(*bdl_iterator, params.operational_params.simulation_parameters);
-    }
-    if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKEXACT)
-    {
-        // perform QuickExact exact simulation
-        const quickexact_params<cell<Lyt>> qe_params{
-            params.operational_params.simulation_parameters,
-            fiction::quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
-        return quickexact(*bdl_iterator, qe_params);
-    }
-    if (params.operational_params.sim_engine == sidb_simulation_engine::CLUSTERCOMPLETE)
-    {
-#if (FICTION_ALGLIB_ENABLED)
-        // perform ClusterComplete exact simulation
-        const clustercomplete_params<cell<Lyt>> cc_params{params.operational_params.simulation_parameters};
-        return clustercomplete(*bdl_iterator, cc_params);
-#else   // FICTION_ALGLIB_ENABLED
-        assert(false && "ALGLIB must be enabled if ClusterComplete is to be used");
 #endif  // FICTION_ALGLIB_ENABLED
-    }
-    if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
-    {
-        assert(params.operational_params.simulation_parameters.base == 2 &&
-               "QuickSim does not support base-3 simulation");
+            else if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
+            {
+                const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
+                                                params.alpha};
 
-        const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
-                                        params.alpha};
+                // All physically valid charge configurations are determined for the given layout (probabilistic ground
+                // state simulation is used).
+                if (const auto result = quicksim(layout, qs_params); result.has_value())
+                {
+                    simulation_results = result.value();
+                }
+                else
+                {
+                    return;
+                }
+            }
+            else
+            {
+                assert(false && "unsupported simulation engine");
+            }
 
-        if (const auto result = quicksim<Lyt>(*bdl_iterator, qs_params))
-        {
-            return result.value();
+            // The number of physically valid charge configurations is stored.
+            stats.num_valid_lyt = simulation_results.charge_distributions.size();
+
+            const auto distribution = energy_distribution(simulation_results.charge_distributions);
+
+            // if there is more than one metastable state
+            if (distribution.size() > 1)
+            {
+                const auto ground_state_energy        = distribution.cbegin()->first;
+                const auto first_excited_state_energy = std::next(distribution.cbegin())->first;
+
+                // The energy difference between the first excited and the ground state in meV.
+                if (stats.energy_between_ground_state_and_first_erroneous >
+                    (first_excited_state_energy - ground_state_energy) * 1000)
+                {
+                    stats.energy_between_ground_state_and_first_erroneous =
+                        (first_excited_state_energy - ground_state_energy) * 1000;
+                }
+            }
+
+            std::vector<double> temp_values{};  // unit: K
+
+            // Calculate the number of iterations as an integer
+            const auto num_iterations = static_cast<uint64_t>(std::round(params.max_temperature * 100));
+            // Reserve space for the vector
+            temp_values.reserve(num_iterations);
+            for (uint64_t i = 1; i <= num_iterations; i++)
+            {
+                temp_values.emplace_back(static_cast<double>(i) / 100.0);
+            }
+
+            // This function determines the critical temperature for a given confidence level.
+            for (const auto& temp : temp_values)
+            {
+                // If the occupation probability of excited states exceeds the given threshold.
+                if (occupation_probability_non_gate_based(distribution, temp) > (1 - params.confidence_level) &&
+                    (temp < critical_temperature))
+                {
+                    // The current temperature is stored as the critical temperature.
+                    critical_temperature = temp;
+
+                    break;
+                }
+
+                if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
+                {
+                    // Maximal temperature is stored as the Critical Temperature.
+                    critical_temperature = params.max_temperature;
+                }
+            }
         }
-        return sidb_simulation_result<Lyt>{};  // return empty result if no valid charge distribution was found
-    }
+        /**
+         * Returns the critical temperature.
+         *
+         * @return The critical temperature (unit: K).
+         */
+        [[nodiscard]] double get_critical_temperature() const noexcept
+        {
+            return critical_temperature;
+        }
 
-    assert(false && "unsupported simulation engine");
+      private:
+        /**
+         * The energy difference between the ground state and the first erroneous state is determined. Additionally, the
+         * state type of the ground state is determined and returned.
+         *
+         * @param energy_and_state_type All energies of all physically valid charge distributions with the corresponding
+         * state type (i.e. transparent, erroneous).
+         * @param min_energy Minimal energy of all physically valid charge distributions of a given layout (unit: eV).
+         * @return State type (i.e. transparent, erroneous) of the ground state is returned.
+         */
+        bool is_ground_state_transparent(const sidb_energy_and_state_type& energy_and_state_type,
+                                         const double                      min_energy) noexcept
+        {
+            bool ground_state_is_transparent = false;
 
-    return sidb_simulation_result<Lyt>{};
-}
-};
+            for (const auto& [energy, state_type] : energy_and_state_type)
+            {
+                // Check if there is at least one ground state that satisfies the logic (transparent). Round the energy
+                // value of the given valid_layout to six decimal places to overcome possible rounding errors and for
+                // comparability with the min_energy.
+                if (std::abs(round_to_n_decimal_places(energy, 6) - round_to_n_decimal_places(min_energy, 6)) <
+                        constants::ERROR_MARGIN &&
+                    state_type)
+                {
+                    ground_state_is_transparent = true;
+                }
+
+                if (!state_type && (energy > min_energy) && ground_state_is_transparent &&
+                    (((energy - min_energy) * 1000) < stats.energy_between_ground_state_and_first_erroneous))
+                {
+                    // The energy difference is stored in meV.
+                    stats.energy_between_ground_state_and_first_erroneous = (energy - min_energy) * 1000;
+                    break;
+                }
+            }
+            return ground_state_is_transparent;
+        };
+        /**
+         * The *Critical Temperature* is determined.
+         *
+         * @param energy_state_type All energies of all physically valid charge distributions with the corresponding
+         * state type (i.e. transparent, erroneous).
+         */
+        void determine_critical_temperature(const sidb_energy_and_state_type& energy_state_type) noexcept
+        {
+            // Vector with temperature values from 0.01 to max_temperature * 100 K in 0.01 K steps is generated.
+            std::vector<double> temp_values{};
+            temp_values.reserve(static_cast<uint64_t>(params.max_temperature * 100));
+
+            for (uint64_t i = 1; i <= static_cast<uint64_t>(params.max_temperature * 100); i++)
+            {
+                temp_values.emplace_back(static_cast<double>(i) / 100.0);
+            }
+            // This function determines the Critical Temperature for a given confidence level.
+            for (const auto& temp : temp_values)
+            {
+                // If the occupation probability of erroneous states exceeds the given threshold...
+                if (occupation_probability_gate_based(energy_state_type, temp) > (1 - params.confidence_level) &&
+                    (temp < critical_temperature))
+                {
+                    // The current temperature is stored as Critical Temperature.
+                    critical_temperature = temp;
+                    break;
+                }
+                if (std::abs(temp - params.max_temperature) < 0.001 && (temp < critical_temperature))
+                {
+                    // Maximal temperature is stored as Critical Temperature.
+                    critical_temperature = params.max_temperature;
+                }
+            }
+        }
+
+        /**
+         * SiDB cell-level layout.
+         */
+        Lyt layout;
+        /**
+         * Parameters for the critical_temperature algorithm.
+         */
+        const critical_temperature_params& params;
+        /**
+         * Statistics.
+         */
+        critical_temperature_stats & stats;
+        /**
+         * Iterator that iterates over all possible input states.
+         */
+        bdl_input_iterator<Lyt> bii;
+        /**
+         * Critical temperature [K].
+         */
+        double critical_temperature;
+        /**
+         * This function conducts physical simulation of the given layout (gate layout with certain input combination).
+         * The simulation results are stored in the `sim_result_100` variable.
+         *
+         * @param bdl_iterator A reference to a BDL input iterator representing the gate layout at a given input
+         * combination. The simulation is performed based on the configuration represented by the iterator.
+         * @return Simulation results.
+         */
+        [[nodiscard]] sidb_simulation_result<Lyt> physical_simulation_of_bdl_iterator(
+            const bdl_input_iterator<Lyt>& bdl_iterator) noexcept
+        {
+            if (params.operational_params.sim_engine == sidb_simulation_engine::EXGS)
+            {
+                // perform exhaustive ground state simulation
+                return exhaustive_ground_state_simulation(*bdl_iterator,
+                                                          params.operational_params.simulation_parameters);
+            }
+            if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKEXACT)
+            {
+                // perform QuickExact exact simulation
+                const quickexact_params<cell<Lyt>> qe_params{
+                    params.operational_params.simulation_parameters,
+                    fiction::quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
+                return quickexact(*bdl_iterator, qe_params);
+            }
+#if (FICTION_ALGLIB_ENABLED)
+            if (params.operational_params.sim_engine == sidb_simulation_engine::CLUSTERCOMPLETE)
+            {
+                // perform ClusterComplete exact simulation
+                const clustercomplete_params<cell<Lyt>> cc_params{params.operational_params.simulation_parameters};
+                return clustercomplete(*bdl_iterator, cc_params);
+            }
+#endif  // FICTION_ALGLIB_ENABLED
+            if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
+            {
+                assert(params.operational_params.simulation_parameters.base == 2 &&
+                       "QuickSim does not support base-3 simulation");
+
+                const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
+                                                params.alpha};
+
+                if (const auto result = quicksim<Lyt>(*bdl_iterator, qs_params))
+                {
+                    return result.value();
+                }
+                return sidb_simulation_result<Lyt>{};  // return empty result if no valid charge distribution was found
+            }
+
+            assert(false && "unsupported simulation engine");
+
+            return sidb_simulation_result<Lyt>{};
+        }
+    };
 
 }  // namespace detail
 

--- a/include/fiction/algorithms/simulation/sidb/is_operational.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_operational.hpp
@@ -947,16 +947,14 @@ class is_operational_impl
                 fiction::quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
             return quickexact(*bdl_iterator, quickexact_params);
         }
+#if (FICTION_ALGLIB_ENABLED)
         if (parameters.sim_engine == sidb_simulation_engine::CLUSTERCOMPLETE)
         {
-#if (FICTION_ALGLIB_ENABLED)
             // perform ClusterComplete exact simulation
             const clustercomplete_params<cell<Lyt>> cc_params{parameters.simulation_parameters};
             return clustercomplete(*bdl_iterator, cc_params);
-#else   // FICTION_ALGLIB_ENABLED
-            assert(false && "ALGLIB must be enabled if ClusterComplete is to be used");
-#endif  // FICTION_ALGLIB_ENABLED
         }
+#endif  // FICTION_ALGLIB_ENABLED
         if constexpr (!is_sidb_defect_surface_v<Lyt>)
         {
             if (parameters.sim_engine == sidb_simulation_engine::QUICKSIM)

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
@@ -183,12 +183,13 @@ get_sidb_simulation_engine(const std::string_view& name) noexcept
         {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
         {"CLUSTERCOMPLETE", sidb_simulation_engine::CLUSTERCOMPLETE},
         {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
-#endif  // FICTION_ALGLIB_ENABLED
+#else   // FICTION_ALGLIB_ENABLED
 
     static const phmap::flat_hash_map<std::string, sidb_simulation_engine> engine_lookup{
         {"EXGS", sidb_simulation_engine::EXGS},
         {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
         {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
+#endif  // FICTION_ALGLIB_ENABLED
 
     std::string upper_name = name.data();
     std::transform(upper_name.begin(), upper_name.end(), upper_name.begin(), ::toupper);

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
@@ -183,7 +183,8 @@ get_sidb_simulation_engine(const std::string_view& name) noexcept
         {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
         {"CLUSTERCOMPLETE", sidb_simulation_engine::CLUSTERCOMPLETE},
         {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
-#else
+#endif  // FICTION_ALGLIB_ENABLED
+
     static const phmap::flat_hash_map<std::string, sidb_simulation_engine> engine_lookup{
         {"EXGS", sidb_simulation_engine::EXGS},
         {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
@@ -108,10 +108,12 @@ template <typename EngineType>
             {
                 return "QuickExact";
             }
+#if (FICTION_ALGLIB_ENABLED)
             case EngineType::CLUSTERCOMPLETE:
             {
                 return "ClusterComplete";
             }
+#endif  // FICTION_ALGLIB_ENABLED
             case EngineType::QUICKSIM:
             {
                 return "QuickSim";
@@ -136,10 +138,12 @@ template <typename EngineType>
             {
                 return "QuickExact";
             }
+#if (FICTION_ALGLIB_ENABLED)
             case EngineType::CLUSTERCOMPLETE:
             {
                 return "ClusterComplete";
             }
+#endif  // FICTION_ALGLIB_ENABLED
             default:
             {
                 return "unsupported simulation engine";
@@ -173,10 +177,16 @@ template <typename EngineType>
 [[nodiscard]] inline std::optional<sidb_simulation_engine>
 get_sidb_simulation_engine(const std::string_view& name) noexcept
 {
+#if (FICTION_ALGLIB_ENABLED)
     static const phmap::flat_hash_map<std::string, sidb_simulation_engine> engine_lookup{
         {"EXGS", sidb_simulation_engine::EXGS},
         {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
         {"CLUSTERCOMPLETE", sidb_simulation_engine::CLUSTERCOMPLETE},
+        {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
+#else
+    static const phmap::flat_hash_map<std::string, sidb_simulation_engine> engine_lookup{
+        {"EXGS", sidb_simulation_engine::EXGS},
+        {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
         {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
 
     std::string upper_name = name.data();

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
@@ -177,19 +177,13 @@ template <typename EngineType>
 [[nodiscard]] inline std::optional<sidb_simulation_engine>
 get_sidb_simulation_engine(const std::string_view& name) noexcept
 {
+    static const phmap::flat_hash_map<std::string, sidb_simulation_engine> engine_lookup{
+        {"EXGS", sidb_simulation_engine::EXGS},
+        {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
 #if (FICTION_ALGLIB_ENABLED)
-    static const phmap::flat_hash_map<std::string, sidb_simulation_engine> engine_lookup{
-        {"EXGS", sidb_simulation_engine::EXGS},
-        {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
         {"CLUSTERCOMPLETE", sidb_simulation_engine::CLUSTERCOMPLETE},
-        {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
-#else   // FICTION_ALGLIB_ENABLED
-
-    static const phmap::flat_hash_map<std::string, sidb_simulation_engine> engine_lookup{
-        {"EXGS", sidb_simulation_engine::EXGS},
-        {"QUICKEXACT", sidb_simulation_engine::QUICKEXACT},
-        {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
 #endif  // FICTION_ALGLIB_ENABLED
+        {"QUICKSIM", sidb_simulation_engine::QUICKSIM}};
 
     std::string upper_name = name.data();
     std::transform(upper_name.begin(), upper_name.end(), upper_name.begin(), ::toupper);

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_engine.hpp
@@ -36,6 +36,7 @@ enum class sidb_simulation_engine : uint8_t
      * than *ExGS* due to its effective search-space pruning.
      */
     QUICKEXACT,
+#if (FICTION_ALGLIB_ENABLED)
     /**
      * *ClusterComplete* is a novel exact simulation engine that requires exponential runtime, though, depending on the
      * simulation problem, it effectively reduces the base number by a real number, thus allowing problem sizes that
@@ -43,6 +44,7 @@ enum class sidb_simulation_engine : uint8_t
      * the simulation base, it simulates very effectively for either base number (2 or 3).
      */
     CLUSTERCOMPLETE
+#endif  // FICTION_ALGLIB_ENABLED
 };
 /**
  * Selector exclusively for exact SiDB simulation engines.
@@ -58,6 +60,7 @@ enum class exact_sidb_simulation_engine : uint8_t
      * than ExGS due to its effective search-space pruning.
      */
     QUICKEXACT,
+#if (FICTION_ALGLIB_ENABLED)
     /**
      * *ClusterComplete* is a novel exact simulation engine that requires exponential runtime, though, depending on the
      * simulation problem, it effectively reduces the base number by a real number, thus allowing problem sizes that
@@ -65,6 +68,7 @@ enum class exact_sidb_simulation_engine : uint8_t
      * the simulation base, it simulates very effectively for either base number (2 or 3).
      */
     CLUSTERCOMPLETE
+#endif  // FICTION_ALGLIB_ENABLED
 };
 /**
  * Selector exclusively for heuristic SiDB simulation engines.

--- a/include/fiction/algorithms/simulation/sidb/time_to_solution.hpp
+++ b/include/fiction/algorithms/simulation/sidb/time_to_solution.hpp
@@ -125,16 +125,14 @@ void time_to_solution(const Lyt& lyt, const quicksim_params& quicksim_params,
         st.algorithm      = sidb_simulation_engine_name(exact_sidb_simulation_engine::QUICKEXACT);
         simulation_result = quickexact(lyt, params);
     }
+#if (FICTION_ALGLIB_ENABLED)
     else if (tts_params.engine == exact_sidb_simulation_engine::CLUSTERCOMPLETE)
     {
-#if (FICTION_ALGLIB_ENABLED)
         const clustercomplete_params<cell<Lyt>> params{quicksim_params.simulation_parameters};
         st.algorithm      = sidb_simulation_engine_name(exact_sidb_simulation_engine::CLUSTERCOMPLETE);
         simulation_result = clustercomplete(lyt, params);
-#else   // FICTION_ALGLIB_ENABLED
-        assert(false && "ALGLIB must be enabled if ClusterComplete is to be used");
-#endif  // FICTION_ALGLIB_ENABLED
     }
+#endif  // FICTION_ALGLIB_ENABLED
     else
     {
         st.algorithm      = sidb_simulation_engine_name(exact_sidb_simulation_engine::EXGS);


### PR DESCRIPTION
## Description

This PR ensures that _ClusterComplete_ cannot be selected as the simulation engine when ALGLIB is disabled.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
