### PR TITLE
🐛 Fix Renovate Sphinx version-pin blocker

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,7 +72,7 @@
       matchDepNames: [
         "sphinx"
       ],
-      matchCurrentVersion: "==8.1.3",
+      matchCurrentVersion: "8.1.3",
       enabled: false
     },
     {


### PR DESCRIPTION
## Summary
- The Renovate rule meant to block Sphinx updates for the Python-<3.11 pin used `matchCurrentVersion: "==8.1.3"`, but Renovate compares `matchCurrentVersion` against the dependency's resolved `currentVersion` when available (the bare version, e.g. `8.1.3`), falling back to `currentValue` (the full constraint) only when `currentVersion` doesn't exist. For a pinned pep440 dependency, `currentVersion` is the bare version, so `"==8.1.3"` never matched and the rule silently never applied.
- This let #1026 propose bumping `sphinx==8.1.3; python_version < '3.11'` to `8.2.3`, which drops Python <3.11 support (the exact breakage the rule's own description warns about).
- Fix: drop the `==` prefix so the matcher compares against the bare version Renovate actually uses.

## Test plan
- [x] `pre-commit` "Validate Renovate Config" hook passes on the updated `.github/renovate.json5`
- [ ] Close/re-trigger #1026 (or wait for next Renovate run) and confirm the Sphinx `<3.11` pin update is no longer proposed