### PR TITLE
🔧 Switch developer tooling from pre-commit to prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 # To run all pre-commit checks, use:
 #
-#     pre-commit run -a
+#     uvx prek run -a
 #
 # To install pre-commit hooks that run every time you commit:
 #
-#     pre-commit install
+#     uv tool install prek
+#     prek install
 #
 
 ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,17 +67,17 @@ Use these commands to validate your work.
 - **Configure**: `cmake -B build -S . -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_ALGLIB=ON`
 - **Build**: `cmake --build build -j`
 - **Test**: `ctest --test-dir build --output-on-failure`
-- **Format**: `pre-commit run clang-format --all-files` (or let pre-commit handle it)
+- **Format**: `prek run clang-format --all-files` (or let prek handle it)
 
 ### Python (Bindings)
 
 - **Test (Full)**: `nox -s tests` (Runs pytest in isolated environments)
 - **Test (Quick)**: `pytest` (Use if only Python code changed to avoid C++ rebuilds)
-- **Lint**: `nox -s lint` (Runs pre-commit hooks including ruff and mypy)
+- **Lint**: `nox -s lint` (Runs prek hooks including ruff and mypy)
 
 ### General
 
-- **Pre-commit**: `pre-commit run -a` (Runs all checks: formatting, linting, static analysis)
+- **Prek**: `prek run -a` (Runs all checks: formatting, linting, static analysis)
 
 ## Code Style
 
@@ -164,7 +164,7 @@ def create_logic_network(filename: str) -> LogicNetwork:
 ## Boundaries
 
 - ✅ **Always**:
-  - Run `pre-commit run -a` before finishing a task.
+  - Run `prek run -a` before finishing a task.
   - Write tests for new functionality (`test/` for C++, `bindings/mnt/pyfiction/test/` for Python).
   - Use `const` correctness.
   - Prefer STL over custom algorithms.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -54,6 +54,7 @@ Core Guidelines
 * Keep your code clean. Remove any debug statements, left-over comments, or code unrelated to your contribution.
 * Follow the style and conventions used throughout the project.
 * Run :code:`clang-format` and :code:`clang-tidy` to check your code for style and linting errors before committing.
+* We recommend installing `prek <https://prek.j178.dev/>`_ and running :code:`prek install` once so that formatting and linting checks run automatically before every commit.
 
 Pull Request Workflow
 #####################

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,10 +44,10 @@ def preserve_lockfile() -> Generator[None]:
 @nox.session(reuse_venv=True)
 def lint(session: nox.Session) -> None:
     """Run the linter."""
-    if shutil.which("pre-commit") is None:
-        session.install("pre-commit")
+    if shutil.which("prek") is None:
+        session.install("prek")
 
-    session.run("pre-commit", "run", "--all-files", *session.posargs, external=True)
+    session.run("prek", "run", "--all-files", *session.posargs, external=True)
 
 
 def _run_tests(


### PR DESCRIPTION
## Summary
- Migrate developer-facing tooling and docs from `pre-commit` to [`prek`](https://prek.j178.dev/), a drop-in, faster Rust reimplementation that reads the same `.pre-commit-config.yaml` and stays compatible with the hosted `pre-commit.ci` bot (mirrors the setup already used in `cda-tum/aigverse`).
- `.pre-commit-config.yaml`: updated header comment to reference `prek run -a` / `prek install`; hook config itself is unchanged.
- `noxfile.py`: `lint` session now checks for/installs/runs `prek` instead of `pre-commit`.
- `AGENTS.md`: updated all command references to `prek run ...`.
- `docs/contributing.rst`: added a note recommending `prek install` for automatic pre-commit checks.

## Test plan
- [x] `.pre-commit-config.yaml` still parses as valid YAML
- [x] `uvx prek run --all-files` runs successfully against the updated config
- [x] Verified the pre-existing `check-yaml`/`.clang-format` failure also occurs on `main` (unrelated to this change)
- [x] `grep` confirms no stray `pre-commit` references remain in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HhUbv3vzzTt9amrt3DwUR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to use `prek` for formatting and linting checks.
  * Added installation and setup instructions for running checks automatically before commits.

* **Chores**
  * Updated automated linting workflows to run through `prek`, including automatic tool availability setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->