### PR TITLE
🎨 Small changes in ``is_operational`` and added ``PRUNING_BASED`` option to gate design

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -59,8 +59,8 @@ inline void design_sidb_gates(pybind11::module& m)
         .value("RANDOM", fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::RANDOM,
                DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_RANDOM))
         .value("PRUNING_BASED",
-               fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::PRUNING_BASED);
-    // todo update docu
+               fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::PRUNING_BASED,
+               DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_BASED));
     ;
     /**
      * Termination condition selector type.
@@ -92,9 +92,7 @@ inline void design_sidb_gates(pybind11::module& m)
                        DOC(fiction_design_sidb_gates_params_number_of_canvas_sidbs))
         .def_readwrite("termination_cond",
                        &fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::termination_cond,
-                       DOC(fiction_design_sidb_gates_params_termination_condition))
-
-        ;
+                       DOC(fiction_design_sidb_gates_params_termination_condition));
 
     detail::design_sidb_gates<py_sidb_100_lattice>(m);
     detail::design_sidb_gates<py_sidb_111_lattice>(m);

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -60,7 +60,7 @@ inline void design_sidb_gates(pybind11::module& m)
                DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_RANDOM))
         .value("PRUNING_ONLY",
                fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::PRUNING_ONLY,
-               DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_BASED))
+               DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_ONLY))
 
         ;
     /**

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -58,10 +58,11 @@ inline void design_sidb_gates(pybind11::module& m)
                DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_QUICKCELL))
         .value("RANDOM", fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::RANDOM,
                DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_RANDOM))
-        .value("PRUNING_BASED",
-               fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::PRUNING_BASED,
-               DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_BASED));
-    ;
+        .value("PRUNING_ONLY",
+               fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::PRUNING_ONLY,
+               DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_BASED))
+
+        ;
     /**
      * Termination condition selector type.
      */
@@ -72,7 +73,9 @@ inline void design_sidb_gates(pybind11::module& m)
             fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::termination_condition::AFTER_FIRST_SOLUTION)
         .value("ALL_COMBINATIONS_ENUMERATED",
                fiction::design_sidb_gates_params<
-                   fiction::offset::ucoord_t>::termination_condition::ALL_COMBINATIONS_ENUMERATED);
+                   fiction::offset::ucoord_t>::termination_condition::ALL_COMBINATIONS_ENUMERATED)
+
+        ;
 
     /**
      * Parameters.

--- a/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -57,7 +57,11 @@ inline void design_sidb_gates(pybind11::module& m)
                    fiction::offset::ucoord_t>::design_sidb_gates_mode::AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER,
                DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_QUICKCELL))
         .value("RANDOM", fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::RANDOM,
-               DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_RANDOM));
+               DOC(fiction_design_sidb_gates_params_design_sidb_gates_mode_RANDOM))
+        .value("PRUNING_BASED",
+               fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::design_sidb_gates_mode::PRUNING_BASED);
+    // todo update docu
+    ;
     /**
      * Termination condition selector type.
      */

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -4697,6 +4697,14 @@ static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode
 
 static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode_AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER = R"doc(Gates are designed by using the *Automatic Exhaustive Gate Designer*.)doc";
 
+static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_BASED =
+R"doc(This design approach adopts the three pruning techniques used by
+*QuickCell* to efficiently filter out non-operational layouts. Unlike
+*QuickCell*, the subsequent physical simulation step is skipped to
+enhance efficiency. As a result, the operational validity of the final
+layouts cannot be guaranteed, although a substantial portion of them
+are usually operational.)doc";
+
 static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode_QUICKCELL = R"doc(Gates are designed by using *QuickCell*.)doc";
 
 static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode_RANDOM = R"doc(Gate layouts are designed randomly.)doc";
@@ -8564,8 +8572,6 @@ Returns:
     `true` if any output wire contains a kink (i.e., an unexpected
     charge state), `false` otherwise.)doc";
 
-static const char *__doc_fiction_detail_is_operational_impl_dependent_cell = R"doc(Dependent cell of the canvas SiDBs.)doc";
-
 static const char *__doc_fiction_detail_is_operational_impl_determine_non_operational_input_patterns_and_non_operationality_reason =
 R"doc(Determines the input combinations for which the layout is non-
 operational and the reason why the layout is non-operational.
@@ -8646,14 +8652,8 @@ identify and discard SiDB layouts that do not satisfy physical model
 constraints under the I/O pin conditions required for the desired
 Boolean function, and (3) detecting I/O signal instability.
 
-Template parameter ``ChargeLyt``:
-    The charge distribution surface layout type.
-
 Parameter ``input_pattern``:
     The current input pattern.
-
-Parameter ``cds_canvas``:
-    The charge distribution of the canvas layout.
 
 Returns:
     A `layout_invalidity_reason` object indicating why the layout is

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -4697,7 +4697,7 @@ static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode
 
 static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode_AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER = R"doc(Gates are designed by using the *Automatic Exhaustive Gate Designer*.)doc";
 
-static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_BASED =
+static const char *__doc_fiction_design_sidb_gates_params_design_sidb_gates_mode_PRUNING_ONLY =
 R"doc(This design approach adopts the three pruning techniques used by
 *QuickCell* to efficiently filter out non-operational layouts. Unlike
 *QuickCell*, the subsequent physical simulation step is skipped to
@@ -6116,7 +6116,7 @@ static const char *__doc_fiction_detail_design_sidb_gates_impl_all_canvas_layout
 static const char *__doc_fiction_detail_design_sidb_gates_impl_all_sidbs_in_canvas = R"doc(All cells within the canvas.)doc";
 
 static const char *__doc_fiction_detail_design_sidb_gates_impl_convert_canvas_cell_indices_to_layout =
-R"doc(This function generates canvas SiDb layouts.
+R"doc(This function generates canvas SiDB layouts.
 
 Parameter ``cell_indices``:
     A vector of indices of cells to be added to the skeleton layout.

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_design_sidb_gates.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_design_sidb_gates.py
@@ -101,7 +101,12 @@ class TestDesignSiDBGates(unittest.TestCase):
         designed_gates = design_sidb_gates(layout, [create_nor_tt()], params)
         self.assertEqual(len(designed_gates), 44)
 
+        params.design_mode = design_sidb_gates_mode.PRUNING_BASED
+        designed_gate_candidates = design_sidb_gates(layout, [create_nor_tt()], params)
+        self.assertEqual(len(designed_gate_candidates), 44)
+
         # tolerate kink states
+        params.design_mode = design_sidb_gates_mode.AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER
         params.operational_params.op_condition = operational_condition.TOLERATE_KINKS
         designed_gates = design_sidb_gates(layout, [create_nor_tt()], params)
         self.assertEqual(len(designed_gates), 175)

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_design_sidb_gates.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_design_sidb_gates.py
@@ -101,7 +101,7 @@ class TestDesignSiDBGates(unittest.TestCase):
         designed_gates = design_sidb_gates(layout, [create_nor_tt()], params)
         self.assertEqual(len(designed_gates), 44)
 
-        params.design_mode = design_sidb_gates_mode.PRUNING_BASED
+        params.design_mode = design_sidb_gates_mode.PRUNING_ONLY
         designed_gate_candidates = design_sidb_gates(layout, [create_nor_tt()], params)
         self.assertEqual(len(designed_gate_candidates), 44)
 

--- a/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -415,7 +415,7 @@ class design_sidb_gates_impl
             return gate_layouts;
         }
 
-        if (params.design_mode == design_sidb_gates_params<cell<Lyt>>::design_sidb_gates_mode::PRUNING_BASED)
+        if (params.design_mode == design_sidb_gates_params<cell<Lyt>>::design_sidb_gates_mode::PRUNING_ONLY)
         {
             // If the design mode is PRUNING_ONLY, we only need to return the gate candidates that passed the pruning
             // steps.

--- a/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
+++ b/include/fiction/algorithms/physical_design/design_sidb_gates.hpp
@@ -84,7 +84,7 @@ struct design_sidb_gates_params
          * the operational validity of the final layouts cannot be guaranteed, although a
          * substantial portion of them are usually operational.
          */
-        PRUNING_BASED
+        PRUNING_ONLY
     };
     /**
      * Parameters for the `is_operational` function.
@@ -417,7 +417,7 @@ class design_sidb_gates_impl
 
         if (params.design_mode == design_sidb_gates_params<cell<Lyt>>::design_sidb_gates_mode::PRUNING_BASED)
         {
-            // If the design mode is PRUNING_BASED, we only need to return the gate candidates that passed the pruning
+            // If the design mode is PRUNING_ONLY, we only need to return the gate candidates that passed the pruning
             // steps.
             return gate_candidates;
         }
@@ -723,7 +723,7 @@ class design_sidb_gates_impl
     }
 
     /**
-     * This function generates canvas SiDb layouts.
+     * This function generates canvas SiDB layouts.
      *
      * @param cell_indices A vector of indices of cells to be added to the skeleton layout.
      * @return An SiDB cell-level layout consisting of canvas SidBs.

--- a/include/fiction/algorithms/simulation/sidb/is_operational.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_operational.hpp
@@ -590,19 +590,7 @@ class is_operational_impl
     [[nodiscard]] std::optional<double>
     is_physical_validity_feasible(charge_distribution_surface<Lyt>& cds_layout) const noexcept
     {
-        if (canvas_lyt.is_empty())
-        {
-            cds_layout.update_after_charge_change(dependent_cell_mode::FIXED,
-                                                  energy_calculation::KEEP_OLD_ENERGY_VALUE);
-
-            if (cds_layout.is_physically_valid())
-            {
-                cds_layout.recompute_electrostatic_potential_energy();
-                return cds_layout.get_electrostatic_potential_energy();
-            }
-
-            return std::nullopt;
-        }
+        assert(!canvas_lyt.is_empty() && "The canvas layout must not be empty.");
 
         auto min_energy = std::numeric_limits<double>::infinity();
 

--- a/include/fiction/algorithms/simulation/sidb/is_operational.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_operational.hpp
@@ -1106,19 +1106,21 @@ is_operational(const Lyt& lyt, const std::vector<TT>& spec, const is_operational
 
     const auto logic_cells = lyt.get_cells_by_type(technology<Lyt>::cell_type::LOGIC);
 
+    // if there are logic cells, we can design the canvas layout consisting of all logic cells
     if (!logic_cells.empty() &&
         params.strategy_to_analyze_operational_status !=
             is_operational_params::operational_analysis_strategy::SIMULATION_ONLY &&
         params.op_condition == is_operational_params::operational_condition::REJECT_KINKS)
     {
-        Lyt c_lyt{};
+        Lyt canvas_lyt{};
 
+        // assign all logic cells to the canvas layout
         for (const auto& c : logic_cells)
         {
-            c_lyt.assign_cell_type(c, technology<Lyt>::cell_type::LOGIC);
+            canvas_lyt.assign_cell_type(c, technology<Lyt>::cell_type::LOGIC);
         }
 
-        detail::is_operational_impl<Lyt, TT> p{lyt, spec, params, c_lyt};
+        detail::is_operational_impl<Lyt, TT> p{lyt, spec, params, canvas_lyt};
 
         const auto [status, _] = p.run();
 

--- a/test/algorithms/physical_design/design_sidb_gates.cpp
+++ b/test/algorithms/physical_design/design_sidb_gates.cpp
@@ -550,6 +550,22 @@ TEST_CASE("Design NOR Bestagon shaped gate on H-Si 111", "[design-sidb-gates]")
     }
 }
 
+TEST_CASE("Design Bestagon shaped CX gate with pruning only", "[design-sidb-gates]")
+{
+    const auto lyt = blueprints::two_input_two_output_bestagon_skeleton<sidb_100_cell_clk_lyt_siqad>();
+
+    const design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>> params{
+        is_operational_params{sidb_simulation_parameters{2, -0.32}, sidb_simulation_engine::QUICKEXACT,
+                              bdl_input_iterator_params{}},
+        design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::PRUNING_BASED,
+        {{16, 8, 0}, {22, 14, 0}},
+        3};
+
+    const auto found_gate_layouts = design_sidb_gates(lyt, std::vector<tt>{create_crossing_wire_tt()}, params);
+    REQUIRE(found_gate_layouts.size() == 3);
+    CHECK(found_gate_layouts.front().num_cells() == lyt.num_cells() + 3);
+}
+
 // to save runtime in the CI, this test is only run in RELEASE mode
 #ifdef NDEBUG
 TEST_CASE("Design Bestagon shaped CX gate with QuickCell", "[design-sidb-gates]")

--- a/test/algorithms/physical_design/design_sidb_gates.cpp
+++ b/test/algorithms/physical_design/design_sidb_gates.cpp
@@ -550,14 +550,14 @@ TEST_CASE("Design NOR Bestagon shaped gate on H-Si 111", "[design-sidb-gates]")
     }
 }
 
-TEST_CASE("Design Bestagon shaped CX gate with pruning only", "[design-sidb-gates]")
+TEST_CASE("Design hexagonal CX gate with pruning only", "[design-sidb-gates]")
 {
     const auto lyt = blueprints::two_input_two_output_bestagon_skeleton<sidb_100_cell_clk_lyt_siqad>();
 
     const design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>> params{
         is_operational_params{sidb_simulation_parameters{2, -0.32}, sidb_simulation_engine::QUICKEXACT,
                               bdl_input_iterator_params{}},
-        design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::PRUNING_BASED,
+        design_sidb_gates_params<cell<sidb_100_cell_clk_lyt_siqad>>::design_sidb_gates_mode::PRUNING_ONLY,
         {{16, 8, 0}, {22, 14, 0}},
         3};
 

--- a/test/algorithms/simulation/sidb/is_operational.cpp
+++ b/test/algorithms/simulation/sidb/is_operational.cpp
@@ -92,6 +92,18 @@ TEST_CASE("SiQAD OR gate", "[is-operational]")
     }
 }
 
+TEST_CASE("Test is_physical_validity_feasible for empty canvas", "[is-operational]")
+{
+    const auto lyt = blueprints::two_input_two_output_bestagon_skeleton<sidb_cell_clk_lyt_siqad>();
+
+    const auto op_params =
+        is_operational_params{sidb_simulation_parameters{2, -0.32}, sidb_simulation_engine::QUICKEXACT,
+                              bdl_input_iterator_params{}, is_operational_params::operational_condition::REJECT_KINKS,
+                              is_operational_params::operational_analysis_strategy::FILTER_THEN_SIMULATION};
+
+    CHECK(is_operational(lyt, create_crossing_wire_tt(), op_params).first == operational_status::NON_OPERATIONAL);
+}
+
 TEST_CASE("SiQAD NAND gate", "[is-operational]")
 {
     const auto nand_gate = blueprints::siqad_nand_gate<sidb_cell_clk_lyt_siqad>();


### PR DESCRIPTION
## Description

This PR introduces two main enhancements. First, pruning techniques have been enabled for all overloaded versions of the ``is_operational`` function. Second, the gate design function has been extended to include a new method, ``PRUNING_BASED``. This method conducts pruning (same as in _QuickCell_) without relying on physical simulation, making it particularly useful in scenarios where gate/standard cell candidates are designed without simulation. However, this approach may lead to false positives as a trade-off for increased performance.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
