### PR TITLE
:bug: Fixed PO extension in `hexagonalization`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,10 @@ Added
     - Maximum-effort mode in `gold` utilizing random fanout substitution strategies and random topological orderings to design high-quality layouts
     - Flag in `gold` to enforce NOT gates to be routed non-bending only
 
+Fixed
+#####
+- Algorithms:
+    - Fixed a corner case in ``hexagonalization`` when extending POs to the bottom border
 
 v0.6.11 - 2025-04-23
 --------------------

--- a/include/fiction/algorithms/physical_design/hexagonalization.hpp
+++ b/include/fiction/algorithms/physical_design/hexagonalization.hpp
@@ -472,9 +472,10 @@ class hexagonalization_impl
                 });
 
             // sort primary inputs by y-coordinate for consistency
-            std::sort(left_pis.begin(), left_pis.end(), [](const auto& lhs, const auto& rhs) { return lhs.y < rhs.y; });
-            std::sort(right_pis.begin(), right_pis.end(),
-                      [](const auto& lhs, const auto& rhs) { return lhs.y < rhs.y; });
+            std::sort(left_pis.begin(), left_pis.end(), [](const auto& lhs, const auto& rhs)
+                      { return (lhs.y < rhs.y) || (lhs.y == rhs.y && lhs.x < rhs.x); });
+            std::sort(right_pis.begin(), right_pis.end(), [](const auto& lhs, const auto& rhs)
+                      { return (lhs.y < rhs.y) || (lhs.y == rhs.y && lhs.x < rhs.x); });
 
             // adjust hex layout width if necessary (only if all inputs placed in top row)
             if (ps.input_pin_extension != hexagonalization_params::io_pin_extension_mode::NONE)
@@ -616,9 +617,10 @@ class hexagonalization_impl
                     }
                 });
 
-            std::sort(left_pos.begin(), left_pos.end(), [](const auto& lhs, const auto& rhs) { return lhs.y > rhs.y; });
-            std::sort(right_pos.begin(), right_pos.end(),
-                      [](const auto& lhs, const auto& rhs) { return lhs.y > rhs.y; });
+            std::sort(left_pos.begin(), left_pos.end(), [](const auto& lhs, const auto& rhs)
+                      { return (lhs.y > rhs.y) || (lhs.y == rhs.y && lhs.x < rhs.x); });
+            std::sort(right_pos.begin(), right_pos.end(), [](const auto& lhs, const auto& rhs)
+                      { return (lhs.y > rhs.y) || (lhs.y == rhs.y && lhs.x < rhs.x); });
 
             if (ps.input_pin_extension != hexagonalization_params::io_pin_extension_mode::NONE)
             {

--- a/include/fiction/algorithms/physical_design/hexagonalization.hpp
+++ b/include/fiction/algorithms/physical_design/hexagonalization.hpp
@@ -474,7 +474,7 @@ class hexagonalization_impl
             // sort primary inputs by y-coordinate for consistency
             std::sort(left_pis.begin(), left_pis.end(), [](const auto& lhs, const auto& rhs) { return lhs.y < rhs.y; });
             std::sort(right_pis.begin(), right_pis.end(),
-                      [](const auto& lhs, const auto& rhs) { return lhs.x < rhs.x; });
+                      [](const auto& lhs, const auto& rhs) { return lhs.y < rhs.y; });
 
             // adjust hex layout width if necessary (only if all inputs placed in top row)
             if (ps.input_pin_extension != hexagonalization_params::io_pin_extension_mode::NONE)
@@ -616,7 +616,7 @@ class hexagonalization_impl
                     }
                 });
 
-            std::sort(left_pos.begin(), left_pos.end(), [](const auto& lhs, const auto& rhs) { return lhs.x > rhs.x; });
+            std::sort(left_pos.begin(), left_pos.end(), [](const auto& lhs, const auto& rhs) { return lhs.y > rhs.y; });
             std::sort(right_pos.begin(), right_pos.end(),
                       [](const auto& lhs, const auto& rhs) { return lhs.y > rhs.y; });
 
@@ -853,6 +853,40 @@ class hexagonalization_impl
                 {
                     auto source        = obj.source;
                     auto update_source = false;
+
+                    const auto above_coord = layout_obstruct.above(obj.source);
+                    if (!layout_obstruct.is_empty_tile(above_coord))
+                    {
+                        const auto below_coord      = layout_obstruct.below(obj.source);
+                        const auto south_east_coord = layout_obstruct.south_east(below_coord);
+                        const auto south_west_coord = layout_obstruct.south_west(below_coord);
+
+                        if (layout_obstruct.is_empty_tile(south_west_coord) &&
+                            !layout_obstruct.is_empty_tile(south_east_coord))
+                        {
+                            if (!layout_obstruct.is_po(layout_obstruct.get_node(south_east_coord)))
+                            {
+                                const auto above_south_east_coord = layout_obstruct.above(south_east_coord);
+                                layout_obstruct.obstruct_connection(below_coord, south_east_coord);
+                                layout_obstruct.obstruct_connection(above_coord, south_east_coord);
+                                layout_obstruct.obstruct_connection(below_coord, above_south_east_coord);
+                                layout_obstruct.obstruct_connection(above_coord, above_south_east_coord);
+                            }
+                        }
+
+                        if (layout_obstruct.is_empty_tile(south_east_coord) &&
+                            !layout_obstruct.is_empty_tile(south_west_coord))
+                        {
+                            if (!layout_obstruct.is_po(layout_obstruct.get_node(south_west_coord)))
+                            {
+                                const auto above_south_west_coord = layout_obstruct.above(south_west_coord);
+                                layout_obstruct.obstruct_connection(below_coord, south_west_coord);
+                                layout_obstruct.obstruct_connection(above_coord, south_west_coord);
+                                layout_obstruct.obstruct_connection(below_coord, above_south_west_coord);
+                                layout_obstruct.obstruct_connection(above_coord, above_south_west_coord);
+                            }
+                        }
+                    }
 
                     // for planar extension, check if source is in the crossing layer
                     if (!crossings && obj.source.z == 1)

--- a/test/algorithms/physical_design/hexagonalization.cpp
+++ b/test/algorithms/physical_design/hexagonalization.cpp
@@ -193,6 +193,7 @@ static void check_mapping_equiv_all()
     check_mapping_equiv_layout(blueprints::crossing_layout<cart_gate_clk_lyt>());
     check_mapping_equiv_layout(blueprints::tautology_gate_layout<cart_gate_clk_lyt>());
     check_mapping_equiv_layout(blueprints::ge_gt_le_lt_layout<cart_gate_clk_lyt>());
+    check_mapping_equiv_layout(blueprints::po_extension_corner_case_layout<cart_gate_clk_lyt>());
 
     check_mapping_equiv_layout_with_planar_rerouting(blueprints::straight_wire_gate_layout<cart_gate_clk_lyt>());
     check_mapping_equiv_layout_with_planar_rerouting(blueprints::or_not_gate_layout<cart_gate_clk_lyt>());

--- a/test/algorithms/physical_design/hexagonalization.cpp
+++ b/test/algorithms/physical_design/hexagonalization.cpp
@@ -200,6 +200,7 @@ static void check_mapping_equiv_all()
     check_mapping_equiv_layout_with_planar_rerouting(blueprints::crossing_layout<cart_gate_clk_lyt>());
     check_mapping_equiv_layout_with_planar_rerouting(blueprints::tautology_gate_layout<cart_gate_clk_lyt>());
     check_mapping_equiv_layout_with_planar_rerouting(blueprints::ge_gt_le_lt_layout<cart_gate_clk_lyt>());
+    check_mapping_equiv_layout_with_planar_rerouting(blueprints::po_extension_corner_case_layout<cart_gate_clk_lyt>());
 }
 
 TEST_CASE("Layout equivalence", "[hexagonalization]")

--- a/test/utils/blueprints/layout_blueprints.hpp
+++ b/test/utils/blueprints/layout_blueprints.hpp
@@ -741,7 +741,7 @@ GateLyt po_extension_corner_case_layout() noexcept
     const auto w8 = layout.create_buf(w7, {2, 2, 1});
     layout.create_po(w8, "f3", {2, 3});
 
-    const auto x4  = layout.create_pi("x3", {3, 0});
+    const auto x4  = layout.create_pi("x4", {3, 0});
     const auto w9  = layout.create_buf(x4, {3, 1, 1});
     const auto w10 = layout.create_buf(w9, {3, 2, 1});
     layout.create_po(w10, "f4", {3, 3});

--- a/test/utils/blueprints/layout_blueprints.hpp
+++ b/test/utils/blueprints/layout_blueprints.hpp
@@ -719,6 +719,36 @@ GateLyt ge_gt_le_lt_layout() noexcept
     return layout;
 }
 
+template <typename GateLyt>
+GateLyt po_extension_corner_case_layout() noexcept
+{
+    GateLyt layout{{4, 3, 1}, fiction::twoddwave_clocking<GateLyt>()};
+
+    const auto x1 = layout.create_pi("x1", {0, 1});
+    const auto w1 = layout.create_buf(x1, {1, 1});
+    const auto w2 = layout.create_buf(w1, {2, 1});
+    const auto w3 = layout.create_buf(w2, {3, 1});
+    layout.create_po(w3, "f1", {4, 1});
+
+    const auto x2 = layout.create_pi("x2", {0, 2});
+    const auto w4 = layout.create_buf(x2, {1, 2});
+    const auto w5 = layout.create_buf(w4, {2, 2});
+    const auto w6 = layout.create_buf(w5, {3, 2});
+    layout.create_po(w6, "f2", {4, 2});
+
+    const auto x3 = layout.create_pi("x3", {2, 0});
+    const auto w7 = layout.create_buf(x3, {2, 1, 1});
+    const auto w8 = layout.create_buf(w7, {2, 2, 1});
+    layout.create_po(w8, "f3", {2, 3});
+
+    const auto x4  = layout.create_pi("x3", {3, 0});
+    const auto w9  = layout.create_buf(x4, {3, 1, 1});
+    const auto w10 = layout.create_buf(w9, {3, 2, 1});
+    layout.create_po(w10, "f4", {3, 3});
+
+    return layout;
+}
+
 template <typename CellLyt>
 CellLyt single_layer_qca_and_gate() noexcept
 {


### PR DESCRIPTION
## Description

Fixing rare bug caused by A* routing over wires.


## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Fixed a corner-case in hexagonalization improving primary-output pre-routing obstruction handling and made I/O ordering deterministic by prioritizing vertical (y) position with x tie-breakers.

- Tests
  - Added a corner-case layout to mapping and planar-rerouting equivalence tests to validate the routing and ordering changes.

- Documentation
  - Recorded the fix in the changelog under Algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->