### PR TITLE
👷 Add Zizmor security scanning and move small CI jobs to ubuntu-slim

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -14,9 +14,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 env:
   Z3_VERSION: 4.13.4
@@ -25,12 +23,16 @@ jobs:
   clangtidy:
     runs-on: ubuntu-latest
     name: 🚨 Clang-Tidy
+    permissions:
+      contents: read
+      pull-requests: write # required to post/update the clang-tidy thread comment on the PR
 
     steps:
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake libreadline-dev libtbb-dev python3-dev

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   Z3_VERSION: 4.13.4
 
@@ -37,9 +39,9 @@ jobs:
     name: Analyze ${{ matrix.language }}
     runs-on: ubuntu-24.04
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read # required by github/codeql-action/init to check the workflow run
+      contents: read # required to check out the repository
+      security-events: write # required to upload the SARIF results
 
     strategy:
       fail-fast: false
@@ -60,12 +62,15 @@ jobs:
           swap-storage: true
 
       - name: Install libraries and the respective compiler
-        run: sudo apt-get update && sudo apt-get install -yq libtbb-dev ${{matrix.compiler}}
+        env:
+          COMPILER: ${{ matrix.compiler }}
+        run: sudo apt-get update && sudo apt-get install -yq libtbb-dev "$COMPILER"
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
@@ -85,7 +90,7 @@ jobs:
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install pip packages
-        run: python -m pip install --disable-pip-version-check -r ${{github.workspace}}/vendors/mugen/requirements.txt
+        run: python -m pip install --disable-pip-version-check -r vendors/mugen/requirements.txt
 
       - name: Setup Z3 Solver
         id: z3
@@ -106,9 +111,11 @@ jobs:
 
       - if: matrix.language == 'cpp'
         name: Configure CMake
+        env:
+          COMPILER: ${{ matrix.compiler }}
         run: >
-          cmake -S ${{github.workspace}} --preset ci-codeql
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          cmake -S . --preset ci-codeql
+          -DCMAKE_CXX_COMPILER="$COMPILER"
 
       - if: matrix.language == 'cpp'
         name: Build fiction

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Generate Coverage Report
         run: |
           lcov --gcov-tool gcov-13 -t "fiction-coverage" -o lcov.info -c -d build-coverage/ --ignore-errors mismatch --ignore-errors gcov
-          lcov --gcov-tool gcov-13 -e lcov.info "include*" -o lcov_filtered.info
+          lcov --gcov-tool gcov-13 -e lcov.info "$GITHUB_WORKSPACE/include*" -o lcov_filtered.info
           lcov -l lcov_filtered.info
 
       - name: Upload report to Codecov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -34,6 +36,9 @@ env:
 
 jobs:
   build_and_test:
+    permissions:
+      contents: read # required to check out the repository
+
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -44,10 +49,14 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -yq ${{matrix.compiler}} lcov ninja-build
+        env:
+          COMPILER: ${{ matrix.compiler }}
+        run: sudo apt-get update && sudo apt-get install -yq "$COMPILER" lcov ninja-build
 
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
@@ -67,7 +76,7 @@ jobs:
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - name: Install pip packages
-        run: python -m pip install --disable-pip-version-check -r ${{github.workspace}}/vendors/mugen/requirements.txt
+        run: python -m pip install --disable-pip-version-check -r vendors/mugen/requirements.txt
 
       - name: Setup Z3 Solver
         id: z3
@@ -80,9 +89,11 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Configure CMake
+        env:
+          COMPILER: ${{ matrix.compiler }}
         run: >
-          cmake -S ${{github.workspace}} --preset coverage
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          cmake -S . --preset coverage
+          -DCMAKE_CXX_COMPILER="$COMPILER"
 
       - name: Build
         run: cmake --build --preset coverage --parallel 4
@@ -92,14 +103,14 @@ jobs:
 
       - name: Generate Coverage Report
         run: |
-          lcov --gcov-tool gcov-13 -t "fiction-coverage" -o lcov.info -c -d ${{github.workspace}}/build-coverage/ --ignore-errors mismatch --ignore-errors gcov
-          lcov --gcov-tool gcov-13 -e lcov.info "${{github.workspace}}/include*" -o lcov_filtered.info
+          lcov --gcov-tool gcov-13 -t "fiction-coverage" -o lcov.info -c -d build-coverage/ --ignore-errors mismatch --ignore-errors gcov
+          lcov --gcov-tool gcov-13 -e lcov.info "include*" -o lcov_filtered.info
           lcov -l lcov_filtered.info
 
       - name: Upload report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ${{github.workspace}}/lcov_filtered.info
+          files: lcov_filtered.info
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,20 +34,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
     name: 🐳 Build and publish Docker image
     runs-on: ubuntu-latest
     permissions:
-      packages: write
-      contents: read
-      attestations: write
-      id-token: write
+      packages: write # required to push the image to ghcr.io on release
+      contents: read # required to check out the repository
+      attestations: write # required to publish the build provenance attestation on release
+      id-token: write # required by actions/attest-build-provenance to mint the attestation
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Log in to Docker Hub
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,6 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -34,6 +36,9 @@ env:
 
 jobs:
   build_and_test:
+    permissions:
+      contents: read # required to check out the repository
+
     strategy:
       matrix:
         os: [macos-14, macos-15]
@@ -45,6 +50,8 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -75,9 +82,11 @@ jobs:
       # Build and test pipeline for Debug mode
 
       - name: Configure CMake (Debug)
+        env:
+          COMPILER: ${{ matrix.compiler }}
         run: >
-          cmake -S ${{github.workspace}} --preset ci-debug
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          cmake -S . --preset ci-debug
+          -DCMAKE_CXX_COMPILER="$COMPILER"
 
       - name: Build (Debug)
         run: cmake --build --preset ci-debug --parallel 3
@@ -88,9 +97,11 @@ jobs:
       # Build and test pipeline for Release mode
 
       - name: Configure CMake (Release)
+        env:
+          COMPILER: ${{ matrix.compiler }}
         run: >
-          cmake -S ${{github.workspace}} --preset ci-release
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          cmake -S . --preset ci-release
+          -DCMAKE_CXX_COMPILER="$COMPILER"
           -DFICTION_ENABLE_JEMALLOC=ON
 
       - name: Build (Release)

--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -8,7 +8,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # head_ref is always empty for this workflow's push/workflow_dispatch triggers (it's only set
+  # for pull_request events), so fall back to github.ref rather than the always-unique run_id --
+  # otherwise concurrent runs on the same branch would never actually be serialized, and could
+  # race on the "Commit docstrings" push below
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/pyfiction-docstring-generator.yml
+++ b/.github/workflows/pyfiction-docstring-generator.yml
@@ -7,12 +7,22 @@ on:
       - ".github/workflows/pyfiction-docstring-generator.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   get_docstrings:
     name: 🐍 Auto-generate docstrings for pyfiction from C++ code
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to commit and push the generated docstrings
     steps:
       - name: Clone Repository
+        # zizmor: ignore[artipacked] persisted credentials are required so the later "Commit
+        # docstrings" step (EndBug/add-and-commit) can push; that action doesn't accept a token
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
@@ -29,17 +39,17 @@ jobs:
 
       - name: Create docstrings file
         working-directory: ${{ github.workspace }}
-        run: touch ${{ github.workspace }}/pybind11_mkdoc_docstrings.hpp
+        run: touch pybind11_mkdoc_docstrings.hpp
 
       - name: Run pybind11_mkdoc
         working-directory: ${{ github.workspace }}
         run: >
           python3
           -m pybind11_mkdoc
-          -o ${{ github.workspace }}/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+          -o bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
           -D FICTION_Z3_SOLVER
           -D FICTION_ALGLIB_ENABLED
-          `find ${{ github.workspace }}/include/fiction -name "*.hpp" -print`
+          `find include/fiction -name "*.hpp" -print`
 
       - name: Upload docstrings as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -48,6 +58,8 @@ jobs:
           overwrite: true
 
       - name: Commit docstrings
+        # zizmor: ignore[superfluous-actions] keeping the well-tested action (handles the
+        # no-changes-to-commit case, author fallback, etc.) instead of hand-rolled git scripting
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           add: "bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp"

--- a/.github/workflows/pyfiction-pypi-deployment.yml
+++ b/.github/workflows/pyfiction-pypi-deployment.yml
@@ -34,14 +34,13 @@ on:
       - ".github/workflows/pyfiction-pypi-deployment.yml"
   workflow_dispatch:
   workflow_run:
+    # zizmor: ignore[dangerous-triggers] no step here checks out the completed run's head SHA;
+    # every checkout below always resolves to this workflow's own trigger ref
     workflows: ["pyfiction Docstring Generator"]
     types:
       - completed
 
-permissions:
-  attestations: write
-  contents: read
-  id-token: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -54,17 +53,20 @@ jobs:
   build_sdist:
     name: 📦 Build Source Distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to check out the repository
     steps:
       - name: Clone repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "latest"
-          enable-cache: true
+          enable-cache: false
 
       - name: Build sdist
         run: uv build --sdist
@@ -82,6 +84,8 @@ jobs:
   build_wheels:
     name: 🛞 Wheels for ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read # required to check out the repository
 
     strategy:
       fail-fast: false
@@ -93,6 +97,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -120,7 +125,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "latest"
-          enable-cache: true
+          enable-cache: false
 
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
@@ -137,6 +142,9 @@ jobs:
     runs-on: ubuntu-latest
     name: 🚀 Publish to PyPI
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      attestations: write # required to publish the build provenance attestation
+      id-token: write # required by actions/attest-build-provenance to mint the attestation
     steps:
       - name: Download the previously stored artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -151,6 +159,9 @@ jobs:
           subject-path: "dist/*"
 
       - name: Deploy to PyPI
+        # zizmor: ignore[use-trusted-publishing] switching to OIDC trusted publishing requires
+        # registering this workflow as a trusted publisher on the PyPI project first (external,
+        # not something this repo alone controls); tracked as follow-up, not done here
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
           password: ${{ secrets.PYPI_DEPLOY_TOKEN }}

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -28,6 +28,8 @@ on:
       - "uv.lock"
       - ".github/workflows/python-bindings.yml"
   workflow_run:
+    # zizmor: ignore[dangerous-triggers] no step here checks out the completed run's head SHA;
+    # the checkout below always resolves to this workflow's own trigger ref
     workflows: ["pyfiction Docstring Generator"]
     types:
       - completed
@@ -35,6 +37,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
+permissions: {}
 
 defaults:
   run:
@@ -47,6 +51,8 @@ jobs:
   python-tests:
     name: 🐍 ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read # required to check out the repository
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +62,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup ccache
         if: matrix.runs-on != 'ubuntu-24.04-arm'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,8 +15,8 @@ concurrency:
 jobs:
   update_release_draft:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # required to create/update the draft release
+      pull-requests: write # required to label pull requests based on release-drafter.yml rules
 
     runs-on: ubuntu-slim
     name: Draft Release

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Draft Release
 
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,6 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -34,6 +36,9 @@ env:
 
 jobs:
   build_and_test:
+    permissions:
+      contents: read # required to check out the repository
+
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
@@ -72,10 +77,14 @@ jobs:
 
     steps:
       - name: Install libraries and the respective compiler
-        run: sudo apt-get update && sudo apt-get install -yq libtbb-dev ${{matrix.compiler}}
+        env:
+          COMPILER: ${{ matrix.compiler }}
+        run: sudo apt-get update && sudo apt-get install -yq libtbb-dev "$COMPILER"
 
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup ccache
         # ccache is not supported on ARM yet
@@ -94,7 +103,7 @@ jobs:
           cache: "pip"
 
       - name: Install pip packages
-        run: python -m pip install --disable-pip-version-check -r ${{github.workspace}}/vendors/mugen/requirements.txt
+        run: python -m pip install --disable-pip-version-check -r vendors/mugen/requirements.txt
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -113,12 +122,15 @@ jobs:
       # Build and test pipeline for Debug mode
 
       - name: Configure CMake (Debug)
+        env:
+          COMPILER: ${{ matrix.compiler }}
+          EXTRA_CMAKE_ARGS: ${{ matrix.os == 'ubuntu-24.04-arm' && '-DFICTION_Z3=OFF' || '' }}
         run: >
-          cmake -S ${{github.workspace}} --preset ci-debug
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          cmake -S . --preset ci-debug
+          -DCMAKE_CXX_COMPILER="$COMPILER"
           -DFICTION_ENABLE_MUGEN=ON
           -DFICTION_LIGHTWEIGHT_DEBUG_BUILDS=ON
-          ${{ matrix.os == 'ubuntu-24.04-arm' && '-DFICTION_Z3=OFF' || '' }}
+          $EXTRA_CMAKE_ARGS
 
       - name: Build (Debug)
         run: cmake --build --preset ci-debug --parallel 4
@@ -129,12 +141,15 @@ jobs:
       # Build and test pipeline for Release mode
 
       - name: Configure CMake (Release)
+        env:
+          COMPILER: ${{ matrix.compiler }}
+          EXTRA_CMAKE_ARGS: ${{ matrix.os == 'ubuntu-24.04-arm' && '-DFICTION_Z3=OFF' || '' }}
         run: >
-          cmake -S ${{github.workspace}} --preset ci-release
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          cmake -S . --preset ci-release
+          -DCMAKE_CXX_COMPILER="$COMPILER"
           -DFICTION_ENABLE_MUGEN=ON
           -DFICTION_ENABLE_JEMALLOC=ON
-          ${{ matrix.os == 'ubuntu-24.04-arm' && '-DFICTION_Z3=OFF' || '' }}
+          $EXTRA_CMAKE_ARGS
 
       - name: Build (Release)
         run: cmake --build --preset ci-release --parallel 4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 defaults:
   run:
     shell: pwsh # use pwsh as directory handling does not seem to work with bash
@@ -34,6 +36,9 @@ env:
 
 jobs:
   build_and_test:
+    permissions:
+      contents: read # required to check out the repository
+
     strategy:
       matrix:
         os: [windows-2022, windows-2025]
@@ -52,6 +57,8 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -78,10 +85,13 @@ jobs:
       # Build and test pipeline for Debug mode
 
       - name: Configure CMake (Debug)
+        env:
+          CXX_COMPILER: ${{ matrix.cxx_compiler }}
+          C_COMPILER: ${{ matrix.c_compiler }}
         run: >
-          cmake -S ${{github.workspace}} --preset ci-debug
-          -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}}
-          -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
+          cmake -S . --preset ci-debug
+          -DCMAKE_CXX_COMPILER="$env:CXX_COMPILER"
+          -DCMAKE_C_COMPILER="$env:C_COMPILER"
 
       - name: Build (Debug)
         run: cmake --build --preset ci-debug --parallel 4
@@ -92,10 +102,13 @@ jobs:
       # Build and test pipeline for Release mode
 
       - name: Configure CMake (Release)
+        env:
+          CXX_COMPILER: ${{ matrix.cxx_compiler }}
+          C_COMPILER: ${{ matrix.c_compiler }}
         run: >
-          cmake -S ${{github.workspace}} --preset ci-release
-          -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}}
-          -DCMAKE_C_COMPILER=${{matrix.c_compiler}}
+          cmake -S . --preset ci-release
+          -DCMAKE_CXX_COMPILER="$env:CXX_COMPILER"
+          -DCMAKE_C_COMPILER="$env:C_COMPILER"
 
       - name: Build (Release)
         run: cmake --build --preset ci-release --parallel 4

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,7 +20,8 @@ permissions: {}
 jobs:
   zizmor:
     name: 🌈 Zizmor
-    runs-on: ubuntu-slim
+    # zizmor-action shells out to Docker, which ubuntu-slim's unprivileged container does not support
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # required to upload results to the code scanning API
 
@@ -34,3 +35,5 @@ jobs:
         uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
         with:
           persona: pedantic
+          # fork PRs get a read-only GITHUB_TOKEN and cannot upload SARIF to code scanning
+          advanced-security: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: 🌈 • Zizmor
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: 🌈 Zizmor
+    runs-on: ubuntu-slim
+    permissions:
+      security-events: write # required to upload results to the code scanning API
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          persona: pedantic

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -23693,11 +23693,11 @@ static const char *__doc_fmt_formatter_parse = R"doc()doc";
 
 static const char *__doc_fmt_formatter_parse_2 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_home_runner_work_fiction_fiction_include_fiction_layouts_coordinates_hpp_1090_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1090_8 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_home_runner_work_fiction_fiction_include_fiction_layouts_coordinates_hpp_1106_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1106_8 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_home_runner_work_fiction_fiction_include_fiction_technology_cell_ports_hpp_291_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_technology_cell_ports_hpp_291_8 = R"doc()doc";
 
 static const char *__doc_mockturtle_detail_foreach_element_if_transform = R"doc()doc";
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,9 @@ Added
         - `cmake-format-precommit`
         - `uv-pre-commit`
     - Enabled auto-merging stable non-major dependency releases via Renovate
+- Continuous integration:
+    - Added a 🌈 Zizmor workflow that statically analyzes the GitHub Actions workflows for security
+      issues on every push, pull request, and merge group, and uploads findings to the code scanning API
 
 Changed
 #######
@@ -39,6 +42,8 @@ Changed
 - Continuous integration:
     - The 🐧/🍎/🪟 CI, ☂️ Coverage, and 📝 CodeQL workflows, the Clang-Tidy Review workflow, and the Docker
       build now configure via the new CMake presets instead of hand-rolled ``-D`` flag lists
+    - The 🔖 Release Drafter workflow now runs on the smaller ``ubuntu-slim`` runner instead of
+      ``ubuntu-latest``, since it only calls the GitHub API and needs no compiler toolchain
 - Python bindings:
     - Restructured the ``pyfiction`` bindings to use multiple translation units (one ``.cpp`` file per
       binding) for better modularity and faster incremental compilation

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,12 @@ Changed
       build now configure via the new CMake presets instead of hand-rolled ``-D`` flag lists
     - The 🔖 Release Drafter workflow now runs on the smaller ``ubuntu-slim`` runner instead of
       ``ubuntu-latest``, since it only calls the GitHub API and needs no compiler toolchain
+    - Hardened every workflow against the findings from the new 🌈 Zizmor workflow: scoped
+      ``permissions`` blocks to the minimum each job needs (instead of relying on the broad default),
+      set ``persist-credentials: false`` on checkouts that don't push, routed matrix/workspace values
+      through ``env`` vars instead of interpolating them directly into shell commands, and disabled
+      the PyPI packaging workflow's build cache to close a cache-poisoning path into published
+      artifacts
 - Python bindings:
     - Restructured the ``pyfiction`` bindings to use multiple translation units (one ``.cpp`` file per
       binding) for better modularity and faster incremental compilation

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,7 +28,9 @@ Added
     - Enabled auto-merging stable non-major dependency releases via Renovate
 - Continuous integration:
     - Added a 🌈 Zizmor workflow that statically analyzes the GitHub Actions workflows for security
-      issues on every push, pull request, and merge group, and uploads findings to the code scanning API
+      issues on every push, pull request, and merge group, and uploads findings to the code scanning
+      API; fork pull requests print findings to the log instead, since their read-only token can't
+      upload to it
 
 Changed
 #######


### PR DESCRIPTION
## Description

Adds [Zizmor](https://docs.zizmor.sh/) — a static analyzer for GitHub Actions workflows — using
`zizmorcore/zizmor-action` with the `pedantic` persona, uploading findings to the code scanning API.
Fork pull requests print findings to the log instead, since they get a read-only `GITHUB_TOKEN` and
can't use the `security-events: write` permission the upload needs.

Also moves the `release-drafter` job to the
[`ubuntu-slim`](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) GitHub-hosted
runner label (1 vCPU, GA as of 2026-01-22), since it only calls an action against the GitHub API and needs
no compiler toolchain. The Zizmor job itself was tried on `ubuntu-slim` too, but `zizmor-action` shells out
to Docker, which that runner's unprivileged container doesn't support — confirmed by a failed CI run — so
it stays on `ubuntu-latest`. The other workflows in this repo (C++/Python builds, CodeQL, coverage, Docker)
all need real build tooling and stay on their current runners.

**Update:** this PR now also fixes every finding Zizmor surfaces against the existing workflows (~80,
across `template-injection`, `excessive-permissions`, `artipacked`, `cache-poisoning`, `dangerous-triggers`,
`concurrency-limits`, and `undocumented-permissions`), rather than leaving them for follow-up:
- Scoped `permissions:` blocks to what each job actually needs, instead of relying on the broad default
  (workflow-level `permissions: {}` plus a minimal per-job grant)
- `persist-credentials: false` on checkouts that don't push back to the repo
- Routed matrix/workspace values through `env` vars (or dropped the redundant `github.workspace` prefix,
  since steps already run from there) instead of interpolating them directly into shell commands
- Disabled `setup-uv`'s build cache in the PyPI packaging workflow, closing a cache-poisoning path into
  published artifacts
- Added a concurrency group to the Docstring Generator workflow (it had none), and fixed the resulting
  group key: `head_ref` is only set for `pull_request` events, but this workflow only triggers on
  `push`/`workflow_dispatch`, so it fell back to the always-unique `run_id` and never actually serialized
  runs — defeating the point, since overlapping runs could race on the "Commit docstrings" push

Two findings are accepted-with-justification rather than changed, documented inline via
`# zizmor: ignore[...]` comments:
- `dangerous-triggers` on the two `workflow_run` triggers (Docstring Generator → Python Bindings CI /
  PyPI Packaging): neither workflow checks out the completed run's head SHA, so there's no path for a
  fork's commit content to execute with these workflows' elevated privileges
- `use-trusted-publishing` on the PyPI publish step: switching to OIDC trusted publishing requires
  registering this workflow as a trusted publisher on the PyPI project first, which is outside this repo;
  tracked as follow-up
- `artipacked` on the Docstring Generator's checkout: persisted credentials are required so the later
  `EndBug/add-and-commit` step can push (that action doesn't accept a token)
- `superfluous-actions` on the same step: kept the well-tested action instead of hand-rolled git scripting

Every workflow is individually clean under `zizmor --persona pedantic` now.

Fixes # (issue)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSn4o2B7uBAa4EXnN3dJTW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Zizmor security-scanning GitHub Actions workflow for Actions configuration changes on pushes, main pull requests, and merge groups, with Code Scanning uploads and safer handling for forked pull requests.
- **Chores**
  - Hardened CI security by tightening GitHub Actions permissions (workflow/job-scoped), disabling credential persistence in checkouts, and standardizing build commands to use repo-root paths and matrix compiler variables.
  - Moved the release draft workflow to a smaller runner and added run serialization to the docstring generator workflow.
- **Documentation**
  - Updated the unreleased changelog and refreshed generated docstring formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->