### PR TITLE
Pin rui314/setup-mold and replace archived BSFishy/pip-action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -82,10 +82,10 @@ jobs:
           cache: "pip"
 
       - name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install pip packages
-        uses: BSFishy/pip-action@v1
+        uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
         with:
           requirements: ${{github.workspace}}/vendors/mugen/requirements.txt
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -85,9 +85,7 @@ jobs:
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install pip packages
-        uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
-        with:
-          requirements: ${{github.workspace}}/vendors/mugen/requirements.txt
+        run: python -m pip install --disable-pip-version-check -r ${{github.workspace}}/vendors/mugen/requirements.txt
 
       - name: Setup Z3 Solver
         id: z3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,9 +67,7 @@ jobs:
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install pip packages
-        uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
-        with:
-          requirements: ${{github.workspace}}/vendors/mugen/requirements.txt
+        run: python -m pip install --disable-pip-version-check -r ${{github.workspace}}/vendors/mugen/requirements.txt
 
       - name: Setup Z3 Solver
         id: z3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,10 +64,10 @@ jobs:
           cache: "pip"
 
       - name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install pip packages
-        uses: BSFishy/pip-action@v1
+        uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
         with:
           requirements: ${{github.workspace}}/vendors/mugen/requirements.txt
 

--- a/.github/workflows/pyfiction-pypi-deployment.yml
+++ b/.github/workflows/pyfiction-pypi-deployment.yml
@@ -114,7 +114,7 @@ jobs:
 
       - if: runner.os == 'Linux'
         name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -67,7 +67,7 @@ jobs:
 
       - if: runner.os == 'Linux'
         name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Setup Z3 Solver
         id: z3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -94,12 +94,12 @@ jobs:
           cache: "pip"
 
       - name: Install pip packages
-        uses: BSFishy/pip-action@v1
+        uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
         with:
           requirements: ${{github.workspace}}/vendors/mugen/requirements.txt
 
       - name: Setup mold
-        uses: rui314/setup-mold@v1
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Setup Z3 Solver
         if: matrix.os != 'ubuntu-24.04-arm'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -94,9 +94,7 @@ jobs:
           cache: "pip"
 
       - name: Install pip packages
-        uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
-        with:
-          requirements: ${{github.workspace}}/vendors/mugen/requirements.txt
+        run: python -m pip install --disable-pip-version-check -r ${{github.workspace}}/vendors/mugen/requirements.txt
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1


### PR DESCRIPTION
## Summary
- Every other third-party action in the repo is pinned to a full commit SHA with the resolved version as a trailing comment; `rui314/setup-mold@v1` was still on a floating tag across 5 workflow files. Pinned it to its current `v1` commit SHA, matching the existing convention.
- `BSFishy/pip-action` (also on a floating `v1` tag) is archived/read-only upstream. Replaced its 3 usages (`codeql-analysis.yml`, `coverage.yml`, `ubuntu.yml`) with a plain `python -m pip install -r ...` run step — each workflow already sets up Python, so there's nothing left to pin. Per CodeRabbit review.

Split out from the CFF/Release Drafter cleanup (#1012) per review discussion — this is an unrelated, mechanical CI hardening fix.

## Test plan
- [x] `git grep` confirms no remaining floating `@v1` references or uses of `BSFishy/pip-action`
- [x] Passed the repo's "Validate GitHub Workflows" pre-commit hook
- [x] Full CI matrix green (ubuntu/windows/macos/coverage/CodeQL/packaging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)