### PR TITLE
📝 Bring Unreleased changelog current and add changelog upkeep rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,8 @@ def create_logic_network(filename: str) -> LogicNetwork:
 - ✅ **Always**:
   - Run `prek run -a` before finishing a task.
   - Write tests for new functionality (`test/` for C++, `bindings/mnt/pyfiction/test/` for Python).
+  - Update `docs/changelog.rst`'s `Unreleased` section for any user-facing change (Added/Changed/Removed/
+    Fixed, following the existing category and bullet style).
   - Check for and consolidate open reviewer comments before considering a PR done (see Code Review above).
   - Use `const` correctness.
   - Prefer STL over custom algorithms.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,10 @@ Added
 - Documentation:
     - Added ``AGENTS.md`` to guide AI agents in the repository
 - Build system:
-    - Added `CMakePresets.json` to offer default CMake configurations
+    - Added ``CMakePresets.json`` with presets for common local development workflows (``dev``,
+      ``dev-asan``, ``dev-full``, ``release``, ``deploy``, ``coverage``) as well as CI-mirroring presets
+      (``ci-debug``, ``ci-release``, ``ci-codeql``, ``ci-tidy``) that let CI failures be reproduced locally
+      with a single ``cmake --preset <name>`` invocation
     - Added support for CMake version 4+
 - Tooling:
     - Added the following `pre-commit` hooks:
@@ -33,11 +36,25 @@ Changed
     - Improved build configuration and option handling for better modularity
     - Addressed several CMake and compiler warnings (including CMP0148 and Pybind11 compatibility) as well as CMake code smells
     - Streamlined package installation and discovery process
+- Continuous integration:
+    - The 🐧/🍎/🪟 CI, ☂️ Coverage, and 📝 CodeQL workflows, the Clang-Tidy Review workflow, and the Docker
+      build now configure via the new CMake presets instead of hand-rolled ``-D`` flag lists
+- Python bindings:
+    - Restructured the ``pyfiction`` bindings to use multiple translation units (one ``.cpp`` file per
+      binding) for better modularity and faster incremental compilation
+- Tooling:
+    - Replaced ``pre-commit`` with ``prek``, a faster Rust reimplementation that stays compatible with
+      ``pre-commit.ci``
+- Dependencies:
+    - Updated all dependencies to their latest versions
 
 Fixed
 #####
 - Code quality:
     - Addressed several ``clang-tidy`` warnings throughout the code base
+- Continuous integration:
+    - Fixed Renovate attempting to bump the ``sphinx`` pin used for Python <3.11, which is unsupported by
+      Sphinx 8.2+
 
 v0.6.12 - 2025-10-29
 --------------------


### PR DESCRIPTION
## Summary
- Update `docs/changelog.rst`'s `Unreleased` section to reflect everything merged since `v0.6.12` (CMakePresets overhaul + CI/Docker wiring, `pyfiction` multi-translation-unit restructuring, `pre-commit` → `prek` switch, dependency updates, Renovate Sphinx-pin fix)
- Add a `Boundaries` rule to `AGENTS.md` requiring the changelog's `Unreleased` section be kept current going forward

## Test plan
- [x] `prek run -a` (ran automatically via pre-commit hook on commit)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pt49AqawH2K3kC2r5ZLNcW