### PR TITLE
:construction_worker: Fallback to default values for some options in clang-tidy CI configuration

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -54,9 +54,7 @@ jobs:
           style: ""
           tidy-checks: ""
           database: "build"
-          files-changed-only: "true"
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
-          file-annotations: "true"
           ignore-tidy: "build|libs/*|docs/*|benchmarks/*|bib/*|*/pyfiction/pybind11_mkdoc_docstrings.hpp|*/pyfiction/documentation.hpp"
           version: "20"
 


### PR DESCRIPTION
## Description

The `files-changed-only` and `file-annotations` settings didn't seem to work properly. This PR removes the options as they were identical to the default values.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
