### PR TITLE
📝 Add missing docstrings for pyfiction constructors and operators

### DIFF
--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/iter/bdl_input_iterator.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/iter/bdl_input_iterator.cpp
@@ -84,8 +84,12 @@ void bdl_input_iterator_impl(pybind11::module& m, const std::string& lattice)
             "__getitem__", [](const fiction::bdl_input_iterator<Lyt>& self, int n) -> fiction::bdl_input_iterator<Lyt>
             { return self[n]; }, py::arg("m"), DOC(fiction_bdl_input_iterator_operator_array))
 
-        .def("num_input_pairs", &fiction::bdl_input_iterator<Lyt>::num_input_pairs)
-        .def("get_layout", [](const fiction::bdl_input_iterator<Lyt>& self) -> const Lyt& { return *self; })
+        .def("num_input_pairs", &fiction::bdl_input_iterator<Lyt>::num_input_pairs,
+             "Returns the number of input BDL pairs the iterator was constructed with.")
+        .def(
+            "get_layout", [](const fiction::bdl_input_iterator<Lyt>& self) -> const Lyt& { return *self; },
+            "Returns the layout that represents the current input state, equivalent to dereferencing the "
+            "iterator.")
 
         ;
 }
@@ -110,8 +114,9 @@ void bdl_input_iterator(pybind11::module& m)
     /**
      * BDL input iterator parameters.
      */
-    py::class_<fiction::bdl_input_iterator_params>(m, "bdl_input_iterator_params")
-        .def(py::init<>())
+    py::class_<fiction::bdl_input_iterator_params>(m, "bdl_input_iterator_params",
+                                                   DOC(fiction_bdl_input_iterator_params))
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("bdl_wire_params", &fiction::bdl_input_iterator_params::bdl_wire_params,
                        DOC(fiction_bdl_input_iterator_params_bdl_wire_params))
         .def_readwrite("input_bdl_config", &fiction::bdl_input_iterator_params::input_bdl_config,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/network_transformation/fanout_substitution.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/network_transformation/fanout_substitution.cpp
@@ -44,7 +44,7 @@ void fanout_substitution(pybind11::module& m)
 
     py::class_<fiction::fanout_substitution_params>(m, "fanout_substitution_params",
                                                     DOC(fiction_fanout_substitution_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("strategy", &fiction::fanout_substitution_params::strategy,
                        DOC(fiction_fanout_substitution_params_strategy))
         .def_readwrite("degree", &fiction::fanout_substitution_params::degree,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/network_transformation/network_balancing.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/network_transformation/network_balancing.cpp
@@ -30,7 +30,7 @@ void network_balancing(pybind11::module& m)
     namespace py = pybind11;
 
     py::class_<fiction::network_balancing_params>(m, "network_balancing_params", DOC(fiction_network_balancing_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("unify_outputs", &fiction::network_balancing_params::unify_outputs,
                        DOC(fiction_network_balancing_params_unify_outputs))
 

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/network_transformation/technology_mapping.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/network_transformation/technology_mapping.cpp
@@ -30,7 +30,7 @@ void technology_mapping(pybind11::module& m)
 
     py::class_<fiction::technology_mapping_params>(m, "technology_mapping_params",
                                                    DOC(fiction_technology_mapping_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
 
         .def_readwrite("decay", &fiction::technology_mapping_params::decay,
                        DOC(fiction_technology_mapping_params_decay))
@@ -64,7 +64,7 @@ void technology_mapping(pybind11::module& m)
         ;
 
     py::class_<fiction::technology_mapping_stats>(m, "technology_mapping_stats", DOC(fiction_technology_mapping_stats))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def("report", &fiction::technology_mapping_stats::report, DOC(fiction_technology_mapping_stats_report))
         .def_readonly("mapper_stats", &fiction::technology_mapping_stats::mapper_stats,
                       DOC(fiction_technology_mapping_stats_mapper_stats));

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/path_finding/a_star.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/path_finding/a_star.cpp
@@ -47,7 +47,7 @@ void a_star(pybind11::module& m)
     namespace py = pybind11;
 
     py::class_<fiction::a_star_params>(m, "a_star_params", DOC(fiction_a_star_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("crossings", &fiction::a_star_params::crossings, DOC(fiction_a_star_params_crossings));
 
     detail::a_star_impl<py_cartesian_obstruction_layout>(m);

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/path_finding/enumerate_all_paths.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/path_finding/enumerate_all_paths.cpp
@@ -51,7 +51,7 @@ void enumerate_all_paths(pybind11::module& m)
 
     py::class_<fiction::enumerate_all_paths_params>(m, "enumerate_all_paths_params",
                                                     DOC(fiction_enumerate_all_paths_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("crossings", &fiction::enumerate_all_paths_params::crossings,
                        DOC(fiction_enumerate_all_paths_params_crossings))
 

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/path_finding/k_shortest_paths.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/path_finding/k_shortest_paths.cpp
@@ -52,7 +52,7 @@ void yen_k_shortest_paths(pybind11::module& m)
 
     py::class_<fiction::yen_k_shortest_paths_params>(m, "yen_k_shortest_paths_params",
                                                      DOC(fiction_yen_k_shortest_paths_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("a_star_params", &fiction::yen_k_shortest_paths_params::astar_params,
                        DOC(fiction_yen_k_shortest_paths_params_astar_params))
 

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/color_routing.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/color_routing.cpp
@@ -59,7 +59,7 @@ void color_routing(pybind11::module& m)
         .value("SAT", fiction::graph_coloring_engine::SAT, DOC(fiction_graph_coloring_engine_SAT));
 
     py::class_<fiction::color_routing_params>(m, "color_routing_params", DOC(fiction_color_routing_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("conduct_partial_routing", &fiction::color_routing_params::conduct_partial_routing,
                        DOC(fiction_color_routing_params_conduct_partial_routing))
         .def_readwrite("crossings", &fiction::color_routing_params::crossings,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/design_sidb_gates.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/design_sidb_gates.cpp
@@ -33,14 +33,16 @@ void design_sidb_gates(pybind11::module& m)
     namespace py = pybind11;
 
     py::class_<fiction::design_sidb_gates_stats>(m, "design_sidb_gates_stats", DOC(fiction_design_sidb_gates_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::design_sidb_gates_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             });
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::design_sidb_gates_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.");
 
     /**
      * Design approach selector type.
@@ -76,7 +78,7 @@ void design_sidb_gates(pybind11::module& m)
      */
     py::class_<fiction::design_sidb_gates_params<fiction::offset::ucoord_t>>(m, "design_sidb_gates_params",
                                                                              DOC(fiction_design_sidb_gates_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("operational_params",
                        &fiction::design_sidb_gates_params<fiction::offset::ucoord_t>::operational_params,
                        DOC(fiction_design_sidb_gates_params_operational_params))

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/exact.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/exact.cpp
@@ -25,7 +25,7 @@ void exact(pybind11::module& m)
                DOC(fiction_technology_constraints_TOPOLINANO));
 
     py::class_<fiction::exact_physical_design_params>(m, "exact_params", DOC(fiction_exact_physical_design_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("scheme", &fiction::exact_physical_design_params::scheme,
                        DOC(fiction_exact_physical_design_params_scheme))
         .def_readwrite("upper_bound_x", &fiction::exact_physical_design_params::upper_bound_x,
@@ -54,14 +54,16 @@ void exact(pybind11::module& m)
                        DOC(fiction_exact_physical_design_params_technology_specifics));
 
     py::class_<fiction::exact_physical_design_stats>(m, "exact_stats", DOC(fiction_exact_physical_design_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::exact_physical_design_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::exact_physical_design_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def("report", &fiction::exact_physical_design_stats::report, DOC(fiction_exact_physical_design_stats_report))
         .def_readonly("time_total", &fiction::exact_physical_design_stats::time_total,
                       DOC(fiction_exact_physical_design_stats_duration))

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/graph_oriented_layout_design.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/graph_oriented_layout_design.cpp
@@ -42,7 +42,7 @@ void graph_oriented_layout_design(pybind11::module& m)
 
     py::class_<fiction::graph_oriented_layout_design_params>(m, "graph_oriented_layout_design_params",
                                                              DOC(fiction_graph_oriented_layout_design_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("timeout", &fiction::graph_oriented_layout_design_params::timeout,
                        DOC(fiction_graph_oriented_layout_design_params_timeout))
         .def_readwrite("num_vertex_expansions", &fiction::graph_oriented_layout_design_params::num_vertex_expansions,
@@ -72,14 +72,16 @@ void graph_oriented_layout_design(pybind11::module& m)
 
     py::class_<fiction::graph_oriented_layout_design_stats>(m, "graph_oriented_layout_design_stats",
                                                             DOC(fiction_graph_oriented_layout_design_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::graph_oriented_layout_design_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::graph_oriented_layout_design_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def_readonly("time_total", &fiction::graph_oriented_layout_design_stats::time_total,
                       DOC(fiction_graph_oriented_layout_design_stats_duration))
         .def_readonly("x_size", &fiction::graph_oriented_layout_design_stats::x_size,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/hexagonalization.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/hexagonalization.cpp
@@ -31,21 +31,23 @@ void hexagonalization(pybind11::module& m)
                DOC(fiction_hexagonalization_params_io_pin_extension_mode_EXTEND_PLANAR));
 
     py::class_<fiction::hexagonalization_params>(m, "hexagonalization_params", DOC(fiction_hexagonalization_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("input_pin_extension", &fiction::hexagonalization_params::input_pin_extension,
                        DOC(fiction_hexagonalization_params_input_pin_extension))
         .def_readwrite("output_pin_extension", &fiction::hexagonalization_params::output_pin_extension,
                        DOC(fiction_hexagonalization_params_output_pin_extension));
 
     py::class_<fiction::hexagonalization_stats>(m, "hexagonalization_stats", DOC(fiction_hexagonalization_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::hexagonalization_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::hexagonalization_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def_readonly("time_total", &fiction::hexagonalization_stats::time_total,
                       DOC(fiction_hexagonalization_stats_duration))
         .def_readonly("x_size", &fiction::hexagonalization_stats::x_size, DOC(fiction_hexagonalization_stats_x_size))

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/orthogonal.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/orthogonal.cpp
@@ -17,18 +17,20 @@ void orthogonal(pybind11::module& m)
 
     py::class_<fiction::orthogonal_physical_design_params>(m, "orthogonal_params",
                                                            DOC(fiction_orthogonal_physical_design_params))
-        .def(py::init<>());
+        .def(py::init<>(), "Default constructor.");
 
     py::class_<fiction::orthogonal_physical_design_stats>(m, "orthogonal_stats",
                                                           DOC(fiction_orthogonal_physical_design_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::orthogonal_physical_design_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::orthogonal_physical_design_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def("report", &fiction::orthogonal_physical_design_stats::report,
              DOC(fiction_orthogonal_physical_design_stats_report))
         .def_readonly("time_total", &fiction::orthogonal_physical_design_stats::time_total,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/post_layout_optimization.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/post_layout_optimization.cpp
@@ -20,7 +20,7 @@ void post_layout_optimization(pybind11::module& m)
 
     py::class_<fiction::post_layout_optimization_params>(m, "post_layout_optimization_params",
                                                          DOC(fiction_post_layout_optimization_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_property(
             "max_gate_relocations",
             [](const fiction::post_layout_optimization_params& p) -> py::object
@@ -52,14 +52,16 @@ void post_layout_optimization(pybind11::module& m)
 
     py::class_<fiction::post_layout_optimization_stats>(m, "post_layout_optimization_stats",
                                                         DOC(fiction_post_layout_optimization_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::post_layout_optimization_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::post_layout_optimization_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def("report", &fiction::post_layout_optimization_stats::report,
              DOC(fiction_post_layout_optimization_stats_report))
         .def_readonly("time_total", &fiction::post_layout_optimization_stats::time_total,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/wiring_reduction.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/physical_design/wiring_reduction.cpp
@@ -16,19 +16,21 @@ void wiring_reduction(pybind11::module& m)
     namespace py = pybind11;
 
     py::class_<fiction::wiring_reduction_params>(m, "wiring_reduction_params", DOC(fiction_wiring_reduction_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("timeout", &fiction::wiring_reduction_params::timeout,
                        DOC(fiction_wiring_reduction_params_timeout));
 
     py::class_<fiction::wiring_reduction_stats>(m, "wiring_reduction_stats", DOC(fiction_wiring_reduction_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::wiring_reduction_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::wiring_reduction_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def("report", &fiction::wiring_reduction_stats::report, DOC(fiction_wiring_reduction_stats_report))
         .def_readonly("time_total", &fiction::wiring_reduction_stats::time_total,
                       DOC(fiction_wiring_reduction_stats_duration))

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/clustercomplete.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/clustercomplete.cpp
@@ -43,7 +43,7 @@ void clustercomplete(pybind11::module& m)
      * ClusterComplete parameters.
      */
     py::class_<fiction::clustercomplete_params<>>(m, "clustercomplete_params", DOC(fiction_clustercomplete_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("simulation_parameters", &fiction::clustercomplete_params<>::simulation_parameters,
                        DOC(fiction_clustercomplete_params_simulation_parameters))
         .def_readwrite("local_external_potential", &fiction::clustercomplete_params<>::local_external_potential,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/critical_temperature.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/critical_temperature.cpp
@@ -39,14 +39,16 @@ void critical_temperature(pybind11::module& m)
      */
     py::class_<fiction::critical_temperature_stats>(m, "critical_temperature_stats",
                                                     DOC(fiction_critical_temperature_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::critical_temperature_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::critical_temperature_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def("report", &fiction::critical_temperature_stats::report, DOC(fiction_critical_temperature_stats_report))
         .def_readonly("algorithm_name", &fiction::critical_temperature_stats::algorithm_name,
                       DOC(fiction_critical_temperature_stats_algorithm_name))
@@ -63,7 +65,7 @@ void critical_temperature(pybind11::module& m)
      */
     py::class_<fiction::critical_temperature_params>(m, "critical_temperature_params",
                                                      DOC(fiction_critical_temperature_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("operational_params", &fiction::critical_temperature_params::operational_params,
                        DOC(fiction_critical_temperature_params))
         .def_readwrite("confidence_level", &fiction::critical_temperature_params::confidence_level,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/detect_bdl_pairs.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/detect_bdl_pairs.cpp
@@ -41,7 +41,7 @@ void detect_bdl_pairs(pybind11::module& m)
         .def_readonly("lower", &fiction::bdl_pair<fiction::offset::ucoord_t>::lower, DOC(fiction_bdl_pair_lower));
 
     py::class_<fiction::detect_bdl_pairs_params>(m, "detect_bdl_pairs_params", DOC(fiction_detect_bdl_pairs_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("minimum_distance", &fiction::detect_bdl_pairs_params::minimum_distance,
                        DOC(fiction_detect_bdl_pairs_params_minimum_distance))
         .def_readwrite("maximum_distance", &fiction::detect_bdl_pairs_params::maximum_distance,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/displacement_robustness_domain.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/displacement_robustness_domain.cpp
@@ -22,7 +22,7 @@ void determine_displacement_robustness_domain_impl(pybind11::module& m, const st
 
     py::class_<fiction::displacement_robustness_domain<Lyt>>(
         m, fmt::format("displacement_robustness_domain_{}", lattice).c_str())
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("influence_information", &fiction::displacement_robustness_domain<Lyt>::operational_values);
 
     m.def(fmt::format("determine_displacement_robustness_domain_{}", lattice).c_str(),
@@ -53,7 +53,7 @@ void determine_displacement_robustness_domain(pybind11::module& m)
 
     py::class_<fiction::displacement_robustness_domain_params<fiction::offset::ucoord_t>>(
         m, "displacement_robustness_domain_params")
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("analysis_mode",
                        &fiction::displacement_robustness_domain_params<fiction::offset::ucoord_t>::analysis_mode)
         .def_readwrite("percentage_of_analyzed_displaced_layouts",
@@ -70,7 +70,7 @@ void determine_displacement_robustness_domain(pybind11::module& m)
                        &fiction::displacement_robustness_domain_params<fiction::offset::ucoord_t>::dimer_policy);
 
     py::class_<fiction::displacement_robustness_domain_stats>(m, "displacement_robustness_domain_stats")
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("time_total", &fiction::displacement_robustness_domain_stats::time_total)
         .def_readwrite("num_operational_sidb_displacements",
                        &fiction::displacement_robustness_domain_stats::num_operational_sidb_displacements)

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/energy_distribution.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/energy_distribution.cpp
@@ -37,7 +37,7 @@ void energy_distribution(pybind11::module& m)
         .def_readwrite("degeneracy", &fiction::energy_state::degeneracy, DOC(fiction_energy_state_degeneracy));
 
     py::class_<fiction::energy_distribution>(m, "energy_distribution")
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def("get_nth_state", &fiction::energy_distribution::get_nth_state, py::arg("state_index"),
              DOC(fiction_energy_distribution_get_nth_state))
         .def("degeneracy", &fiction::energy_distribution::degeneracy, py::arg("energy"),

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/is_operational.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/is_operational.cpp
@@ -105,7 +105,7 @@ void is_operational(pybind11::module& m)
                DOC(fiction_is_operational_params_operational_analysis_strategy_FILTER_THEN_SIMULATION));
 
     py::class_<fiction::is_operational_params>(m, "is_operational_params", DOC(fiction_is_operational_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("simulation_parameters", &fiction::is_operational_params::simulation_parameters,
                        DOC(fiction_is_operational_params_simulation_parameters))
         .def_readwrite("sim_engine", &fiction::is_operational_params::sim_engine,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/operational_domain.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/operational_domain.cpp
@@ -82,11 +82,15 @@ void operational_domain(pybind11::module& m)
         .def(py::self != py::self, py::arg("other"), DOC(fiction_parameter_point_operator_ne))
         // NOLINTEND(misc-redundant-expression)
 
-        .def("__hash__",
-             [](const fiction::parameter_point& self) { return std::hash<fiction::parameter_point>{}(self); })
-        .def("__str__", [](const fiction::parameter_point& self) { return fmt::format("{}", self.get_parameters()); })
-        .def("__getitem__",
-             [](const fiction::parameter_point& self, const std::size_t index) { return self.get_parameters()[index]; })
+        .def(
+            "__hash__", [](const fiction::parameter_point& self)
+            { return std::hash<fiction::parameter_point>{}(self); }, "Returns a hash value of the parameter point.")
+        .def(
+            "__str__", [](const fiction::parameter_point& self) { return fmt::format("{}", self.get_parameters()); },
+            "Returns a string representation of the parameter point.")
+        .def(
+            "__getitem__", [](const fiction::parameter_point& self, const std::size_t index)
+            { return self.get_parameters()[index]; }, "Returns the value of the parameter at the given index.")
 
         ;
 
@@ -99,8 +103,9 @@ void operational_domain(pybind11::module& m)
 
     py::class_<fiction::critical_temperature_domain>(m, "critical_temperature_domain",
                                                      DOC(fiction_critical_temperature_domain))
-        .def(py::init<>())
-        .def(py::init<const std::vector<fiction::sweep_parameter>>(), py::arg("dims"))
+        .def(py::init<>(), "Default constructor.")
+        .def(py::init<const std::vector<fiction::sweep_parameter>>(), py::arg("dims"),
+             "Constructs a critical temperature domain with the given sweep dimensions.")
         .def("get_dimension", &fiction::critical_temperature_domain::get_dimension, py::arg("index"),
              DOC(fiction_critical_temperature_domain_get_dimension))
         .def("get_number_of_dimensions", &fiction::critical_temperature_domain::get_number_of_dimensions,
@@ -111,32 +116,42 @@ void operational_domain(pybind11::module& m)
              DOC(fiction_critical_temperature_domain_maximum_ct))
 
         // Pythonic interface functions
-        .def("__getitem__",
-             [](const fiction::critical_temperature_domain& self, const fiction::parameter_point& key)
-             {
-                 const auto val = self.contains(key);
-                 if (!val.has_value())
-                 {
-                     throw py::key_error("Key not found");
-                 }
-                 return val.value();
-             })
-        .def("__setitem__",
-             [](fiction::critical_temperature_domain& self, const fiction::parameter_point& key,
-                const std::tuple<fiction::operational_status, double>& value) { self.add_value(key, value); })
-        .def("__contains__", [](const fiction::critical_temperature_domain& self, const fiction::parameter_point& key)
-             { return self.contains(key).has_value(); })
-        .def("__len__", [](const fiction::critical_temperature_domain& self) { return self.size(); })
-        .def("__iter__",
-             [](const fiction::critical_temperature_domain& self)
-             {
-                 std::vector<fiction::parameter_point> keys{};
-                 keys.reserve(self.size());
-                 self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
+        .def(
+            "__getitem__",
+            [](const fiction::critical_temperature_domain& self, const fiction::parameter_point& key)
+            {
+                const auto val = self.contains(key);
+                if (!val.has_value())
+                {
+                    throw py::key_error("Key not found");
+                }
+                return val.value();
+            },
+            "Returns the value stored for the given parameter point, raising a KeyError if it does not exist.")
+        .def(
+            "__setitem__",
+            [](fiction::critical_temperature_domain& self, const fiction::parameter_point& key,
+               const std::tuple<fiction::operational_status, double>& value) { self.add_value(key, value); },
+            "Sets the value stored for the given parameter point.")
+        .def(
+            "__contains__", [](const fiction::critical_temperature_domain& self, const fiction::parameter_point& key)
+            { return self.contains(key).has_value(); },
+            "Checks whether the given parameter point is contained in the domain.")
+        .def(
+            "__len__", [](const fiction::critical_temperature_domain& self) { return self.size(); },
+            "Returns the number of parameter points stored in the domain.")
+        .def(
+            "__iter__",
+            [](const fiction::critical_temperature_domain& self)
+            {
+                std::vector<fiction::parameter_point> keys{};
+                keys.reserve(self.size());
+                self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
 
-                 const py::list py_keys = py::cast(keys);
-                 return py::iter(py_keys);
-             })
+                const py::list py_keys = py::cast(keys);
+                return py::iter(py_keys);
+            },
+            "Returns an iterator over the parameter points stored in the domain.")
         .def("keys",
              [](const fiction::critical_temperature_domain& self)
              {
@@ -177,32 +192,44 @@ void operational_domain(pybind11::module& m)
              DOC(fiction_operational_domain_get_number_of_dimensions))
 
         // Pythonic interface functions
-        .def("__getitem__",
-             [](const fiction::operational_domain& self, const fiction::parameter_point& key)
-             {
-                 const auto val = self.contains(key);
-                 if (!val.has_value())
-                 {
-                     throw py::key_error("Key not found");
-                 }
+        .def(
+            "__getitem__",
+            [](const fiction::operational_domain& self, const fiction::parameter_point& key)
+            {
+                const auto val = self.contains(key);
+                if (!val.has_value())
+                {
+                    throw py::key_error("Key not found");
+                }
 
-                 return std::get<0>(val.value());
-             })
-        .def("__setitem__", [](fiction::operational_domain& self, const fiction::parameter_point& key,
-                               const fiction::operational_status& value) { self.add_value(key, {value}); })
-        .def("__contains__", [](const fiction::operational_domain& self, const fiction::parameter_point& key)
-             { return self.contains(key).has_value(); })
-        .def("__len__", [](const fiction::operational_domain& self) { return self.size(); })
-        .def("__iter__",
-             [](const fiction::operational_domain& self)
-             {
-                 std::vector<fiction::parameter_point> keys{};
-                 keys.reserve(self.size());
-                 self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
+                return std::get<0>(val.value());
+            },
+            "Returns the operational status stored for the given parameter point, raising a KeyError if it does "
+            "not exist.")
+        .def(
+            "__setitem__",
+            [](fiction::operational_domain& self, const fiction::parameter_point& key,
+               const fiction::operational_status& value) { self.add_value(key, {value}); },
+            "Sets the operational status stored for the given parameter point.")
+        .def(
+            "__contains__", [](const fiction::operational_domain& self, const fiction::parameter_point& key)
+            { return self.contains(key).has_value(); },
+            "Checks whether the given parameter point is contained in the domain.")
+        .def(
+            "__len__", [](const fiction::operational_domain& self) { return self.size(); },
+            "Returns the number of parameter points stored in the domain.")
+        .def(
+            "__iter__",
+            [](const fiction::operational_domain& self)
+            {
+                std::vector<fiction::parameter_point> keys{};
+                keys.reserve(self.size());
+                self.for_each([&keys](const auto& key, const auto&) { keys.push_back(key); });
 
-                 const py::list py_keys = py::cast(keys);
-                 return py::iter(py_keys);
-             })
+                const py::list py_keys = py::cast(keys);
+                return py::iter(py_keys);
+            },
+            "Returns an iterator over the parameter points stored in the domain.")
         .def("keys",
              [](const fiction::operational_domain& self)
              {
@@ -249,14 +276,14 @@ void operational_domain(pybind11::module& m)
 
     py::class_<fiction::operational_domain_params>(m, "operational_domain_params",
                                                    DOC(fiction_operational_domain_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("operational_params", &fiction::operational_domain_params::operational_params,
                        DOC(fiction_operational_domain_params_operational_params))
         .def_readwrite("sweep_dimensions", &fiction::operational_domain_params::sweep_dimensions,
                        DOC(fiction_operational_domain_params_sweep_dimensions));
 
     py::class_<fiction::operational_domain_stats>(m, "operational_domain_stats", DOC(fiction_operational_domain_stats))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readonly("time_total", &fiction::operational_domain_stats::time_total,
                       DOC(fiction_operational_domain_stats_duration))
         .def_readonly("num_simulator_invocations", &fiction::operational_domain_stats::num_simulator_invocations,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/operational_domain_ratio.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/operational_domain_ratio.cpp
@@ -31,7 +31,7 @@ void compute_operational_ratio(pybind11::module& m)
 
     py::class_<fiction::operational_domain_ratio_params>(m, "operational_domain_ratio_params",
                                                          DOC(fiction_operational_domain_ratio_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("op_domain_params", &fiction::operational_domain_ratio_params::op_domain_params,
                        DOC(fiction_operational_domain_ratio_params_op_domain_params));
 

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/physical_population_stability.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/physical_population_stability.cpp
@@ -22,7 +22,7 @@ void physical_population_stability_impl(pybind11::module& m, const std::string& 
     py::class_<fiction::population_stability_information<Lyt>>(
         m, fmt::format("population_stability_information_{}", lattice).c_str(),
         DOC(fiction_population_stability_information))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("critical_cell", &fiction::population_stability_information<Lyt>::critical_cell,
                        DOC(fiction_population_stability_information_critical_cell))
         .def_readwrite("transition_potentials", &fiction::population_stability_information<Lyt>::transition_potentials,
@@ -60,7 +60,7 @@ void physical_population_stability(pybind11::module& m)
      */
     py::class_<fiction::physical_population_stability_params>(m, "physical_population_stability_params",
                                                               DOC(fiction_physical_population_stability_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("simulation_parameters", &fiction::physical_population_stability_params::simulation_parameters,
                        DOC(fiction_physical_population_stability_params))
         .def_readwrite(

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/physically_valid_parameters.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/physically_valid_parameters.cpp
@@ -33,7 +33,7 @@ void physically_valid_parameters(pybind11::module& m)
 
     py::class_<fiction::sidb_simulation_domain<fiction::parameter_point, uint64_t>>(
         m, "physically_valid_parameters_domain")
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def(
             "get_excited_state_number_for_parameter",
             [](const fiction::sidb_simulation_domain<fiction::parameter_point, uint64_t>& domain,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/quickexact.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/quickexact.cpp
@@ -38,7 +38,7 @@ void quickexact(pybind11::module& m)
      * QuickExact parameters.
      */
     py::class_<fiction::quickexact_params<>>(m, "quickexact_params", DOC(fiction_quickexact_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("simulation_parameters", &fiction::quickexact_params<>::simulation_parameters,
                        DOC(fiction_quickexact_params_simulation_parameters))
         .def_readwrite("base_number_detection", &fiction::quickexact_params<>::base_number_detection,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/quicksim.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/quicksim.cpp
@@ -31,7 +31,7 @@ void quicksim(pybind11::module& m)
      * QuickSim parameters.
      */
     py::class_<fiction::quicksim_params>(m, "quicksim_params", DOC(fiction_quicksim_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("simulation_parameters", &fiction::quicksim_params::simulation_parameters,
                        DOC(fiction_quicksim_params_simulation_parameters))
         .def_readwrite("iteration_steps", &fiction::quicksim_params::iteration_steps,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/random_sidb_layout_generator.cpp
@@ -55,7 +55,7 @@ void random_sidb_layout_generator(pybind11::module& m)
      */
     py::class_<fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>>(
         m, "generate_random_sidb_layout_params", DOC(fiction_generate_random_sidb_layout_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("coordinate_pair",
                        &fiction::generate_random_sidb_layout_params<fiction::offset::ucoord_t>::coordinate_pair,
                        DOC(fiction_generate_random_sidb_layout_params_coordinate_pair))

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/sidb_simulation_parameters.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/sidb_simulation_parameters.cpp
@@ -20,7 +20,7 @@ void sidb_simulation_parameters(pybind11::module& m)
         .def(py::init<const uint8_t, const double, const double, const double>(), py::arg("base_number") = 3,
              py::arg("mu_minus") = -0.32, py::arg("relative_permittivity") = 5.6, py::arg("screening_distance") = 5.0,
              DOC(fiction_sidb_simulation_parameters_sidb_simulation_parameters))
-        .def(py::init<>())
+        .def(py::init<>(), DOC(fiction_sidb_simulation_parameters_sidb_simulation_parameters))
         .def_readwrite("epsilon_r", &fiction::sidb_simulation_parameters::epsilon_r,
                        DOC(fiction_sidb_simulation_parameters_epsilon_r))
         .def_readwrite("lambda_tf", &fiction::sidb_simulation_parameters::lambda_tf,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/sidb_simulation_result.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/sidb_simulation_result.cpp
@@ -80,7 +80,7 @@ void sidb_simulation_result_impl(pybind11::module& m, const std::string& lattice
 
     py::class_<fiction::sidb_simulation_result<Lyt>>(m, fmt::format("sidb_simulation_result{}", lattice).c_str(),
                                                      DOC(fiction_sidb_simulation_result))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("algorithm_name", &fiction::sidb_simulation_result<Lyt>::algorithm_name,
                        DOC(fiction_sidb_simulation_result_algorithm_name))
         .def_readwrite("simulation_runtime", &fiction::sidb_simulation_result<Lyt>::simulation_runtime,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/time_to_solution.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/simulation/sidb/time_to_solution.cpp
@@ -41,7 +41,7 @@ void time_to_solution(pybind11::module& m)
      * Parameters.
      */
     py::class_<fiction::time_to_solution_params>(m, "time_to_solution_params", DOC(fiction_time_to_solution_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("engine", &fiction::time_to_solution_params::engine, DOC(fiction_time_to_solution_params_engine))
         .def_readwrite("repetitions", &fiction::time_to_solution_params::repetitions,
                        DOC(fiction_time_to_solution_params_repetitions))
@@ -51,14 +51,16 @@ void time_to_solution(pybind11::module& m)
      * Statistics.
      */
     py::class_<fiction::time_to_solution_stats>(m, "time_to_solution_stats", DOC(fiction_time_to_solution_stats))
-        .def(py::init<>())
-        .def("__repr__",
-             [](const fiction::time_to_solution_stats& stats)
-             {
-                 std::stringstream stream{};
-                 stats.report(stream);
-                 return stream.str();
-             })
+        .def(py::init<>(), "Default constructor.")
+        .def(
+            "__repr__",
+            [](const fiction::time_to_solution_stats& stats)
+            {
+                std::stringstream stream{};
+                stats.report(stream);
+                return stream.str();
+            },
+            "Returns a string representation of the statistics.")
         .def("report", &fiction::time_to_solution_stats::report, DOC(fiction_time_to_solution_stats_report))
         .def_readonly("time_to_solution", &fiction::time_to_solution_stats::time_to_solution,
                       DOC(fiction_time_to_solution_stats_time_to_solution))

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/verification/design_rule_violations.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/verification/design_rule_violations.cpp
@@ -51,7 +51,7 @@ void design_rule_violations(pybind11::module& m)
     namespace py = pybind11;  // NOLINT(misc-unused-alias-decls)
 
     py::class_<fiction::gate_level_drv_params>(m, "gate_level_drv_params", DOC(fiction_gate_level_drv_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("unplaced_nodes", &fiction::gate_level_drv_params::unplaced_nodes,
                        DOC(fiction_gate_level_drv_params_unplaced_nodes))
         .def_readwrite("placed_dead_nodes", &fiction::gate_level_drv_params::placed_dead_nodes,

--- a/bindings/mnt/pyfiction/src/pyfiction/algorithms/verification/equivalence_checking.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/algorithms/verification/equivalence_checking.cpp
@@ -53,7 +53,7 @@ void equivalence_checking(pybind11::module& m)
 
     py::class_<fiction::equivalence_checking_stats>(m, "equivalence_checking_stats",
                                                     DOC(fiction_equivalence_checking_stats))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readonly("eq", &fiction::equivalence_checking_stats::eq, DOC(fiction_equivalence_checking_stats_eq))
         .def_readonly("tp_spec", &fiction::equivalence_checking_stats::tp_spec,
                       DOC(fiction_equivalence_checking_stats_tp_spec))

--- a/bindings/mnt/pyfiction/src/pyfiction/inout/write_fqca_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/inout/write_fqca_layout.cpp
@@ -42,7 +42,7 @@ void write_fqca_layout(pybind11::module& m)
         PyExc_IndexError);  // NOLINT(misc-include-cleaner): Included through pybind11.h
 
     py::class_<fiction::write_fqca_layout_params>(m, "write_fqca_layout_params", DOC(fiction_write_fqca_layout_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("create_inter_layer_via_cells", &fiction::write_fqca_layout_params::create_inter_layer_via_cells,
                        DOC(fiction_write_fqca_layout_params_create_inter_layer_via_cells))
 

--- a/bindings/mnt/pyfiction/src/pyfiction/inout/write_operational_domain.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/inout/write_operational_domain.cpp
@@ -88,7 +88,7 @@ void write_operational_domain(pybind11::module& m)
 
     py::class_<fiction::write_operational_domain_params>(m, "write_operational_domain_params",
                                                          DOC(fiction_write_operational_domain_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("operational_tag", &fiction::write_operational_domain_params::operational_tag,
                        DOC(fiction_write_operational_domain_params_operational_tag))
         .def_readwrite("non_operational_tag", &fiction::write_operational_domain_params::non_operational_tag,

--- a/bindings/mnt/pyfiction/src/pyfiction/inout/write_qca_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/inout/write_qca_layout.cpp
@@ -19,7 +19,7 @@ void write_qca_layout(pybind11::module& m)
     namespace py = pybind11;  // NOLINT(misc-unused-alias-decls)
 
     py::class_<fiction::write_qca_layout_params>(m, "write_qca_layout_params", DOC(fiction_write_qca_layout_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("create_inter_layer_via_cells", &fiction::write_qca_layout_params::create_inter_layer_via_cells,
                        DOC(fiction_write_qca_layout_params_create_inter_layer_via_cells))
 

--- a/bindings/mnt/pyfiction/src/pyfiction/inout/write_svg_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/inout/write_svg_layout.cpp
@@ -82,7 +82,7 @@ void write_svg_layout(pybind11::module& m)
 
     py::class_<fiction::write_sidb_layout_svg_params>(m, "write_sidb_layout_svg_params",
                                                       DOC(fiction_write_sidb_layout_svg_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("lattice_point_size", &fiction::write_sidb_layout_svg_params::lattice_point_size,
                        DOC(fiction_write_sidb_layout_svg_params_lattice_point_size))
         .def_readwrite("sidb_size", &fiction::write_sidb_layout_svg_params::sidb_size,
@@ -98,7 +98,7 @@ void write_svg_layout(pybind11::module& m)
 
     py::class_<fiction::write_qca_layout_svg_params>(m, "write_qca_layout_svg_params",
                                                      DOC(fiction_write_qca_layout_svg_params))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def_readwrite("simple", &fiction::write_qca_layout_svg_params::simple,
                        DOC(fiction_write_qca_layout_svg_params_simple));
     ;

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/cartesian_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/cartesian_layout.cpp
@@ -27,7 +27,7 @@ void cartesian_layout(pybind11::module& m)
      * Cartesian layout.
      */
     py::class_<py_cartesian_layout>(m, "cartesian_layout", DOC(fiction_cartesian_layout_overridden))
-        .def(py::init<>())
+        .def(py::init<>(), DOC(fiction_cartesian_layout_cartesian_layout))
         .def(py::init<const fiction::aspect_ratio<py_cartesian_layout>&>(), py::arg("dimension"),
              DOC(fiction_cartesian_layout_cartesian_layout))
         .def(
@@ -129,13 +129,15 @@ void cartesian_layout(pybind11::module& m)
         .def("adjacent_opposite_coordinates", &py_cartesian_layout::adjacent_opposite_coordinates, py::arg("c"),
              DOC(fiction_cartesian_layout_adjacent_opposite_coordinates))
 
-        .def("__repr__",
-             [](const py_cartesian_layout& lyt) -> std::string
-             {
-                 std::stringstream stream{};
-                 print_layout(lyt, stream);
-                 return stream.str();
-             })
+        .def(
+            "__repr__",
+            [](const py_cartesian_layout& lyt) -> std::string
+            {
+                std::stringstream stream{};
+                print_layout(lyt, stream);
+                return stream.str();
+            },
+            "Returns a string representation of the layout.")
 
         ;
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/cell_level_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/cell_level_layout.cpp
@@ -88,7 +88,7 @@ void fcn_technology_cell_level_layout(pybind11::module& m)
         py_cartesian_technology_cell_layout,
         fiction::clocked_layout<fiction::tile_based_layout<fiction::cartesian_layout<fiction::offset::ucoord_t>>>>(
         m, fmt::format("{}_layout", tech_name).c_str(), DOC(fiction_cell_level_layout))
-        .def(py::init<>())
+        .def(py::init<>(), DOC(fiction_cell_level_layout_cell_level_layout))
         .def(py::init<const fiction::aspect_ratio<py_cartesian_technology_cell_layout>&>(), py::arg("dimension"),
              DOC(fiction_cell_level_layout_cell_level_layout))
         .def(py::init(
@@ -169,22 +169,24 @@ void fcn_technology_cell_level_layout(pybind11::module& m)
             },
             DOC(fiction_bounding_box_2d_overridden))
 
-        .def("__repr__",
-             [](const py_cartesian_technology_cell_layout& lyt) -> std::string
-             {
-                 std::stringstream stream{};
+        .def(
+            "__repr__",
+            [](const py_cartesian_technology_cell_layout& lyt) -> std::string
+            {
+                std::stringstream stream{};
 
-                 if constexpr (std::is_same_v<Technology, fiction::sidb_technology>)
-                 {
-                     print_layout(convert_layout_to_siqad_coordinates(lyt), stream);
-                 }
-                 else
-                 {
-                     print_layout(lyt, stream);
-                 }
+                if constexpr (std::is_same_v<Technology, fiction::sidb_technology>)
+                {
+                    print_layout(convert_layout_to_siqad_coordinates(lyt), stream);
+                }
+                else
+                {
+                    print_layout(lyt, stream);
+                }
 
-                 return stream.str();
-             })
+                return stream.str();
+            },
+            "Returns a string representation of the layout.")
 
         ;
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/clocked_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/clocked_layout.cpp
@@ -32,7 +32,7 @@ void clocked_layout(pybind11::module& m, const std::string& topology)
      * Clocked Cartesian layout.
      */
     py::class_<ClockedLyt, LytBase>(m, fmt::format("clocked_{}_layout", topology).c_str(), DOC(fiction_clocked_layout))
-        .def(py::init<>())
+        .def(py::init<>(), DOC(fiction_clocked_layout_clocked_layout))
         .def(py::init<const fiction::aspect_ratio<ClockedLyt>&>(), py::arg("dimension"),
              DOC(fiction_clocked_layout_clocked_layout))
         .def(py::init(
@@ -72,13 +72,15 @@ void clocked_layout(pybind11::module& m, const std::string& topology)
         .def("out_degree", &ClockedLyt::out_degree, py::arg("cz"), DOC(fiction_clocked_layout_out_degree))
         .def("degree", &ClockedLyt::degree, py::arg("cz"), DOC(fiction_clocked_layout_degree))
 
-        .def("__repr__",
-             [](const ClockedLyt& lyt) -> std::string
-             {
-                 std::stringstream stream{};
-                 print_layout(lyt, stream);
-                 return stream.str();
-             })
+        .def(
+            "__repr__",
+            [](const ClockedLyt& lyt) -> std::string
+            {
+                std::stringstream stream{};
+                print_layout(lyt, stream);
+                return stream.str();
+            },
+            "Returns a string representation of the layout.")
 
         ;
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/coordinates.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/coordinates.cpp
@@ -76,7 +76,9 @@ void offset_coordinate(pybind11::module& m)
         // NOLINTEND(misc-redundant-expression)
 
         .def("__repr__", &py_offset_coordinate::str, DOC(fiction_offset_ucoord_t_str))
-        .def("__hash__", [](const py_offset_coordinate& self) { return std::hash<py_offset_coordinate>{}(self); })
+        .def(
+            "__hash__", [](const py_offset_coordinate& self) { return std::hash<py_offset_coordinate>{}(self); },
+            "Returns a hash value of the coordinate.")
 
         ;
 
@@ -134,7 +136,9 @@ void cube_coordinate(pybind11::module& m)
         // NOLINTEND(misc-redundant-expression)
 
         .def("__repr__", &py_cube_coordinate::str, DOC(fiction_cube_coord_t_str))
-        .def("__hash__", [](const py_cube_coordinate& self) { return std::hash<py_cube_coordinate>{}(self); })
+        .def(
+            "__hash__", [](const py_cube_coordinate& self) { return std::hash<py_cube_coordinate>{}(self); },
+            "Returns a hash value of the coordinate.")
 
         ;
 
@@ -195,7 +199,9 @@ void siqad_coordinate(pybind11::module& m)
         // NOLINTEND(misc-redundant-expression)
 
         .def("__repr__", &py_siqad_coordinate::str, DOC(fiction_siqad_coord_t_str))
-        .def("__hash__", [](const py_siqad_coordinate& self) { return std::hash<py_siqad_coordinate>{}(self); })
+        .def(
+            "__hash__", [](const py_siqad_coordinate& self) { return std::hash<py_siqad_coordinate>{}(self); },
+            "Returns a hash value of the coordinate.")
 
         ;
 

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/gate_level_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/gate_level_layout.cpp
@@ -32,7 +32,7 @@ void gate_level_layout(pybind11::module& m, const std::string& topology)
     namespace py = pybind11;  // NOLINT(misc-unused-alias-decls)
 
     py::class_<GateLyt, LytBase>(m, fmt::format("{}_gate_layout", topology).c_str(), DOC(fiction_gate_level_layout))
-        .def(py::init<>())
+        .def(py::init<>(), DOC(fiction_gate_level_layout_gate_level_layout))
         .def(py::init<const fiction::aspect_ratio<GateLyt>&>(), py::arg("dimension"),
              DOC(fiction_gate_level_layout_gate_level_layout))
         .def(py::init(
@@ -299,13 +299,15 @@ void gate_level_layout(pybind11::module& m, const std::string& topology)
             },
             DOC(fiction_bounding_box_2d_overridden))
         .def("is_dead", &GateLyt::is_dead, py::arg("n"), DOC(fiction_gate_level_layout_is_dead))
-        .def("__repr__",
-             [](const GateLyt& lyt) -> std::string
-             {
-                 std::stringstream stream{};
-                 fiction::print_layout(lyt, stream);
-                 return stream.str();
-             })
+        .def(
+            "__repr__",
+            [](const GateLyt& lyt) -> std::string
+            {
+                std::stringstream stream{};
+                fiction::print_layout(lyt, stream);
+                return stream.str();
+            },
+            "Returns a string representation of the layout.")
 
         ;
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/hexagonal_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/hexagonal_layout.cpp
@@ -27,7 +27,7 @@ void hexagonal_layout(pybind11::module& m)
      * Hexagonal layout.
      */
     py::class_<py_hexagonal_layout>(m, "hexagonal_layout", DOC(fiction_hexagonal_layout_overridden))
-        .def(py::init<>())
+        .def(py::init<>(), DOC(fiction_hexagonal_layout_hexagonal_layout))
         .def(py::init<const fiction::aspect_ratio<py_hexagonal_layout>&>(), py::arg("dimension"),
              DOC(fiction_hexagonal_layout_hexagonal_layout))
         .def(
@@ -129,13 +129,15 @@ void hexagonal_layout(pybind11::module& m)
         .def("adjacent_opposite_coordinates", &py_hexagonal_layout::adjacent_opposite_coordinates, py::arg("c"),
              DOC(fiction_hexagonal_layout_adjacent_opposite_coordinates))
 
-        .def("__repr__",
-             [](const py_hexagonal_layout& lyt) -> std::string
-             {
-                 std::stringstream stream{};
-                 print_layout(lyt, stream);
-                 return stream.str();
-             })
+        .def(
+            "__repr__",
+            [](const py_hexagonal_layout& lyt) -> std::string
+            {
+                std::stringstream stream{};
+                print_layout(lyt, stream);
+                return stream.str();
+            },
+            "Returns a string representation of the layout.")
 
         ;
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/obstruction_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/obstruction_layout.cpp
@@ -23,7 +23,7 @@ void obstruction_layout(pybind11::module& m, const std::string& topology)
 
     py::class_<ObstrLyt, LytBase>(m, fmt::format("{}_obstruction_layout", topology).c_str(),
                                   DOC(fiction_obstruction_layout))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def(py::init<const LytBase&>(), py::arg("layout"), DOC(fiction_obstruction_layout_obstruction_layout))
 
         .def("obstruct_coordinate", &ObstrLyt::obstruct_coordinate, py::arg("c"))

--- a/bindings/mnt/pyfiction/src/pyfiction/layouts/shifted_cartesian_layout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/layouts/shifted_cartesian_layout.cpp
@@ -31,7 +31,7 @@ void shifted_cartesian_layout(pybind11::module& m)
      */
     py::class_<py_shifted_cartesian_layout>(m, "shifted_cartesian_layout",
                                             DOC(fiction_shifted_cartesian_layout_overridden))
-        .def(py::init<>())
+        .def(py::init<>(), DOC(fiction_shifted_cartesian_layout_shifted_cartesian_layout))
         .def(py::init<const fiction::aspect_ratio<py_shifted_cartesian_layout>&>(), py::arg("dimension"),
              DOC(fiction_shifted_cartesian_layout_shifted_cartesian_layout))
         .def(
@@ -206,13 +206,15 @@ void shifted_cartesian_layout(pybind11::module& m)
             { return lyt.adjacent_opposite_coordinates(c); }, py::arg("c"),
             DOC(fiction_cartesian_layout_adjacent_opposite_coordinates))
 
-        .def("__repr__",
-             [](const py_shifted_cartesian_layout& lyt) -> std::string
-             {
-                 std::stringstream stream{};
-                 print_layout(lyt, stream);
-                 return stream.str();
-             })
+        .def(
+            "__repr__",
+            [](const py_shifted_cartesian_layout& lyt) -> std::string
+            {
+                std::stringstream stream{};
+                print_layout(lyt, stream);
+                return stream.str();
+            },
+            "Returns a string representation of the layout.")
 
         ;
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/networks/logic_networks.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/networks/logic_networks.cpp
@@ -40,7 +40,9 @@ void network(pybind11::module& m, const std::string& network_name)
      * Network node.
      */
     py::class_<mockturtle::node<Ntk>>(m, fmt::format("{}_node", network_name).c_str())
-        .def("__hash__", [](const mockturtle::node<Ntk>& n) { return std::hash<mockturtle::node<Ntk>>{}(n); })
+        .def(
+            "__hash__", [](const mockturtle::node<Ntk>& n) { return std::hash<mockturtle::node<Ntk>>{}(n); },
+            "Returns a hash value of the node.")
 
         ;
 
@@ -50,7 +52,7 @@ void network(pybind11::module& m, const std::string& network_name)
      * Network.
      */
     py::class_<Ntk>(m, network_name.c_str(), DOC(fiction_technology_network))
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
 
         .def("size", &Ntk::size)
         .def("num_gates", &Ntk::num_gates)

--- a/bindings/mnt/pyfiction/src/pyfiction/networks/truth_tables.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/networks/truth_tables.cpp
@@ -17,8 +17,8 @@ void truth_tables(pybind11::module& m)
     namespace py = pybind11;
 
     py::class_<py_tt>(m, "dynamic_truth_table")
-        .def(py::init<>())
-        .def(py::init<uint32_t>())
+        .def(py::init<>(), "Default constructor. Constructs a truth table of 0 variables.")
+        .def(py::init<uint32_t>(), py::arg("num_vars"), "Constructs a truth table of the given number of variables.")
 
         .def("num_vars", &py_tt::num_vars)
         .def("num_blocks", &py_tt::num_blocks)

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/charge_distribution_surface.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/charge_distribution_surface.cpp
@@ -195,13 +195,15 @@ void charge_distribution_surface_layout(pybind11::module& m, const std::string& 
             },
             DOC(fiction_bounding_box_2d_overridden))
 
-        .def("__repr__",
-             [](const py_cds& lyt)
-             {
-                 std::stringstream ss;
-                 print_layout(fiction::convert_layout_to_siqad_coordinates(lyt), ss);
-                 return ss.str();
-             })
+        .def(
+            "__repr__",
+            [](const py_cds& lyt)
+            {
+                std::stringstream ss;
+                print_layout(fiction::convert_layout_to_siqad_coordinates(lyt), ss);
+                return ss.str();
+            },
+            "Returns a string representation of the layout.")
 
         ;
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/sidb_lattice.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/sidb_lattice.cpp
@@ -39,7 +39,7 @@ void sidb_lattice_cell_level_layout(pybind11::module& m)
      */
     py::class_<py_sidb_lattice, py_sidb_layout>(m, fmt::format("sidb_{}_lattice", orientation).c_str(),
                                                 DOC(fiction_cell_level_layout), py::module_local())
-        .def(py::init<>())
+        .def(py::init<>(), "Default constructor.")
         .def(py::init<const fiction::aspect_ratio<py_sidb_layout>&, const std::string&>(), py::arg("dimension"),
              py::arg("name") = "", DOC(fiction_sidb_lattice))
         .def("clone", &py_sidb_lattice::clone)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -62,6 +62,11 @@ Fixed
     - Fixed broken ``:ref:`` links in the publications list
     - Added missing Python binding exports (``charge_distribution_history``,
       ``sidb_charge_states_for_base_number``) that were referenced by the documentation but not importable
+- Python bindings:
+    - Added missing docstrings for numerous ``pyfiction`` constructors (e.g., ``cartesian_gate_layout``) that
+      were previously undocumented despite an equivalent, documented constructor overload existing
+    - Added missing docstrings for several dunder/operator methods (e.g., ``bdl_input_iterator_params``,
+      ``__repr__``, ``__hash__``, ``__getitem__``) across the layout, network, and SiDB simulation bindings
 
 v0.6.12 - 2025-10-29
 --------------------


### PR DESCRIPTION
## Description

Feedback flagged that pyfiction's generated API docs are missing docstrings on some constructors (e.g. `cartesian_gate_layout`) and operators (e.g. `bdl_input_iterator`). Investigating confirmed the pattern:

- Several constructors bound via `.def(py::init<>())` had no docstring even though an equivalent, documented constructor overload existed in the same binding (e.g. `cartesian_gate_layout`'s default constructor duplicates the already-documented `aspect_ratio` overload) — these now reuse the existing `DOC(...)` symbol.
- `bdl_input_iterator`'s actual operators were already documented; the real gap was its sibling `bdl_input_iterator_params` struct, whose class-level doc existed but wasn't wired in, and whose default constructor had no doc at all.
- The same "undocumented default constructor" pattern repeats across ~45 more binding files, and several dunder/operator methods (`__repr__`, `__hash__`, `__getitem__`, `__setitem__`, `__contains__`, `__len__`, `__iter__`) were undocumented across layout, network, and SiDB simulation bindings.

**Scope/approach:** Rather than touching C++ headers (many of the affected structs are plain aggregates used with brace-initialization elsewhere in the codebase — adding an explicit default constructor there would make them non-aggregate types and break call sites), this PR only touches `.cpp` binding files:
- Where a sibling constructor overload already carries a generated `DOC(...)` symbol for the same underlying C++ constructor, that symbol is now reused on the parameterless `py::init<>()`.
- Where no such symbol exists (pure aggregate structs, or Python-only dunder methods with no C++ counterpart), a short hand-written string docstring was added directly in the `.def(...)` call.

All 49 touched translation units were compiled locally (via `cmake --preset` with `FICTION_PYTHON_BINDINGS=ON`) to confirm no build breakage; only pre-existing, unrelated warnings remain.

Fixes the documentation gap reported as: *"pyfiction: Konstruktoren fehlen in der Doku (z.B. cartesian_gate_layout), operatoren fehlen (z.B. bdl_input_iterator)"*.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzX9VU7ehi5doxzvYUp9aG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Python API documentation for constructors and common methods across layouts, networks, algorithms, and simulation tools.
  * Improved descriptions for representations, hashing, indexing, iteration, and truth-table construction.
  * Updated the unreleased changelog to record these documentation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->