### PR TITLE
:bug: Add missing `clone` member function to pyfiction's SiDB lattices

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/technology/sidb_lattice.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/technology/sidb_lattice.hpp
@@ -47,6 +47,7 @@ void sidb_lattice_cell_level_layout(pybind11::module& m)
         .def(py::init<>())
         .def(py::init<const fiction::aspect_ratio<py_sidb_layout>&, const std::string&>(), py::arg("dimension"),
              py::arg("name") = "", DOC(fiction_sidb_lattice))
+        .def("clone", &py_sidb_lattice::clone)
 
         ;
 }


### PR DESCRIPTION
## Description

The SiDB lattices in `pyfiction` were missing the `clone` member function. This PR fixes that oversight.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
