### PR TITLE
Stop Renovate from bumping Sphinx on Python <3.11

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,6 +65,17 @@
       commitMessagePrefix: "⬆\uD83D\uDC0B",
     },
     {
+      description: "Sphinx 8.2+ dropped support for Python <3.11, so keep this pin as-is to avoid breaking dependency resolution",
+      matchManagers: [
+        "pep621"
+      ],
+      matchDepNames: [
+        "sphinx"
+      ],
+      matchCurrentVersion: "==8.1.3",
+      enabled: false
+    },
+    {
       description: "Group and automerge all patch updates",
       groupName: "patch versions",
       groupSlug: "all-patch",


### PR DESCRIPTION
## Summary
- #995 (and its predecessors) repeatedly try to bump `sphinx==8.1.3; python_version < '3.11'` to match the newer Sphinx pin used for `python_version >= '3.11'`, but Sphinx 8.2+ dropped support for Python <3.11, which breaks dependency resolution.
- Adds a Renovate `packageRule` that disables updates for the `sphinx` package specifically when its current pinned version is `8.1.3`, so that pin stays put while the `>=3.11` Sphinx pin continues to update normally.

## Test plan
- [x] Validated with `renovate-config-validator` (`Config validated successfully`)
- [x] `.pre-commit-config.yaml`'s "Validate Renovate Config" hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to skip updates for Sphinx version 8.1.3.
  * Existing grouping and automatic patch-update behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->