### PR TITLE
:snake: Add Pythonic dictionary-like interfaces to `operational_domain` and `critical_temperature_domain`

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -10,6 +10,7 @@
 
 #include <fiction/algorithms/simulation/sidb/operational_domain.hpp>
 
+#include <fmt/format.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -84,6 +85,9 @@ inline void operational_domain(pybind11::module& m)
 
         .def("__hash__",
              [](const fiction::parameter_point& self) { return std::hash<fiction::parameter_point>{}(self); })
+        .def("__str__", [](const fiction::parameter_point& self) { return fmt::format("{}", self.get_parameters()); })
+        .def("__getitem__",
+             [](const fiction::parameter_point& self, const std::size_t index) { return self.get_parameters()[index]; })
 
         ;
 
@@ -124,9 +128,59 @@ inline void operational_domain(pybind11::module& m)
              DOC(fiction_operational_domain_get_dimension))
         .def("get_number_of_dimensions", &fiction::operational_domain::get_number_of_dimensions,
              DOC(fiction_operational_domain_get_number_of_dimensions))
-        .def("contains", &fiction::operational_domain::contains, py::arg("key"))
-        .def("add_value", &fiction::operational_domain::add_value, py::arg("key"), py::arg("value"))
-        .def("size", &fiction::operational_domain::size)
+
+        // Pythonic interface functions
+        .def("__getitem__",
+             [](const fiction::operational_domain& self, const fiction::parameter_point& key)
+             {
+                 const auto val = self.contains(key);
+                 if (!val.has_value())
+                 {
+                     throw py::key_error("Key not found");
+                 }
+
+                 return std::get<0>(val.value());
+             })
+        .def("__setitem__", [](fiction::operational_domain& self, const fiction::parameter_point& key,
+                               const fiction::operational_status& value) { self.add_value(key, {value}); })
+        .def("__contains__", [](const fiction::operational_domain& self, const fiction::parameter_point& key)
+             { return self.contains(key).has_value(); })
+        .def("__len__", [](const fiction::operational_domain& self) { return self.size(); })
+        .def("__iter__",
+             [](const fiction::operational_domain& self)
+             {
+                 std::vector<fiction::parameter_point> keys{};
+                 keys.reserve(self.size());
+                 self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
+
+                 const py::list py_keys = py::cast(keys);
+                 return py::iter(py_keys);
+             })
+        .def("keys",
+             [](const fiction::operational_domain& self)
+             {
+                 std::vector<fiction::parameter_point> keys{};
+                 keys.reserve(self.size());
+                 self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
+                 return keys;
+             })
+        .def("values",
+             [](const fiction::operational_domain& self)
+             {
+                 std::vector<fiction::operational_status> values{};
+                 values.reserve(self.size());
+                 self.for_each([&values](const auto&, const auto& value) { values.push_back(std::get<0>(value)); });
+                 return values;
+             })
+        .def("items",
+             [](const fiction::operational_domain& self)
+             {
+                 std::vector<std::pair<fiction::parameter_point, fiction::operational_status>> items{};
+                 items.reserve(self.size());
+                 self.for_each([&items](const auto& key, const auto& value)
+                               { items.emplace_back(key, std::get<0>(value)); });
+                 return items;
+             })
 
         ;
 

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -102,19 +102,67 @@ inline void operational_domain(pybind11::module& m)
                                                      DOC(fiction_critical_temperature_domain))
         .def(py::init<>())
         .def(py::init<const std::vector<fiction::sweep_parameter>>(), py::arg("dims"))
-        .def("add_dimension", &fiction::critical_temperature_domain::add_dimension, py::arg("dim"),
-             DOC(fiction_critical_temperature_domain_add_dimension))
         .def("get_dimension", &fiction::critical_temperature_domain::get_dimension, py::arg("index"),
              DOC(fiction_critical_temperature_domain_get_dimension))
         .def("get_number_of_dimensions", &fiction::critical_temperature_domain::get_number_of_dimensions,
              DOC(fiction_critical_temperature_domain_get_number_of_dimensions))
-        .def("contains", &fiction::critical_temperature_domain::contains, py::arg("key"))
-        .def("add_value", &fiction::critical_temperature_domain::add_value, py::arg("key"), py::arg("value"))
-        .def("size", &fiction::critical_temperature_domain::size)
         .def("minimum_ct", &fiction::critical_temperature_domain::minimum_ct,
              DOC(fiction_critical_temperature_domain_minimum_ct))
         .def("maximum_ct", &fiction::critical_temperature_domain::maximum_ct,
              DOC(fiction_critical_temperature_domain_maximum_ct))
+
+        // Pythonic interface functions
+        .def("__getitem__",
+             [](const fiction::critical_temperature_domain& self, const fiction::parameter_point& key)
+             {
+                 const auto val = self.contains(key);
+                 if (!val.has_value())
+                 {
+                     throw py::key_error("Key not found");
+                 }
+                 return val.value();
+             })
+        .def("__setitem__",
+             [](fiction::critical_temperature_domain& self, const fiction::parameter_point& key,
+                const std::tuple<fiction::operational_status, double>& value) { self.add_value(key, value); })
+        .def("__contains__", [](const fiction::critical_temperature_domain& self, const fiction::parameter_point& key)
+             { return self.contains(key).has_value(); })
+        .def("__len__", [](const fiction::critical_temperature_domain& self) { return self.size(); })
+        .def("__iter__",
+             [](const fiction::critical_temperature_domain& self)
+             {
+                 std::vector<fiction::parameter_point> keys{};
+                 keys.reserve(self.size());
+                 self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
+
+                 const py::list py_keys = py::cast(keys);
+                 return py::iter(py_keys);
+             })
+        .def("keys",
+             [](const fiction::critical_temperature_domain& self)
+             {
+                 std::vector<fiction::parameter_point> keys{};
+                 keys.reserve(self.size());
+                 self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
+                 return keys;
+             })
+        .def("values",
+             [](const fiction::critical_temperature_domain& self)
+             {
+                 std::vector<std::tuple<fiction::operational_status, double>> values{};
+                 values.reserve(self.size());
+                 self.for_each([&values](const auto&, const auto& value) { values.push_back(value); });
+                 return values;
+             })
+        .def("items",
+             [](const fiction::critical_temperature_domain& self)
+             {
+                 std::vector<std::pair<fiction::parameter_point, std::tuple<fiction::operational_status, double>>>
+                     items{};
+                 items.reserve(self.size());
+                 self.for_each([&items](const auto& key, const auto& value) { items.emplace_back(key, value); });
+                 return items;
+             })
 
         ;
 

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
@@ -75,24 +75,24 @@ class TestOperationalDomain(unittest.TestCase):
 
         stats_grid = operational_domain_stats()
         ct_domain_grid = critical_temperature_domain_grid_search(lyt, [create_xor_tt()], params, stats_grid)
-        self.assertEqual(ct_domain_grid.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
-        self.assertGreater(ct_domain_grid.contains(parameter_point([5.60, 5.00]))[1], 30)
+        self.assertEqual(ct_domain_grid[parameter_point([5.60, 5.00])][0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_grid[parameter_point([5.60, 5.00])][1], 30)
         self.assertGreater(stats_grid.num_operational_parameter_combinations, 0)
         self.assertGreater(ct_domain_grid.minimum_ct(), 23)
         self.assertLess(ct_domain_grid.maximum_ct(), 38)
 
         stats_flood_fill = operational_domain_stats()
         ct_domain_flood = critical_temperature_domain_flood_fill(lyt, [create_xor_tt()], 100, params, stats_flood_fill)
-        self.assertEqual(ct_domain_flood.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
-        self.assertGreater(ct_domain_flood.contains(parameter_point([5.60, 5.00]))[1], 30)
+        self.assertEqual(ct_domain_flood[parameter_point([5.60, 5.00])][0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_flood[parameter_point([5.60, 5.00])][1], 30)
         self.assertGreater(stats_flood_fill.num_operational_parameter_combinations, 0)
 
         stats_contour_tracing = operational_domain_stats()
         ct_domain_contour = critical_temperature_domain_contour_tracing(
             lyt, [create_xor_tt()], 1000, params, stats_contour_tracing
         )
-        self.assertEqual(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
-        self.assertGreater(ct_domain_contour.contains(parameter_point([5.60, 5.00]))[1], 30)
+        self.assertEqual(ct_domain_contour[parameter_point([5.60, 5.00])][0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_contour[parameter_point([5.60, 5.00])][1], 30)
         self.assertGreater(stats_contour_tracing.num_operational_parameter_combinations, 0)
 
         params.sweep_dimensions = [
@@ -104,8 +104,8 @@ class TestOperationalDomain(unittest.TestCase):
         ct_domain_random = critical_temperature_domain_random_sampling(
             lyt, [create_xor_tt()], 1000, params, stats_random_sampling
         )
-        self.assertEqual(ct_domain_random.contains(parameter_point([5.60, 5.00]))[0], operational_status.OPERATIONAL)
-        self.assertGreater(ct_domain_random.contains(parameter_point([5.60, 5.00]))[1], 30)
+        self.assertEqual(ct_domain_random[parameter_point([5.60, 5.00])][0], operational_status.OPERATIONAL)
+        self.assertGreater(ct_domain_random[parameter_point([5.60, 5.00])][1], 30)
         self.assertGreater(stats_random_sampling.num_operational_parameter_combinations, 0)
 
     def test_operational_domain_AND_gate_111_lattice(self):

--- a/bindings/mnt/pyfiction/test/inout/test_write_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/inout/test_write_operational_domain.py
@@ -17,8 +17,8 @@ class TestWriteOperationalDomain(unittest.TestCase):
     def test_write_simple_operational_domain(self):
         opdom = operational_domain([sweep_parameter.EPSILON_R, sweep_parameter.LAMBDA_TF])
 
-        opdom.add_value(parameter_point([0, 0]), [operational_status.OPERATIONAL])
-        opdom.add_value(parameter_point([0, 1]), [operational_status.NON_OPERATIONAL])
+        opdom[parameter_point([0, 0])] = operational_status.OPERATIONAL
+        opdom[parameter_point([0, 1])] = operational_status.NON_OPERATIONAL
 
         expected = "epsilon_r,lambda_tf,operational status\n0,0,1\n0,1,0"
 

--- a/bindings/mnt/pyfiction/test/inout/test_write_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/inout/test_write_operational_domain.py
@@ -42,8 +42,8 @@ class TestWriteOperationalDomain(unittest.TestCase):
         opdom = operational_domain([sweep_parameter.EPSILON_R, sweep_parameter.LAMBDA_TF])
 
         # Using floating point values for the parameter points
-        opdom.add_value(parameter_point([0.1, 0.2]), [operational_status.OPERATIONAL])
-        opdom.add_value(parameter_point([0.3, 0.4]), [operational_status.NON_OPERATIONAL])
+        opdom[parameter_point([0.1, 0.2])] = operational_status.OPERATIONAL
+        opdom[parameter_point([0.3, 0.4])] = operational_status.NON_OPERATIONAL
 
         expected = "epsilon_r,lambda_tf,operational status\n0.1,0.2,1\n0.3,0.4,0"
 
@@ -68,8 +68,8 @@ class TestWriteOperationalDomain(unittest.TestCase):
         opdom = critical_temperature_domain([sweep_parameter.EPSILON_R, sweep_parameter.LAMBDA_TF])
 
         # Adding metric values
-        opdom.add_value(parameter_point([0.1, 0.2]), [operational_status.OPERATIONAL, 50.3])
-        opdom.add_value(parameter_point([0.3, 0.4]), [operational_status.NON_OPERATIONAL, 0.0])
+        opdom[parameter_point([0.1, 0.2])] = [operational_status.OPERATIONAL, 50.3]
+        opdom[parameter_point([0.3, 0.4])] = [operational_status.NON_OPERATIONAL, 0.0]
 
         expected = "epsilon_r,lambda_tf,operational status,critical temperature\n0.1,0.2,1,50.3\n0.3,0.4,0,0"
 
@@ -96,8 +96,8 @@ class TestWriteOperationalDomain(unittest.TestCase):
     def test_skip_non_operational_samples(self):
         opdom = operational_domain([sweep_parameter.EPSILON_R, sweep_parameter.LAMBDA_TF])
 
-        opdom.add_value(parameter_point([0.1, 0.2]), [operational_status.OPERATIONAL])
-        opdom.add_value(parameter_point([0.3, 0.4]), [operational_status.NON_OPERATIONAL])
+        opdom[parameter_point([0.1, 0.2])] = operational_status.OPERATIONAL
+        opdom[parameter_point([0.3, 0.4])] = operational_status.NON_OPERATIONAL
 
         # Skip non-operational samples
         params = write_operational_domain_params()

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -20,7 +20,6 @@
 #include "fiction/technology/constants.hpp"
 #include "fiction/traits.hpp"
 #include "fiction/utils/hash.hpp"
-#include "fiction/utils/map_utils.hpp"
 #include "fiction/utils/math_utils.hpp"
 
 #include <btree.h>

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_domain.hpp
@@ -93,7 +93,7 @@ class sidb_simulation_domain
         return result;
     }
 
-  private:
+  protected:
     /**
      * The domain values stored in a thread-safe map.
      */


### PR DESCRIPTION
## Description

This PR adds a dictionary-like function interface to the Python bindings of  `operational_domain` and `critical_temperature_domain`. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
