### PR TITLE
:recycle: C++20 modernization in `fiction/utils/`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ Unreleased
 
 Changed
 #######
+- Code quality:
+    - Adopted ``std::ranges`` algorithms (``std::ranges::for_each``, ``std::ranges::find``) in place of
+      hand-rolled loops in ``fiction/utils/hash.hpp`` and ``fiction/utils/stl_utils.hpp``, as the first
+      step of an incremental, module-by-module C++20 idiom adoption
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
 - Continuous integration:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,7 +17,8 @@ Changed
       ``std::ranges::max_element``) in place of hand-rolled loops; ``std::integral``/``std::floating_point``/
       ``std::random_access_iterator`` concepts in place of ``static_assert`` type checks; and a defaulted
       ``operator==`` on ``mockturtle::edge`` (relying on C++20 rewritten candidates instead of a
-      hand-written ``operator!=``)
+      hand-written ``operator!=``). Extended the same modernization to ``test/utils/routing_utils.cpp``
+      (``std::ranges`` and designated initializers)
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
 - Continuous integration:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,9 +11,10 @@ Unreleased
 Changed
 #######
 - Code quality:
-    - Adopted ``std::ranges`` algorithms (``std::ranges::for_each``, ``std::ranges::find``) in place of
-      hand-rolled loops in ``fiction/utils/hash.hpp`` and ``fiction/utils/stl_utils.hpp``, as the first
-      step of an incremental, module-by-module C++20 idiom adoption
+    - Adopted ``std::ranges`` algorithms (``std::ranges::for_each``, ``std::ranges::find``,
+      ``std::ranges::find_if``, ``std::ranges::all_of``, ``std::ranges::max_element``) in place of
+      hand-rolled loops across ``include/fiction/utils/``, as the first step of an incremental,
+      module-by-module C++20 idiom adoption
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
 - Continuous integration:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,7 @@ Changed
       module-by-module modernization: ``std::ranges`` algorithms (``std::ranges::for_each``,
       ``std::ranges::find``, ``std::ranges::find_if``, ``std::ranges::all_of``,
       ``std::ranges::max_element``) in place of hand-rolled loops; ``std::integral``/``std::floating_point``/
-      ``std::input_iterator``/``std::forward_iterator`` concepts in place of ``static_assert`` type checks;
-      ``std::forward`` where a callback parameter is genuinely single-use; and a defaulted
+      ``std::random_access_iterator`` concepts in place of ``static_assert`` type checks; and a defaulted
       ``operator==`` on ``mockturtle::edge`` (relying on C++20 rewritten candidates instead of a
       hand-written ``operator!=``)
 - Build system:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,10 +11,14 @@ Unreleased
 Changed
 #######
 - Code quality:
-    - Adopted ``std::ranges`` algorithms (``std::ranges::for_each``, ``std::ranges::find``,
-      ``std::ranges::find_if``, ``std::ranges::all_of``, ``std::ranges::max_element``) in place of
-      hand-rolled loops across ``include/fiction/utils/``, as the first step of an incremental,
-      module-by-module C++20 idiom adoption
+    - Adopted C++20 idioms across ``include/fiction/utils/`` as the first step of an incremental,
+      module-by-module modernization: ``std::ranges`` algorithms (``std::ranges::for_each``,
+      ``std::ranges::find``, ``std::ranges::find_if``, ``std::ranges::all_of``,
+      ``std::ranges::max_element``) in place of hand-rolled loops; ``std::integral``/``std::floating_point``/
+      ``std::input_iterator``/``std::forward_iterator`` concepts in place of ``static_assert`` type checks;
+      ``std::forward`` where a callback parameter is genuinely single-use; and a defaulted
+      ``operator==`` on ``mockturtle::edge`` (relying on C++20 rewritten candidates instead of a
+      hand-written ``operator!=``)
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
 - Continuous integration:

--- a/include/fiction/utils/hash.hpp
+++ b/include/fiction/utils/hash.hpp
@@ -5,6 +5,7 @@
 #ifndef FICTION_HASH_HPP
 #define FICTION_HASH_HPP
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <functional>
@@ -50,10 +51,7 @@ struct hash<std::array<T, N>>
     std::size_t operator()(const std::array<T, N>& a) const noexcept
     {
         std::size_t h = 0;
-        for (const auto& e : a)
-        {
-            fiction::hash_combine(h, e);
-        }
+        std::ranges::for_each(a, [&h](const auto& e) { fiction::hash_combine(h, e); });
 
         return h;
     }
@@ -69,10 +67,7 @@ struct hash<std::set<T>>
     std::size_t operator()(const std::set<T>& s) const noexcept
     {
         std::size_t h = 0;
-        for (const auto& e : s)
-        {
-            fiction::hash_combine(h, e);
-        }
+        std::ranges::for_each(s, [&h](const auto& e) { fiction::hash_combine(h, e); });
 
         return h;
     }
@@ -88,10 +83,7 @@ struct hash<std::multiset<T>>
     std::size_t operator()(const std::multiset<T>& s) const noexcept
     {
         std::size_t h = 0;
-        for (const auto& e : s)
-        {
-            fiction::hash_combine(h, e);
-        }
+        std::ranges::for_each(s, [&h](const auto& e) { fiction::hash_combine(h, e); });
 
         return h;
     }

--- a/include/fiction/utils/hash.hpp
+++ b/include/fiction/utils/hash.hpp
@@ -48,6 +48,12 @@ namespace std
 template <typename T, std::size_t N>
 struct hash<std::array<T, N>>
 {
+    /**
+     * Computes the hash value of a given `std::array`.
+     *
+     * @param a Array to hash.
+     * @return Hash value of `a`.
+     */
     std::size_t operator()(const std::array<T, N>& a) const noexcept
     {
         std::size_t h = 0;
@@ -64,6 +70,12 @@ struct hash<std::array<T, N>>
 template <typename T>
 struct hash<std::set<T>>
 {
+    /**
+     * Computes the hash value of a given `std::set`.
+     *
+     * @param s Set to hash.
+     * @return Hash value of `s`.
+     */
     std::size_t operator()(const std::set<T>& s) const noexcept
     {
         std::size_t h = 0;
@@ -80,6 +92,12 @@ struct hash<std::set<T>>
 template <typename T>
 struct hash<std::multiset<T>>
 {
+    /**
+     * Computes the hash value of a given `std::multiset`.
+     *
+     * @param s Multiset to hash.
+     * @return Hash value of `s`.
+     */
     std::size_t operator()(const std::multiset<T>& s) const noexcept
     {
         std::size_t h = 0;

--- a/include/fiction/utils/map_utils.hpp
+++ b/include/fiction/utils/map_utils.hpp
@@ -31,7 +31,7 @@ typename MapType::const_iterator find_key_with_tolerance(const MapType& map, con
 
     auto compare_keys = [&key, &tolerance](const auto& pair) { return std::abs(pair.first - key) < tolerance; };
 
-    return std::find_if(map.cbegin(), map.cend(), compare_keys);
+    return std::ranges::find_if(map, compare_keys);
 }
 
 }  // namespace fiction

--- a/include/fiction/utils/map_utils.hpp
+++ b/include/fiction/utils/map_utils.hpp
@@ -8,6 +8,7 @@
 #include "fiction/technology/constants.hpp"
 
 #include <algorithm>
+#include <concepts>
 
 namespace fiction
 {
@@ -23,10 +24,9 @@ namespace fiction
  * @return An iterator to the found parameter point in the map, or `map.cend()` if not found.
  */
 template <typename MapType>
+    requires std::floating_point<typename MapType::key_type>
 typename MapType::const_iterator find_key_with_tolerance(const MapType& map, const typename MapType::key_type& key)
 {
-    static_assert(std::is_floating_point_v<typename MapType::key_type>, "Map key type must be floating-point");
-
     constexpr double tolerance = constants::ERROR_MARGIN;
 
     auto compare_keys = [&key, &tolerance](const auto& pair) { return std::abs(pair.first - key) < tolerance; };

--- a/include/fiction/utils/math_utils.hpp
+++ b/include/fiction/utils/math_utils.hpp
@@ -6,6 +6,7 @@
 #define FICTION_MATH_UTILS_HPP
 
 #include <cmath>
+#include <concepts>
 #include <cstdint>
 #include <cstdlib>
 #include <numeric>
@@ -27,10 +28,9 @@ namespace fiction
  * @return The number rounded to n decimal places.
  */
 template <typename T>
+    requires std::integral<T> || std::floating_point<T>
 [[nodiscard]] inline T round_to_n_decimal_places(const T number, const uint64_t n) noexcept
 {
-    static_assert(std::is_arithmetic_v<T>, "T is not a number type");
-
     const auto factor = std::pow(10.0, static_cast<double>(n));
     return static_cast<T>(std::round(static_cast<double>(number) * factor) / factor);
 }
@@ -41,11 +41,9 @@ template <typename T>
  * @param n The number to take the absolute value of.
  * @return |n|.
  */
-template <typename T>
+template <std::integral T>
 [[nodiscard]] inline T integral_abs(const T n) noexcept
 {
-    static_assert(std::is_integral_v<T>, "T is not an integral number type");
-
     if constexpr (std::is_unsigned_v<T>)
     {
         return n;

--- a/include/fiction/utils/network_utils.hpp
+++ b/include/fiction/utils/network_utils.hpp
@@ -449,13 +449,13 @@ std::vector<uint32_t> inverse_levels(const Ntk& ntk) noexcept
     {
         auto fos = fanouts(ntk, n);
         // if all inverse predecessors are already discovered
-        if (std::all_of(fos.cbegin(), fos.cend(), is_discovered))
+        if (std::ranges::all_of(fos, is_discovered))
         {
             set_discovered(n);
 
             // determine successor's maximum level
-            const auto post_l = std::max_element(fos.cbegin(), fos.cend(), [&](const auto& n1, const auto& n2)
-                                                 { return get_inv_level(n1) < get_inv_level(n2); });
+            const auto post_l = std::ranges::max_element(fos, [&](const auto& n1, const auto& n2)
+                                                         { return get_inv_level(n1) < get_inv_level(n2); });
 
             // if there are no successors, the level of current node is 0, else it is 1 higher than theirs
             set_inv_level(n, post_l != fos.cend() ? std::max(get_inv_level(n), get_inv_level(*post_l) + 1u) : 0u);

--- a/include/fiction/utils/network_utils.hpp
+++ b/include/fiction/utils/network_utils.hpp
@@ -35,20 +35,7 @@ struct edge
      * @param other Edge to compare to.
      * @return `true` iff both sources and targets match.
      */
-    bool operator==(const edge<Ntk>& other) const
-    {
-        return source == other.source && target == other.target;
-    }
-    /**
-     * Inequality operator.
-     *
-     * @param other Edge to compare to.
-     * @return `true` iff this edge is not equal to other.
-     */
-    bool operator!=(const edge<Ntk>& other) const
-    {
-        return !(*this == other);
-    }
+    bool operator==(const edge<Ntk>& other) const = default;
 };
 }  // namespace mockturtle
 

--- a/include/fiction/utils/network_utils.hpp
+++ b/include/fiction/utils/network_utils.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace mockturtle
@@ -82,7 +83,8 @@ namespace fiction
  * @param fn Function object to apply to each edge in `ntk`.
  */
 template <typename Ntk, typename Fn>
-// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is invoked once per edge, so it cannot be forwarded
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is captured by two nested lambdas, so it cannot be
+// forwarded
 void foreach_edge(const Ntk& ntk, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node function.");
@@ -111,7 +113,6 @@ void foreach_edge(const Ntk& ntk, Fn&& fn)
  * @param fn Function object to apply to each outgoing edge of `n` in `ntk`.
  */
 template <typename Ntk, typename Fn>
-// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is invoked once per edge, so it cannot be forwarded
 void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_fanout_v<Ntk>, "Ntk does not implement the foreach_fanout function.");
@@ -121,7 +122,7 @@ void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& 
                        {
                            mockturtle::edge<Ntk> e{n, fon};
 
-                           fn(e);
+                           std::forward<Fn>(fn)(e);
                        });
 }
 /**
@@ -134,7 +135,6 @@ void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& 
  * @param fn Function object to apply to each incoming edge of `n` in `ntk`.
  */
 template <typename Ntk, typename Fn>
-// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is invoked once per edge, so it cannot be forwarded
 void foreach_incoming_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin function.");
@@ -145,7 +145,7 @@ void foreach_incoming_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& 
                       {
                           mockturtle::edge<Ntk> e{ntk.get_node(fi), n};
 
-                          fn(e);
+                          std::forward<Fn>(fn)(e);
                       });
 }
 /**

--- a/include/fiction/utils/network_utils.hpp
+++ b/include/fiction/utils/network_utils.hpp
@@ -15,7 +15,6 @@
 #include <functional>
 #include <optional>
 #include <stdexcept>
-#include <utility>
 #include <vector>
 
 namespace mockturtle
@@ -100,6 +99,8 @@ void foreach_edge(const Ntk& ntk, Fn&& fn)
  * @param fn Function object to apply to each outgoing edge of `n` in `ntk`.
  */
 template <typename Ntk, typename Fn>
+// fn is invoked once per outgoing edge, so it cannot be forwarded
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
 void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_fanout_v<Ntk>, "Ntk does not implement the foreach_fanout function.");
@@ -109,7 +110,7 @@ void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& 
                        {
                            mockturtle::edge<Ntk> e{n, fon};
 
-                           std::forward<Fn>(fn)(e);
+                           fn(e);
                        });
 }
 /**
@@ -122,6 +123,8 @@ void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& 
  * @param fn Function object to apply to each incoming edge of `n` in `ntk`.
  */
 template <typename Ntk, typename Fn>
+// fn is invoked once per incoming edge, so it cannot be forwarded
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
 void foreach_incoming_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin function.");
@@ -132,7 +135,7 @@ void foreach_incoming_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& 
                       {
                           mockturtle::edge<Ntk> e{ntk.get_node(fi), n};
 
-                          std::forward<Fn>(fn)(e);
+                          fn(e);
                       });
 }
 /**

--- a/include/fiction/utils/network_utils.hpp
+++ b/include/fiction/utils/network_utils.hpp
@@ -10,11 +10,11 @@
 #include <mockturtle/traits.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <stdexcept>
-#include <type_traits>
 #include <vector>
 
 namespace mockturtle
@@ -82,6 +82,7 @@ namespace fiction
  * @param fn Function object to apply to each edge in `ntk`.
  */
 template <typename Ntk, typename Fn>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is invoked once per edge, so it cannot be forwarded
 void foreach_edge(const Ntk& ntk, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node function.");
@@ -110,6 +111,7 @@ void foreach_edge(const Ntk& ntk, Fn&& fn)
  * @param fn Function object to apply to each outgoing edge of `n` in `ntk`.
  */
 template <typename Ntk, typename Fn>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is invoked once per edge, so it cannot be forwarded
 void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_fanout_v<Ntk>, "Ntk does not implement the foreach_fanout function.");
@@ -132,6 +134,7 @@ void foreach_outgoing_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& 
  * @param fn Function object to apply to each incoming edge of `n` in `ntk`.
  */
 template <typename Ntk, typename Fn>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is invoked once per edge, so it cannot be forwarded
 void foreach_incoming_edge(const Ntk& ntk, const mockturtle::node<Ntk>& n, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_fanin_v<Ntk>, "Ntk does not implement the foreach_fanin function.");

--- a/include/fiction/utils/network_utils.hpp
+++ b/include/fiction/utils/network_utils.hpp
@@ -83,8 +83,8 @@ namespace fiction
  * @param fn Function object to apply to each edge in `ntk`.
  */
 template <typename Ntk, typename Fn>
-// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward): fn is captured by two nested lambdas, so it cannot be
-// forwarded
+// fn is captured by two nested lambdas, so it cannot be forwarded
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
 void foreach_edge(const Ntk& ntk, Fn&& fn)
 {
     static_assert(mockturtle::has_foreach_node_v<Ntk>, "Ntk does not implement the foreach_node function.");

--- a/include/fiction/utils/placement_utils.hpp
+++ b/include/fiction/utils/placement_utils.hpp
@@ -395,19 +395,19 @@ struct branching_signal_container
      */
     [[nodiscard]] mockturtle::signal<Lyt> operator[](const mockturtle::node<Ntk>& n) const
     {
-        if (const auto branch = std::find_if(branches.cbegin(), branches.cend(),
-                                             [&n](const auto& b)
-                                             {
-                                                 if (b != nullptr)
-                                                 {
-                                                     if (b->ntk_node == n)
+        if (const auto branch = std::ranges::find_if(branches,
+                                                     [&n](const auto& b)
                                                      {
-                                                         return true;
-                                                     }
-                                                 }
+                                                         if (b != nullptr)
+                                                         {
+                                                             if (b->ntk_node == n)
+                                                             {
+                                                                 return true;
+                                                             }
+                                                         }
 
-                                                 return false;
-                                             });
+                                                         return false;
+                                                     });
             branch != branches.cend())
         {
             return (*branch)->lyt_signal;

--- a/include/fiction/utils/placement_utils.hpp
+++ b/include/fiction/utils/placement_utils.hpp
@@ -17,6 +17,8 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <string>
 
 namespace fiction
 {

--- a/include/fiction/utils/routing_utils.hpp
+++ b/include/fiction/utils/routing_utils.hpp
@@ -84,6 +84,12 @@ class path_collection : public std::vector<Path>
         this->push_back(p);
     }
 
+    /**
+     * Checks whether a given path is contained in the collection.
+     *
+     * @param p Path to search for.
+     * @return `true` iff `p` is contained in the collection.
+     */
     [[nodiscard]] bool contains(const Path& p) const noexcept
     {
         return std::ranges::find(*this, p) != std::cend(*this);

--- a/include/fiction/utils/routing_utils.hpp
+++ b/include/fiction/utils/routing_utils.hpp
@@ -85,7 +85,7 @@ class path_collection : public std::vector<Path>
 
     [[nodiscard]] bool contains(const Path& p) const noexcept
     {
-        return std::find(std::cbegin(*this), std::cend(*this), p) != std::cend(*this);
+        return std::ranges::find(*this, p) != std::cend(*this);
     }
 
   protected:

--- a/include/fiction/utils/routing_utils.hpp
+++ b/include/fiction/utils/routing_utils.hpp
@@ -10,6 +10,7 @@
 #include <mockturtle/traits.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <functional>
 #include <set>
 #include <vector>

--- a/include/fiction/utils/stl_utils.hpp
+++ b/include/fiction/utils/stl_utils.hpp
@@ -5,6 +5,7 @@
 #ifndef FICTION_STL_UTILS_HPP
 #define FICTION_STL_UTILS_HPP
 
+#include <algorithm>
 #include <ctime>
 #include <functional>
 #include <iterator>
@@ -105,19 +106,7 @@ class searchable_priority_queue : public std::priority_queue<T, Container, Compa
      */
     iterator find(const T& val) noexcept
     {
-        auto first = begin(), last = end();
-
-        while (first != last)
-        {
-            if (*first == val)
-            {
-                return first;
-            }
-
-            ++first;
-        }
-
-        return last;
+        return std::ranges::find(this->c, val);
     }
     /**
      * Returns a `const_iterator` to the provided value if it is contained in the priority queue. Returns an iterator to
@@ -128,20 +117,7 @@ class searchable_priority_queue : public std::priority_queue<T, Container, Compa
      */
     const_iterator find(const T& val) const noexcept
     {
-        auto       first = cbegin();
-        const auto last  = cend();
-
-        while (first != last)
-        {
-            if (*first == val)
-            {
-                return first;
-            }
-
-            ++first;
-        }
-
-        return last;
+        return std::ranges::find(this->c, val);
     }
     /**
      * Returns `true` if the provided value is stored in the queue and `false` otherwise.

--- a/include/fiction/utils/stl_utils.hpp
+++ b/include/fiction/utils/stl_utils.hpp
@@ -10,7 +10,6 @@
 #include <functional>
 #include <iterator>
 #include <queue>
-#include <type_traits>
 #include <vector>
 
 namespace fiction
@@ -36,15 +35,9 @@ namespace fiction
  * @return Iterator in the range `[first, last)` to the first position of the first 2-element sub-sequence shared
  * between the two ranges, or `last` if no such shared sub-sequence exists.
  */
-template <class InputIt, class ForwardIt>
+template <std::input_iterator InputIt, std::forward_iterator ForwardIt>
 InputIt find_first_two_of(InputIt first, InputIt last, ForwardIt s_first, ForwardIt s_last) noexcept
 {
-    static_assert(std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<InputIt>::iterator_category>,
-                  "InputIt must meet the requirements of LegacyInputIterator");
-    static_assert(
-        std::is_base_of_v<std::forward_iterator_tag, typename std::iterator_traits<ForwardIt>::iterator_category>,
-        "ForwardIt must meet the requirements of LegacyForwardIterator");
-
     for (; first != last - 1; ++first)
     {
         for (ForwardIt it = s_first; it != s_last - 1; ++it)
@@ -106,7 +99,7 @@ class searchable_priority_queue : public std::priority_queue<T, Container, Compa
      */
     iterator find(const T& val) noexcept
     {
-        return std::ranges::find(this->c, val);
+        return std::ranges::find(*this, val);
     }
     /**
      * Returns a `const_iterator` to the provided value if it is contained in the priority queue. Returns an iterator to
@@ -117,7 +110,7 @@ class searchable_priority_queue : public std::priority_queue<T, Container, Compa
      */
     const_iterator find(const T& val) const noexcept
     {
-        return std::ranges::find(this->c, val);
+        return std::ranges::find(*this, val);
     }
     /**
      * Returns `true` if the provided value is stored in the queue and `false` otherwise.

--- a/include/fiction/utils/stl_utils.hpp
+++ b/include/fiction/utils/stl_utils.hpp
@@ -26,8 +26,9 @@ namespace fiction
  * iterator to index 2, i.e., the second `1` in the first list, because the 2-element sub-sequence `[1,2]` is shared
  * between the two ranges.
  *
- * @tparam InputIt must meet the requirements of `LegacyInputIterator`.
- * @tparam ForwardIt must meet the requirements of `LegacyForwardIterator`.
+ * @tparam InputIt must meet the requirements of `LegacyRandomAccessIterator` (the implementation subtracts from and
+ * adds to `last`/`s_last`, which forward iterators do not support).
+ * @tparam ForwardIt must meet the requirements of `LegacyRandomAccessIterator` (see above).
  * @param first Begin of the range to examine.
  * @param last End of the range to examine.
  * @param s_first Begin of the range to search for.
@@ -35,7 +36,7 @@ namespace fiction
  * @return Iterator in the range `[first, last)` to the first position of the first 2-element sub-sequence shared
  * between the two ranges, or `last` if no such shared sub-sequence exists.
  */
-template <std::input_iterator InputIt, std::forward_iterator ForwardIt>
+template <std::random_access_iterator InputIt, std::random_access_iterator ForwardIt>
 InputIt find_first_two_of(InputIt first, InputIt last, ForwardIt s_first, ForwardIt s_last) noexcept
 {
     for (; first != last - 1; ++first)

--- a/test/utils/routing_utils.cpp
+++ b/test/utils/routing_utils.cpp
@@ -6,6 +6,7 @@
 
 #include "utils/blueprints/layout_blueprints.hpp"
 
+#include <fiction/traits.hpp>
 #include <fiction/types.hpp>
 #include <fiction/utils/routing_utils.hpp>
 
@@ -20,12 +21,8 @@ void check_containing_objectives(const std::vector<routing_objective<Lyt>>& obje
 {
     CHECK(objectives.size() == expected_objectives.size());
 
-    std::for_each(objectives.cbegin(), objectives.cend(),
-                  [&expected_objectives](const auto& obj)
-                  {
-                      CHECK(std::find(expected_objectives.cbegin(), expected_objectives.cend(), obj) !=
-                            expected_objectives.cend());
-                  });
+    std::ranges::for_each(objectives, [&expected_objectives](const auto& obj)
+                          { CHECK(std::ranges::find(expected_objectives, obj) != expected_objectives.cend()); });
 }
 
 TEST_CASE("Extract routing objectives", "[routing-utils]")
@@ -35,41 +32,47 @@ TEST_CASE("Extract routing objectives", "[routing-utils]")
         const auto layout     = blueprints::straight_wire_gate_layout<cart_gate_clk_lyt>();
         const auto objectives = extract_routing_objectives(layout);
 
-        check_containing_objectives(objectives, {{{0, 1}, {2, 1}}});
+        check_containing_objectives(objectives, {{.source = {0, 1}, .target = {2, 1}}});
     }
     SECTION("Two paths wire connections")
     {
         const auto layout     = blueprints::unbalanced_and_layout<cart_gate_clk_lyt>();
         const auto objectives = extract_routing_objectives(layout);
 
-        check_containing_objectives(objectives, {{{0, 2}, {2, 0}}, {{1, 0}, {2, 0}}, {{2, 0}, {3, 0}}});
+        check_containing_objectives(objectives, {{.source = {0, 2}, .target = {2, 0}},
+                                                 {.source = {1, 0}, .target = {2, 0}},
+                                                 {.source = {2, 0}, .target = {3, 0}}});
     }
     SECTION("Three paths wire connections")
     {
         const auto layout     = blueprints::three_wire_paths_gate_layout<cart_gate_clk_lyt>();
         const auto objectives = extract_routing_objectives(layout);
 
-        check_containing_objectives(objectives, {{{0, 0}, {4, 0}}, {{0, 2}, {4, 2}}, {{0, 4}, {4, 4}}});
+        check_containing_objectives(objectives, {{.source = {0, 0}, .target = {4, 0}},
+                                                 {.source = {0, 2}, .target = {4, 2}},
+                                                 {.source = {0, 4}, .target = {4, 4}}});
     }
     SECTION("Direct gate connections")
     {
         const auto layout     = blueprints::xor_maj_gate_layout<cart_gate_clk_lyt>();
         const auto objectives = extract_routing_objectives(layout);
 
-        check_containing_objectives(objectives, {{{1, 1}, {2, 1}},
-                                                 {{2, 0}, {2, 1}},
-                                                 {{3, 1}, {2, 1}},
-                                                 {{1, 1}, {1, 0}},
-                                                 {{2, 0}, {1, 0}},
-                                                 {{2, 1}, {2, 2}},
-                                                 {{1, 0}, {0, 0}}});
+        check_containing_objectives(objectives, {{.source = {1, 1}, .target = {2, 1}},
+                                                 {.source = {2, 0}, .target = {2, 1}},
+                                                 {.source = {3, 1}, .target = {2, 1}},
+                                                 {.source = {1, 1}, .target = {1, 0}},
+                                                 {.source = {2, 0}, .target = {1, 0}},
+                                                 {.source = {2, 1}, .target = {2, 2}},
+                                                 {.source = {1, 0}, .target = {0, 0}}});
     }
     SECTION("Two incoming gate wires")
     {
         const auto layout     = blueprints::use_and_gate_layout<cart_gate_clk_lyt>();
         const auto objectives = extract_routing_objectives(layout);
 
-        check_containing_objectives(objectives, {{{0, 1}, {1, 2}}, {{3, 3}, {1, 2}}, {{1, 2}, {3, 2}}});
+        check_containing_objectives(objectives, {{.source = {0, 1}, .target = {1, 2}},
+                                                 {.source = {3, 3}, .target = {1, 2}},
+                                                 {.source = {1, 2}, .target = {3, 2}}});
     }
 }
 


### PR DESCRIPTION
## Summary

First in a planned sequence of small, independently-reviewable PRs adopting C++20 idioms module-by-module, now that the language standard has been bumped (#1038). Scope covers `include/fiction/utils/` and `test/utils/`, expanded from an initial two-file, ranges-only scope once CI showed the diff stays small and clang-tidy findings stay light.

### `std::ranges` algorithms replacing hand-rolled loops
- `hash.hpp`: three `for` loops (`std::array`/`std::set`/`std::multiset` hashers) → `std::ranges::for_each`
- `stl_utils.hpp`: `searchable_priority_queue::find()` (both overloads) → `std::ranges::find(*this, val)`
- `map_utils.hpp`: `std::find_if` → `std::ranges::find_if`
- `routing_utils.hpp`: `std::find` → `std::ranges::find` (`path_collection::contains`)
- `network_utils.hpp`: `std::all_of`/`std::max_element` → `std::ranges::` equivalents
- `placement_utils.hpp`: `std::find_if` → `std::ranges::find_if`
- `test/utils/routing_utils.cpp`: `std::for_each`/`std::find` → `std::ranges::` equivalents (the only genuine `std::ranges` opportunity found across all of `test/utils/`)

### Other C++20 idioms
- `math_utils.hpp`: `round_to_n_decimal_places`/`integral_abs` constrained with `std::integral`/`std::floating_point` concepts instead of `static_assert` type checks
- `map_utils.hpp`: `find_key_with_tolerance` constrains `MapType::key_type` with `std::floating_point` via a `requires` clause
- `stl_utils.hpp`: `find_first_two_of`'s iterator parameters constrained with `std::random_access_iterator` (tightened from an initial `input_iterator`/`forward_iterator` attempt after CodeRabbit correctly pointed out the implementation does pointer arithmetic that only random-access iterators support)
- `network_utils.hpp`: `mockturtle::edge::operator==` is now `= default`; the hand-written `operator!=` was removed (C++20 rewritten candidates synthesize `!=` from `==` automatically)
- `test/utils/routing_utils.cpp`: designated initializers for `routing_objective` aggregate construction in every test `SECTION`

### CodeRabbit feedback addressed
- Reverted an earlier `std::forward` change in `foreach_outgoing_edge`/`foreach_incoming_edge`: CodeRabbit correctly flagged that forwarding a callback invoked multiple times per call (once per edge) isn't generally safe — it happened to work for the plain lambdas used everywhere in this codebase, but silently misbehaves for callables with rvalue-ref-qualified `operator()` overloads. Both functions keep a documented `NOLINT` instead, matching `foreach_edge`'s existing treatment.
- Added missing Doxygen docs on the edited `hash.hpp` operators and `routing_utils.hpp`'s `contains()`.

## Files surveyed and deliberately left untouched

`array_utils.hpp`, `phmap_utils.hpp`, `execution_utils.hpp`, `mockturtle_utils.hpp`, `name_utils.hpp`, `range.hpp`, `truth_table_utils.hpp`, `layout_utils.hpp` (header), and `test/utils/{layout_utils,math_utils,network_utils,stl_utils}.cpp` were surveyed and found to have no clean, low-risk C++20 idiom opportunities — no full-container algorithm calls, no `static_assert` type checks with a matching standard concept, no comparison-operator pairs to default. Forcing changes into these would mean inventing new patterns without a clear payoff, so they were left as-is.

## No existing precedent

There was no prior `std::ranges`/concepts usage anywhere in `include/fiction/` before this PR, so this establishes the house style (always-qualified `std::ranges::`, no `using namespace`; standard-library concepts over hand-rolled ones) for the PRs that follow.

## Verification

- `hash.hpp` is not covered by a dedicated test; `network_utils.hpp`, `routing_utils.hpp`, `stl_utils.hpp`, `math_utils.hpp`, `map_utils.hpp`, and `placement_utils.hpp` are exercised indirectly or directly by `test_network_utils`, `test_routing_utils`, `test_stl_utils`, and `test_math_utils`. All were rebuilt from scratch against this branch after every substantive change and pass (39/98/13/61 assertions respectively as of the last full rebuild).
- Every touched header/source file was compiled directly with both `clang++ 22` and `g++ 16` under `-std=c++20 -Wall -Wextra`, with no new warnings or errors.
- `clang-tidy` run locally against every touched file (using the project's own compile database) reports no actionable findings — only a couple of checks that fire locally (clang-tidy 22) but not in CI (clang-tidy 21), and Catch2-macro-internal noise (`__COUNTER__`/static-init warnings) that's pervasive across every `TEST_CASE` in the codebase and not fixable from this PR.
- `prek` (clang-format, cmake-format, etc.) passed on every commit.

## What's next

Follow-up PRs will move module-by-module through `technology/`, `networks/`, `layouts/`, `io/`, and finally `algorithms/` (headers and their tests together, following the pattern established here). Semantic changes with real behavioral risk (spaceship-operator collapsing of hand-written orderings, `std::thread`→`std::jthread`, the `port_direction::cardinal` enum-to-enum-class conversion) are explicitly deferred to their own dedicated, individually-reviewed PRs — not folded into idiom-adoption PRs like this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2khX9HTvK5zmXcByxtZSY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized utility components for C++20, improving compile-time validation and algorithm consistency.
  * Added clearer constraints for numeric and iterator-based operations, producing more direct diagnostics for invalid usage.
  * Improved callback forwarding and equality handling for network edges.
  * Updated collection, hashing, lookup, and membership operations while preserving existing behavior.
  * Refined routing tests with clearer source and target assignments.
* **Documentation**
  * Added an unreleased changelog entry describing the modernization work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->