### PR TITLE
:bug: Use correct function for charge index calculation and fix base for TTS calculation

### DIFF
--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_result.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_result.hpp
@@ -81,7 +81,7 @@ struct sidb_simulation_result
         // distributions.
         for (auto& cds : charge_distributions)
         {
-            cds.charge_distribution_to_index();
+            cds.charge_distribution_to_index_general();
             charge_indices.insert(cds.get_charge_index_and_base().first);
         }
 

--- a/include/fiction/algorithms/simulation/sidb/time_to_solution.hpp
+++ b/include/fiction/algorithms/simulation/sidb/time_to_solution.hpp
@@ -121,7 +121,8 @@ void time_to_solution(const Lyt& lyt, const quicksim_params& quicksim_params,
     sidb_simulation_result<Lyt> simulation_result{};
     if (tts_params.engine == exact_sidb_simulation_engine::QUICKEXACT)
     {
-        const quickexact_params<cell<Lyt>> params{quicksim_params.simulation_parameters};
+        const quickexact_params<cell<Lyt>> params{quicksim_params.simulation_parameters,
+                                                  quickexact_params<cell<Lyt>>::automatic_base_number_detection::OFF};
         st.algorithm      = sidb_simulation_engine_name(exact_sidb_simulation_engine::QUICKEXACT);
         simulation_result = quickexact(lyt, params);
     }

--- a/test/algorithms/simulation/sidb/time_to_solution.cpp
+++ b/test/algorithms/simulation/sidb/time_to_solution.cpp
@@ -238,7 +238,7 @@ TEMPLATE_TEST_CASE("time-to-solution test with fewer negatively charged SiDBs in
 {
     TestType lyt{};
 
-    SECTION("layout with seven SiDBs placed")
+    SECTION("layout with six SiDBs placed, large µ-value")
     {
         lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
         lyt.assign_cell_type({3, 0, 0}, TestType::cell_type::NORMAL);

--- a/test/algorithms/simulation/sidb/time_to_solution.cpp
+++ b/test/algorithms/simulation/sidb/time_to_solution.cpp
@@ -232,3 +232,28 @@ TEMPLATE_TEST_CASE("time-to-solution test with simulation results", "[time-to-so
         CHECK_THAT(st.time_to_solution - tts_calculated, Catch::Matchers::WithinAbs(0.0, constants::ERROR_MARGIN));
     }
 }
+
+TEMPLATE_TEST_CASE("time-to-solution test with fewer negatively charged SiDBs in the layout", "[time-to-solution]",
+                   sidb_100_cell_clk_lyt, cds_sidb_100_cell_clk_lyt)
+{
+    TestType lyt{};
+
+    SECTION("layout with seven SiDBs placed")
+    {
+        lyt.assign_cell_type({0, 0, 0}, TestType::cell_type::NORMAL);
+        lyt.assign_cell_type({3, 0, 0}, TestType::cell_type::NORMAL);
+        lyt.assign_cell_type({6, 0, 0}, TestType::cell_type::NORMAL);
+        lyt.assign_cell_type({0, 3, 0}, TestType::cell_type::NORMAL);
+        lyt.assign_cell_type({3, 3, 0}, TestType::cell_type::NORMAL);
+        lyt.assign_cell_type({6, 3, 0}, TestType::cell_type::NORMAL);
+
+        const sidb_simulation_parameters params{2, -0.05};
+        const quicksim_params            quicksim_params{params};
+
+        auto tts_stats_quicksim = time_to_solution_stats{};
+
+        time_to_solution(lyt, quicksim_params, time_to_solution_params{}, &tts_stats_quicksim);
+
+        CHECK(tts_stats_quicksim.time_to_solution < 10.0);
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes two bugs: 

1.) The charge index calculation was done wrongly for ``groundstates()`` for charge distributions with base = 3. This is now fixed by using ``charge_distribution_to_index_general()``. 
2.) The automatic base detection in the TTS calculation was activated. Hence, the heuristic and exact simulations might be conducted with different bases. This is not desired. The automatic base detection is now turned off, ensuring that the same base is used in both cases. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
