### PR TITLE
:fire: Drop Windows 2019 and v142 support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,22 +38,13 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [windows-2019, windows-2022, windows-2025]
-        toolset: [v142, v143, ClangCL]
+        os: [windows-2022, windows-2025]
+        toolset: [v143, ClangCL]
         include:
-          - os: windows-2019
-            env: "Visual Studio 16 2019"
           - os: windows-2022
             env: "Visual Studio 17 2022"
           - os: windows-2025
             env: "Visual Studio 17 2022"
-        exclude:
-          - os: windows-2019
-            toolset: v143
-          - os: windows-2022
-            toolset: v142
-          - os: windows-2025
-            toolset: v142
 
     name: 🪟 ${{matrix.os}} with ${{matrix.env}} and ${{matrix.toolset}} toolset
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
## Description

This PR removes support for Windows 2019 and the corresponding v142 toolkit because [GitHub Actions will no longer support it](https://github.com/Perl/perl5/issues/23348).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
