### PR TITLE
:construction_worker: Adjust the Clang-Tidy Workflow to Run on Pull Request Target Triggers Exclusively

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,13 +1,6 @@
 name: Clang-Tidy Review
 
 on:
-  pull_request:
-    paths:
-      - "**/*.hpp"
-      - "**/*.cpp"
-      - "libs/**"
-      - ".github/workflows/clang-tidy-review.yml"
-      - "!bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp"
   pull_request_target:
     paths:
       - "**/*.hpp"


### PR DESCRIPTION
## Description

Try to keep only the `pull_request_target` and remove the `pull_request` trigger.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
