### PR TITLE
:construction_worker: Update clang-tidy CI to use the `pull_request_target` trigger

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,8 +1,14 @@
 name: Clang-Tidy Review
 
 on:
+  pull_request:
+    paths:
+      - "**/*.hpp"
+      - "**/*.cpp"
+      - "libs/**"
+      - ".github/workflows/clang-tidy-review.yml"
+      - "!bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp"
   pull_request_target:
-    types: [opened, synchronize, reopened]
     paths:
       - "**/*.hpp"
       - "**/*.cpp"

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,7 +1,8 @@
 name: Clang-Tidy Review
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     paths:
       - "**/*.hpp"
       - "**/*.cpp"
@@ -26,6 +27,8 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v4
         with:
+          # Check out the PR's code, not the base branch's code
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Install dependencies


### PR DESCRIPTION
## Description

This runs the workflow in the context of the base repository for proper permission management.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
