### PR TITLE
:construction_worker: Adjust fetch depth in clang-tidy CI to ensure complete history is available

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -29,6 +29,7 @@ jobs:
           # Check out the PR's code, not the base branch's code
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
+          fetch-depth: 0
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake libreadline-dev libtbb-dev python3-dev


### PR DESCRIPTION
## Description

Added `fetch-depth: 0` to the checkout step to ensure the full commit history is available, which may be necessary for Clang-Tidy.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
