### PR TITLE
:rotating_light: Fixed `clang-tidy` warnings

### DIFF
--- a/include/fiction/algorithms/physical_design/hexagonalization.hpp
+++ b/include/fiction/algorithms/physical_design/hexagonalization.hpp
@@ -11,7 +11,6 @@
 #include "fiction/layouts/bounding_box.hpp"
 #include "fiction/layouts/obstruction_layout.hpp"
 #include "fiction/traits.hpp"
-#include "fiction/types.hpp"
 #include "fiction/utils/name_utils.hpp"
 #include "fiction/utils/placement_utils.hpp"
 #include "fiction/utils/routing_utils.hpp"
@@ -24,8 +23,11 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <string>
+#include <string_view>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #pragma GCC diagnostic push
@@ -45,8 +47,8 @@ class hexagonalization_io_pin_routing_error : public std::runtime_error
      *
      * @param msg The error message describing the error.
      */
-    explicit hexagonalization_io_pin_routing_error(const std::string_view& msg) noexcept :
-            std::runtime_error(msg.data())
+    explicit hexagonalization_io_pin_routing_error(std::string_view msg) noexcept :
+           std::runtime_error(std::string{msg})
     {}
 };
 


### PR DESCRIPTION
## Description

It seems like the `clang-tidy` CI was failing due to warnings in `hexagonalization.hpp`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
