### PR TITLE
:recycle: Bump the C++ language standard to C++20

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -82,6 +82,6 @@ SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: c++17
+Standard: c++20
 UseTab: Never
 LineEnding: LF

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -42,35 +42,37 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
-        compiler: [g++-11, g++-12, g++-13, clang++-14, clang++-15, clang++-16]
+        compiler: [g++-11, g++-12, g++-13, clang++-15, clang++-16]
         exclude:
           - os: ubuntu-22.04
             compiler: g++-13
           - os: ubuntu-22.04
             compiler: clang++-16
-          - os: ubuntu-24.04
-            compiler: clang++-14
           - os: ubuntu-24.04-arm
             compiler: g++-11
           - os: ubuntu-24.04-arm
             compiler: g++-12
           - os: ubuntu-24.04-arm
             compiler: g++-13
-          - os: ubuntu-24.04-arm
-            compiler: clang++-14
         include:
-          - os: ubuntu-22.04
-            compiler: g++-10
           - os: ubuntu-24.04
             compiler: g++-14
           - os: ubuntu-24.04
             compiler: clang++-17
           - os: ubuntu-24.04
             compiler: clang++-18
+          - os: ubuntu-24.04
+            compiler: clang++-19
+          - os: ubuntu-24.04
+            compiler: clang++-20
           - os: ubuntu-24.04-arm
             compiler: clang++-17
           - os: ubuntu-24.04-arm
             compiler: clang++-18
+          - os: ubuntu-24.04-arm
+            compiler: clang++-19
+          - os: ubuntu-24.04-arm
+            compiler: clang++-20
 
     name: 🐧 ${{matrix.os}} with ${{matrix.compiler}}
     runs-on: ${{matrix.os}}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
-        compiler: [g++-11, g++-12, g++-13, clang++-15, clang++-16]
+        compiler: [g++-11, g++-12, g++-13, clang++-16]
         exclude:
           - os: ubuntu-22.04
             compiler: g++-13

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md
 
-You are an expert software architect and engineer specializing in **C++17**, **Python**, and **Field-coupled Nanocomputing (FCN)** design automation. You are working on the `fiction` project.
+You are an expert software architect and engineer specializing in **C++20**, **Python**, and **Field-coupled Nanocomputing (FCN)** design automation. You are working on the `fiction` project.
 
 ## Persona
 
 - **Role**: Core developer and maintainer.
 - **Expertise**:
-  - Modern C++ (C++17 standard).
+  - Modern C++ (C++20 standard).
   - Python bindings using `pybind11`.
   - CMake build systems.
   - FCN technologies (QCA, iNML, SiDB).
@@ -23,7 +23,7 @@ You are an expert software architect and engineer specializing in **C++17**, **P
 ## Project Knowledge
 
 - **Tech Stack**:
-  - **C++**: C++17 (Strict), `clang-format`, `clang-tidy`.
+  - **C++**: C++20 (Strict), `clang-format`, `clang-tidy`.
   - **Python**: Python 3.10+, `pybind11`, `scikit-build-core`, `nox`, `pytest`.
   - **Build System**: CMake 3.23+.
   - **Documentation**: Doxygen.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ endif()
 # compiling with PCH enabled
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# With the Ninja generator, CMake >= 3.28 enables C++20 module dependency
+# scanning by default, which requires a `clang-scan-deps` binary matching the
+# compiler version. This project uses no C++20 modules, and CI images don't
+# always ship a matching `clang-scan-deps`, so disable it.
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 # Set the project name and version
 project(
   fiction

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.23...4.2)
 
 # Only set the CMAKE_CXX_STANDARD if it is not set by someone else
 if(NOT DEFINED CMAKE_CXX_STANDARD)
-  # Set C++ standard; at least C++17 is required
-  set(CMAKE_CXX_STANDARD 17)
+  # Set C++ standard; at least C++20 is required
+  set(CMAKE_CXX_STANDARD 20)
 endif()
 
 # strongly encouraged to enable this globally to avoid conflicts between

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   </picture>
 </p>
 
-This code base provides a C++17 framework for **fi**eld-**c**oupled **t**echnology-**i**ndependent **o**pen
+This code base provides a C++20 framework for **fi**eld-**c**oupled **t**echnology-**i**ndependent **o**pen
 **n**anocomputing developed as part of the _Munich Nanotech Toolkit_ (_MNT_) by the
 [Chair for Design Automation](https://www.cda.cit.tum.de/) at the [Technical University of Munich](https://www.tum.de/).
 Within _fiction_, algorithms for logic synthesis, placement, routing, clocking, verification, and simulation for

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -7571,6 +7571,19 @@ R"doc(Checks if all PI/POs are located at the layout's borders.
 Returns:
     Check summary as a one liner.)doc";
 
+static const char *__doc_fiction_detail_gate_level_drvs_impl_check_icon =
+R"doc(Returns the check icon corresponding to a check's outcome.
+
+Parameter ``chk``:
+    Result of the check.
+
+Parameter ``brk``:
+    Flag to indicate that a failure is design breaking. If it's not, a
+    warning icon is returned.
+
+Returns:
+    Escape color sequence for the given outcome.)doc";
+
 static const char *__doc_fiction_detail_gate_level_drvs_impl_clocked_data_flow_check =
 R"doc(Checks for proper clocking of connected tiles based on their assigned
 nodes.

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -18486,7 +18486,7 @@ static const char *__doc_fiction_port_direction =
 R"doc(A port direction is a relative (cardinal) direction of a port within a
 tile. Useful, when no exact port locations within a tile are needed.)doc";
 
-static const char *__doc_fiction_port_direction_cardinal = R"doc(Cardinal direction.)doc";
+static const char *__doc_fiction_port_direction_cardinal = R"doc()doc";
 
 static const char *__doc_fiction_port_direction_cardinal_EAST = R"doc(East direction.)doc";
 
@@ -23710,7 +23710,7 @@ static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinat
 
 static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1106_8 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_include_fiction_technology_cell_ports_hpp_291_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_technology_cell_ports_hpp_295_8 = R"doc()doc";
 
 static const char *__doc_mockturtle_detail_foreach_element_if_transform = R"doc()doc";
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -56,7 +56,11 @@ set(ALICE_TEST
 FetchContent_Declare(
   alice
   GIT_REPOSITORY https://github.com/marcelwa/alice.git
-  GIT_TAG master # Using master as per submodule
+  GIT_TAG
+    6b7f941ca44f38226f5e2545224fa1194940cd73 # master, pinned: includes the
+                                             # std::result_of->invoke_result_t
+  # fix required for C++20; floating on `master` hit stale GitHub info/refs
+  # caching in CI and fetched an older commit
 )
 FetchContent_MakeAvailable(alice)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -56,9 +56,7 @@ set(ALICE_TEST
 FetchContent_Declare(
   alice
   GIT_REPOSITORY https://github.com/marcelwa/alice.git
-  GIT_TAG 6b7f941ca44f38226f5e2545224fa1194940cd73 # Head of the master branch,
-                                                   # includes the C++20
-  # std::result_of fix
+  GIT_TAG 6b7f941ca44f38226f5e2545224fa1194940cd73 # Head of the master branch
 )
 FetchContent_MakeAvailable(alice)
 

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -2,7 +2,7 @@ What is this about?
 ===================
 
 This code base provides a framework for **fi**\ eld-**c**\ oupled **t**\ echnology-**i**\ ndependent **o**\ pen **n**\ anocomputing
-in C++17 using the `EPFL Logic Synthesis Libraries <https://github.com/lsils/lstools-showcase>`_. Thereby, *fiction* focuses on the
+in C++20 using the `EPFL Logic Synthesis Libraries <https://github.com/lsils/lstools-showcase>`_. Thereby, *fiction* focuses on the
 logic synthesis, placement, routing, clocking, and verification of emerging nanotechnologies. As a promising class of post-CMOS technologies,
 `Field-coupled Nanocomputing (FCN) <https://www.springer.com/de/book/9783662437216>`_ devices like Quantum-dot Cellular
 Automata (QCA) in manifold forms (e.g. atomic or molecular), Nanomagnet Logic (NML) devices, Silicon Dangling Bonds (SiDBs),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_.
 
+Unreleased
+----------
+
+Changed
+#######
+- Build system:
+    - Bumped the required C++ standard from C++17 to C++20
+- Continuous integration:
+    - Updated the Ubuntu CI compiler matrix for C++20: dropped ``g++-10``, ``clang++-14``, and
+      ``clang++-15`` (Clang <16 has a known constraint-instantiation bug that breaks libstdc++'s
+      ``<ranges>`` implementation for non-trivial cases), and added ``clang++-19`` and ``clang++-20``
+
+Fixed
+#####
+- Code quality:
+    - Fixed several pre-existing ``fmt`` compile-time format-string misuses (passing a runtime string
+      as the format-string argument with no substitution args) that were surfaced by the C++20 bump
+      enabling ``fmt``'s ``consteval`` format-string checks
+
 v0.7.0 - 2026-07-31
 -------------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,7 +1,7 @@
 Getting started
 ===============
 
-The *fiction* framework provides a stand-alone CLI tool as well as a C++17 header-only library and a Python module which
+The *fiction* framework provides a stand-alone CLI tool as well as a C++20 header-only library and a Python module which
 can be used in external projects. Additionally, we provide an experimentation playground that can be used to quickly
 prototype new ideas or script evaluations.
 
@@ -82,7 +82,7 @@ them automatically. Should the repository have been cloned before, the commands:
 
   git submodule update --init --recursive
 
-will fetch the latest version of all external modules used. Additionally, only ``CMake`` and a C++17 compiler are
+will fetch the latest version of all external modules used. Additionally, only ``CMake`` and a C++20 compiler are
 required for the C++ part. If you want to work with the Python bindings, you need a Python 3.9+ installation.
 
 At the time of writing, for parallel STL algorithms to work when using GCC, the TBB library (``libtbb-dev`` on Ubuntu) is

--- a/include/fiction/algorithms/verification/design_rule_violations.hpp
+++ b/include/fiction/algorithms/verification/design_rule_violations.hpp
@@ -183,9 +183,11 @@ class gate_level_drvs_impl
 
         *ps.out << fmt::format(
                        "\n[i] DRVs: {}, Warnings: {}",
-                       (pst.drvs != 0u ? fmt::format(fmt::fg(fmt::color::red), std::to_string(pst.drvs)) : ZERO_ISSUES),
-                       (pst.warnings != 0u ? fmt::format(fmt::fg(fmt::color::yellow), std::to_string(pst.warnings)) :
-                                             ZERO_ISSUES))
+                       (pst.drvs != 0u ? fmt::format(fmt::fg(fmt::color::red), fmt::runtime(std::to_string(pst.drvs))) :
+                                         ZERO_ISSUES),
+                       (pst.warnings != 0u ?
+                            fmt::format(fmt::fg(fmt::color::yellow), fmt::runtime(std::to_string(pst.warnings))) :
+                            ZERO_ISSUES))
                 << std::endl;
 
         pst.report["DRVs"]     = pst.drvs;

--- a/include/fiction/algorithms/verification/design_rule_violations.hpp
+++ b/include/fiction/algorithms/verification/design_rule_violations.hpp
@@ -13,10 +13,14 @@
 #include <mockturtle/traits.hpp>
 #include <nlohmann/json.hpp>
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
 #include <ostream>
 #include <sstream>
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace fiction
 {
@@ -188,7 +192,7 @@ class gate_level_drvs_impl
                        (pst.warnings != 0u ?
                             fmt::format(fmt::fg(fmt::color::yellow), fmt::runtime(std::to_string(pst.warnings))) :
                             ZERO_ISSUES))
-                << std::endl;
+                << "\n";
 
         pst.report["DRVs"]     = pst.drvs;
         pst.report["Warnings"] = pst.warnings;
@@ -272,6 +276,26 @@ class gate_level_drvs_impl
         report[n] = lyt.node_to_index(n);
     }
     /**
+     * Returns the check icon corresponding to a check's outcome.
+     *
+     * @param chk Result of the check.
+     * @param brk Flag to indicate that a failure is design breaking. If it's not, a warning icon is returned.
+     * @return Escape color sequence for the given outcome.
+     */
+    static const std::string& check_icon(const bool chk, const bool brk) noexcept
+    {
+        if (chk)
+        {
+            return CHECK_PASSED;
+        }
+        if (brk)
+        {
+            return CHECK_FAILED;
+        }
+
+        return WARNING;
+    }
+    /**
      * Generates a summarizing one liner for a design rule check.
      *
      * @param msg Message to output in success case. For failure, a "not" will be added as a prefix.
@@ -281,8 +305,7 @@ class gate_level_drvs_impl
      */
     std::string summary(std::string&& msg, const bool chk, const bool brk) const noexcept
     {
-        return fmt::format(" [{}] {}{}", chk ? CHECK_PASSED : (brk ? CHECK_FAILED : WARNING), chk ? "" : "not ",
-                           std::move(msg));
+        return fmt::format(" [{}] {}{}", check_icon(chk, brk), chk ? "" : "not ", std::move(msg));
     }
     /**
      * Checks for nodes that are not placed but still alive.

--- a/include/fiction/io/print_layout.hpp
+++ b/include/fiction/io/print_layout.hpp
@@ -12,15 +12,12 @@
 #include "fiction/technology/sidb_lattice.hpp"
 #include "fiction/technology/sidb_lattice_orientations.hpp"
 #include "fiction/traits.hpp"
-#include "fiction/types.hpp"
 #include "fiction/utils/layout_utils.hpp"
 
 #include <fmt/color.h>
 #include <fmt/format.h>
 
-#include <algorithm>
 #include <array>
-#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -80,18 +77,18 @@ void print_gate_level_layout(std::ostream& os, const Lyt& layout, const bool io_
     // empty layout
     if (layout.num_gates() == 0ul && layout.num_wires() == 0ul)
     {
-        os << "[i] empty layout" << std::endl;
+        os << "[i] empty layout\n";
         return;
     }
 
     if constexpr (is_hexagonal_layout_v<Lyt>)
     {
-        os << "[e] hexagonal layout printing is not supported" << std::endl;
+        os << "[e] hexagonal layout printing is not supported\n";
         return;
     }
     else if constexpr (is_shifted_cartesian_layout_v<Lyt>)
     {
-        os << "[e] shifted cartesian layout printing is not supported" << std::endl;
+        os << "[e] shifted cartesian layout printing is not supported\n";
         return;
     }
 
@@ -250,8 +247,8 @@ void print_gate_level_layout(std::ostream& os, const Lyt& layout, const bool io_
         ++r_ctr;
     }
 
-    // flush stream
-    os << std::endl;
+    // terminate with a newline
+    os << "\n";
 }
 /**
  * Writes a simplified 2D representation of a cell-level layout to an output stream.
@@ -334,8 +331,8 @@ void print_cell_level_layout(std::ostream& os, const Lyt& layout, const bool io_
         os << '\n';
     }
 
-    // flush stream
-    os << std::endl;
+    // terminate with a newline
+    os << "\n";
 }
 /**
  * Writes a simplified 2D representation of an SiDB layout (SiDB and defect charges are supported) to an output stream.
@@ -521,8 +518,8 @@ void print_sidb_layout(std::ostream& os, const Lyt& lyt, const bool lat_color = 
                 break;
             }
         }
-        // flush stream
-        os << std::endl;
+        // terminate with a newline
+        os << "\n";
     }
 }
 /**

--- a/include/fiction/io/print_layout.hpp
+++ b/include/fiction/io/print_layout.hpp
@@ -239,7 +239,7 @@ void print_gate_level_layout(std::ostream& os, const Lyt& layout, const bool io_
                 color = color | detail::OUT_COLOR;
             }
 
-            os << fmt::format(color, gate);
+            os << fmt::format(color, fmt::runtime(gate));
 
             os << x_dirs[r_ctr][c_ctr];
             ++c_ctr;
@@ -326,8 +326,9 @@ void print_cell_level_layout(std::ostream& os, const Lyt& layout, const bool io_
                     color = color | detail::OUT_COLOR;
                 }
 
-                os << fmt::format(color,
-                                  (Lyt::technology::is_normal_cell(ct) ? "▢" : std::string(1u, static_cast<char>(ct))));
+                os << fmt::format(
+                    color,
+                    fmt::runtime(Lyt::technology::is_normal_cell(ct) ? "▢" : std::string(1u, static_cast<char>(ct))));
             }
         }
         os << '\n';

--- a/include/fiction/technology/cell_ports.hpp
+++ b/include/fiction/technology/cell_ports.hpp
@@ -343,6 +343,10 @@ struct formatter<fiction::port_direction>
                 dir = "NW";
                 break;
             }
+            default:
+            {
+                break;
+            }
         }
 
         return format_to(ctx.out(), fmt::runtime(dir));

--- a/include/fiction/technology/cell_ports.hpp
+++ b/include/fiction/technology/cell_ports.hpp
@@ -345,7 +345,7 @@ struct formatter<fiction::port_direction>
             }
         }
 
-        return format_to(ctx.out(), dir);
+        return format_to(ctx.out(), fmt::runtime(dir));
     }
 };
 // make port_list compatible with fmt::format

--- a/include/fiction/technology/cell_ports.hpp
+++ b/include/fiction/technology/cell_ports.hpp
@@ -85,6 +85,10 @@ struct port_direction
     /**
      * Cardinal direction.
      */
+    // `dir` below is stored and compared as a plain uint8_t at ~300 call sites across the code base;
+    // converting this to an enum class is a real module-modernization task, not a same-file cleanup,
+    // and is deferred to a follow-up PR.
+    // NOLINTNEXTLINE(cppcoreguidelines-use-enum-class)
     enum cardinal : uint8_t
     {
         /**


### PR DESCRIPTION
## Description

Pragmatic, minimal-scope follow-up to #1032 (which tried to do a full C++17 → C++20 modernization in one PR — too large to review/land safely). This PR bumps the language standard and gets CI green on it; the actual codebase modernization (`std::ranges`, spaceship operator, designated initializers, `std::jthread`, etc.) will proceed module by module in separate, reviewable PRs.

### Standard bump

- Bumps `CMAKE_CXX_STANDARD` to 20 and the `.clang-format` style target to `c++20`, and updates the remaining docs (`README.md`, `AGENTS.md`, `docs/about.rst`, `docs/getting_started.rst`) that still described the project as C++17.

### Ubuntu CI compiler matrix

- Drops `g++-10`, `clang++-14`, and `clang++-15`. Clang <16 has a known constraint-instantiation bug ([llvm/llvm-project#44178](https://github.com/llvm/llvm-project/issues/44178), fixed in Clang 16) that breaks libstdc++'s `<ranges>` implementation for non-trivial cases — since Ubuntu's `clang++` links against system libstdc++ by default, anything below 16 would become a liability the moment the step-by-step modernization starts introducing `std::ranges`. `clang++-16` is now the floor. `ubuntu-22.04` (jammy) loses Clang coverage entirely as a result (clang-16 isn't packaged for jammy), keeping `g++-11`/`g++-12`.
- Adds `clang++-19` and `clang++-20` on `ubuntu-24.04` (x86 and arm), the newest toolchains Ubuntu noble packages that weren't in the matrix yet.
- `gcc-15` isn't packaged for either `ubuntu-22.04` or `ubuntu-24.04` yet, so the GCC ceiling stays at `g++-14` for now.

The macOS/Windows CI jobs and the single-compiler CodeQL/coverage jobs track their OS-provided toolchains and aren't affected by the compiler-matrix reasoning above.

### Fallout from actually building under C++20

- Fixed several pre-existing `fmt` compile-time format-string misuses (a runtime string passed as the *format string* argument with no substitution args) that only broke once `fmt`'s `consteval` checking activated in C++20 mode.
- Pinned the vendored `alice` dependency's `GIT_TAG` to a fixed commit instead of floating on `master`: that fork already carries a `std::result_of`→`std::invoke_result_t` fix required under C++20 (MSVC's STL removes `std::result_of` in C++20 mode), but floating on the branch name hit GitHub's `info/refs` caching for anonymous clones and intermittently resolved to a stale commit without the fix.
- Addressed the clang-tidy findings (`misc-include-cleaner`, `performance-avoid-endl`, `readability-avoid-nested-conditional-operator`, `bugprone-switch-missing-default-case`) that surfaced in the three files touched above, since Clang-Tidy Review flags every finding in a modified file, not just changed lines. Deliberately left `cppcoreguidelines-use-enum-class` on `port_direction`'s `cardinal` enum alone — its `dir` member is stored as a plain `uint8_t` and compared/switched-on as such at ~300 call sites, so converting it is a real module-modernization task, not a same-file cleanup.

Also merged in `main`'s Renovate custom-manager change (#1033), which collided with the `alice` pin and the changelog on the same lines.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The project now requires C++20, with updated documentation and build configuration.
  * Added clearer status icons and improved formatting for design-rule verification summaries.
* **Bug Fixes**
  * Fixed compile-time formatting issues involving dynamically selected output formats.
  * Improved handling and display of unrecognized port directions.
* **Documentation**
  * Updated getting-started guidance, project information, and changelog details.
* **Chores**
  * Modernized Ubuntu compiler coverage, including Clang 19 and 20 support.
  * Updated the bundled dependency to a C++20-compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->