### PR TITLE
:wrench: Modernize CITATION.cff and Release Drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -88,6 +88,22 @@ autolabeler:
     title:
       - "/^:zap:/"
       - "/^⚡️/"
+  - label: "experiment"
+    title:
+      - "/^:alembic:/"
+      - "/^⚗️/"
+  - label: "test"
+    title:
+      - "/^:white_check_mark:/"
+      - "/^✅/"
+  - label: "docker"
+    title:
+      - "/^:whale:/"
+      - "/^🐋/"
+  - label: "dependencies"
+    title:
+      - "/^:arrow_up:/"
+      - "/^⬆️/"
 footer: |
   Many thanks to all contributors!
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,22 +13,40 @@ categories:
       - "bug"
       - "compiler issue"
       - "small fix"
+  - title: "♻️ Refactoring"
+    labels:
+      - "refactoring"
+  - title: "⚗️ Experiments"
+    labels:
+      - "experiment"
   - title: "📝 Documentation"
     labels:
       - "documentation"
   - title: "✅ Testing"
     labels:
       - "test"
+  - title: "🔧 Build System and Tooling"
+    labels:
+      - "build system"
+      - "tooling"
   - title: "👷 CI"
     labels:
       - "github_actions"
+  - title: "🐋 Docker"
+    labels:
+      - "docker"
   - title: "⬆️ Dependencies"
     collapse-after: 5
     labels:
       - "dependencies"
       - "submodules"
+      - "pre-commit"
+      - "python:uv"
+exclude-labels:
+  - "versioning"
+  - "skip-changelog"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
-change-title-escapes: '\<*&'
+change-title-escapes: '\<*_&'
 version-resolver:
   major:
     labels:
@@ -44,6 +62,32 @@ autolabeler:
   - label: "dependencies"
     title:
       - "/update pre-commit hooks/i"
+  # Gitmoji-based fallbacks (https://gitmoji.dev) for PRs that were merged
+  # without an explicit label, so they still land in the right section.
+  - label: "documentation"
+    title:
+      - "/^:memo:/"
+      - "/^📝/"
+  - label: "tooling"
+    title:
+      - "/^:wrench:/"
+      - "/^🔧/"
+  - label: "github_actions"
+    title:
+      - "/^:construction_worker:/"
+      - "/^👷/"
+  - label: "refactoring"
+    title:
+      - "/^:recycle:/"
+      - "/^♻️/"
+  - label: "bug"
+    title:
+      - "/^:bug:/"
+      - "/^🐛/"
+  - label: "performance"
+    title:
+      - "/^:zap:/"
+      - "/^⚡️/"
 footer: |
   Many thanks to all contributors!
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -72,3 +72,24 @@ preferred-citation:
   doi: 10.1109/NANO61778.2024.10628747
   publisher:
     name: IEEE
+references:
+  - type: generic
+    title: "fiction: An Open Source Framework for the Design of Field-coupled Nanocomputing Circuits"
+    authors:
+      - family-names: "Walter"
+        given-names: "Marcel"
+        orcid: "https://orcid.org/0000-0001-5660-9518"
+      - family-names: "Wille"
+        given-names: "Robert"
+        orcid: "https://orcid.org/0000-0002-4993-7860"
+      - family-names: "Sill Torres"
+        given-names: "Frank"
+      - family-names: "Große"
+        given-names: "Daniel"
+      - family-names: "Drechsler"
+        given-names: "Rolf"
+    year: 2019
+    month: 5
+    doi: 10.48550/arXiv.1905.02477
+    url: "https://arxiv.org/abs/1905.02477"
+    notes: "arXiv:1905.02477"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,22 +1,70 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: >-
+  If you use this software, please cite it as below. If you use any of the
+  design automation algorithms provided by fiction, please additionally cite
+  their respective papers as listed at
+  https://fiction.readthedocs.io/en/latest/publications.html.
+title: "fiction: The Munich Nanotech Toolkit (MNT)"
+abstract: >-
+  fiction is an open-source design automation framework for Field-coupled
+  Nanocomputing (FCN) circuits, providing data structures and algorithms for
+  the physical design and verification of FCN technologies such as
+  Quantum-dot Cellular Automata (QCA) and Silicon Dangling Bonds (SiDB).
+type: software
+license: MIT
+repository-code: "https://github.com/cda-tum/fiction"
+url: "https://fiction.readthedocs.io"
+keywords:
+  - field-coupled nanocomputing
+  - design automation
+  - electronic design automation
+  - quantum-dot cellular automata
+  - silicon dangling bonds
 authors:
-- family-names: "Walter"
-  given-names: "Marcel"
-  orcid: "0000-0001-5660-9518"
-- family-names: "Drewniok"
-  given-names: "Jan"
-  orcid: "0000-0002-7545-159X"
-- family-names: "Hofmann"
-  given-names: "Simon"
-  orcid: "0009-0003-8575-9998"
-- family-names: "Hien"
-  given-names: "Benjamin"
-  orcid: "0000-0002-6878-8063"
-- family-names: "Wille"
-  given-names: "Robert"
-  orcid: "0000-0002-4993-7860"
-title: "The Munich Nanotech Toolkit (MNT)"
-version: 0.6.12
-doi: 10.1109/NANO61778.2024.10628747
-url: "https://github.com/cda-tum/fiction"
+  - family-names: "Walter"
+    given-names: "Marcel"
+    orcid: "https://orcid.org/0000-0001-5660-9518"
+  - family-names: "Drewniok"
+    given-names: "Jan"
+    orcid: "https://orcid.org/0000-0002-7545-159X"
+  - family-names: "Hofmann"
+    given-names: "Simon"
+    orcid: "https://orcid.org/0009-0003-8575-9998"
+  - family-names: "Hien"
+    given-names: "Benjamin"
+    orcid: "https://orcid.org/0000-0002-6878-8063"
+  - family-names: "Wille"
+    given-names: "Robert"
+    orcid: "https://orcid.org/0000-0002-4993-7860"
+contact:
+  - family-names: "Walter"
+    given-names: "Marcel"
+    orcid: "https://orcid.org/0000-0001-5660-9518"
+preferred-citation:
+  type: conference-paper
+  title: "The Munich Nanotech Toolkit (MNT)"
+  authors:
+    - family-names: "Walter"
+      given-names: "Marcel"
+      orcid: "https://orcid.org/0000-0001-5660-9518"
+    - family-names: "Drewniok"
+      given-names: "Jan"
+      orcid: "https://orcid.org/0000-0002-7545-159X"
+    - family-names: "Hofmann"
+      given-names: "Simon"
+      orcid: "https://orcid.org/0009-0003-8575-9998"
+    - family-names: "Hien"
+      given-names: "Benjamin"
+      orcid: "https://orcid.org/0000-0002-6878-8063"
+    - family-names: "Wille"
+      given-names: "Robert"
+      orcid: "https://orcid.org/0000-0002-4993-7860"
+  collection-title: "2024 IEEE International Conference on Nanotechnology (IEEE NANO)"
+  conference:
+    name: "2024 IEEE International Conference on Nanotechnology (IEEE NANO)"
+  year: 2024
+  start: 454
+  end: 459
+  doi: 10.1109/NANO61778.2024.10628747
+  publisher:
+    name: IEEE

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,10 +16,14 @@ repository-code: "https://github.com/cda-tum/fiction"
 url: "https://fiction.readthedocs.io"
 keywords:
   - field-coupled nanocomputing
-  - design automation
-  - electronic design automation
   - quantum-dot cellular automata
   - silicon dangling bonds
+  - design automation
+  - logic synthesis
+  - placement
+  - routing
+  - verification
+  - simulation
 authors:
   - family-names: "Walter"
     given-names: "Marcel"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -85,10 +85,13 @@ references:
         orcid: "https://orcid.org/0000-0002-4993-7860"
       - family-names: "Sill Torres"
         given-names: "Frank"
+        orcid: "https://orcid.org/0000-0002-4028-455X"
       - family-names: "Große"
         given-names: "Daniel"
+        orcid: "https://orcid.org/0000-0002-1490-6175"
       - family-names: "Drechsler"
         given-names: "Rolf"
+        orcid: "https://orcid.org/0000-0002-9872-1740"
     year: 2019
     month: 5
     doi: 10.48550/arXiv.1905.02477

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,12 +4,13 @@ message: >-
   design automation algorithms provided by fiction, please additionally cite
   their respective papers as listed at
   https://fiction.readthedocs.io/en/latest/publications.html.
-title: "fiction: The Munich Nanotech Toolkit (MNT)"
+title: "The Munich Nanotech Toolkit (MNT)"
 abstract: >-
   fiction is an open-source design automation framework for Field-coupled
   Nanocomputing (FCN) circuits, providing data structures and algorithms for
   the physical design and verification of FCN technologies such as
   Quantum-dot Cellular Automata (QCA) and Silicon Dangling Bonds (SiDB).
+  It forms the backbone of the Munich Nanotech Toolkit (MNT).
 type: software
 license: MIT
 repository-code: "https://github.com/cda-tum/fiction"


### PR DESCRIPTION
## Summary
- **CITATION.cff**: fix invalid ORCID format (bare IDs didn't satisfy the CFF 1.2.0 schema — now validated), restructure the IEEE NANO 2024 paper as a proper `preferred-citation` (venue, pages, publisher, DOI) instead of a flat top-level `doi`/`url`, and add `license`, `repository-code`, `abstract`, `keywords`, and `contact`. Dropped the hardcoded `version` field, which had no automation keeping it in sync and was already stale (`0.6.12` vs. the current draft `0.6.13`).
- **Release Drafter**: added categories for labels that previously had nowhere to go (`build system`, `tooling`, `docker`, `pre-commit`, `python:uv`, `refactoring`, `experiment`) — these were falling through into an uncategorized block at the top of every draft release. Excluded `versioning`-labeled (self-referential version-bump) PRs from the changelog and added a `skip-changelog` escape hatch. Added gitmoji-based autolabeler fallbacks so PRs merged without an explicit label still land in the right section, and escaped underscores in change titles so identifiers like `is_operational` don't render as markdown emphasis.

## Test plan
- [x] `CITATION.cff` validated against the CFF 1.2.0 schema via `cffconvert --validate`
- [x] `release-drafter.yml` validated as YAML and against pre-commit's GitHub Workflows validator
- [ ] Confirm the next draft release renders the new categories as expected

https://claude.ai/code/session_019nZj2zTzswUbmSWdzskP3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Improved automatic release note categorization, including support for refactoring, experiments, tooling, and Docker changes.
  * Added rules to exclude versioning and intentionally skipped changes from release notes.
  * Enhanced automatic labeling for common change types such as documentation, tooling, bug fixes, and performance.

* **Documentation**
  * Expanded project citation metadata with richer descriptions, licensing, keywords, author details, publication information, and contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->