### PR TITLE
:recycle: C++20 modernization in `fiction/networks/`

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -12682,10 +12682,13 @@ the second `1` in the first list, because the 2-element sub-sequence
 `[1,2]` is shared between the two ranges.
 
 Template parameter ``InputIt``:
-    must meet the requirements of `LegacyInputIterator`.
+    must meet the requirements of `LegacyRandomAccessIterator` (the
+    implementation subtracts from and adds to `last`/`s_last`, which
+    forward iterators do not support).
 
 Template parameter ``ForwardIt``:
-    must meet the requirements of `LegacyForwardIterator`.
+    must meet the requirements of `LegacyRandomAccessIterator` (see
+    above).
 
 Parameter ``first``:
     Begin of the range to examine.
@@ -12703,25 +12706,6 @@ Returns:
     Iterator in the range `[first, last)` to the first position of the
     first 2-element sub-sequence shared between the two ranges, or
     `last` if no such shared sub-sequence exists.)doc";
-
-static const char *__doc_fiction_find_key_with_tolerance =
-R"doc(This function searches for a floating-point value specified by the
-`key` in the provided map `map`, applying a tolerance specified by
-`fiction::constants::ERROR_MARGIN`. Each key in the map is compared to
-the specified key within this tolerance.
-
-Template parameter ``MapType``:
-    The type of the map containing parameter points as keys.
-
-Parameter ``map``:
-    The map containing parameter points as keys and associated values.
-
-Parameter ``key``:
-    The parameter point to search for in the map.
-
-Returns:
-    An iterator to the found parameter point in the map, or
-    `map.cend()` if not found.)doc";
 
 static const char *__doc_fiction_flat_top_hex = R"doc(\verbatim _____ / \ / \ \ / \_____/ \endverbatim)doc";
 
@@ -18193,7 +18177,14 @@ Template parameter ``Path``:
 
 static const char *__doc_fiction_path_collection_add = R"doc()doc";
 
-static const char *__doc_fiction_path_collection_contains = R"doc()doc";
+static const char *__doc_fiction_path_collection_contains =
+R"doc(Checks whether a given path is contained in the collection.
+
+Parameter ``p``:
+    Path to search for.
+
+Returns:
+    `true` iff `p` is contained in the collection.)doc";
 
 static const char *__doc_fiction_path_set =
 R"doc(A set of multiple paths in a layout.
@@ -19915,21 +19906,6 @@ Template parameter ``Lyt``:
 
 Returns:
     Ripple clocking scheme.)doc";
-
-static const char *__doc_fiction_round_to_n_decimal_places =
-R"doc(Rounds a number to a specified number of decimal places.
-
-Template parameter ``T``:
-    The type of the number to round.
-
-Parameter ``number``:
-    The number to round.
-
-Parameter ``n``:
-    The number of decimal places to round to.
-
-Returns:
-    The number rounded to n decimal places.)doc";
 
 static const char *__doc_fiction_route_path =
 R"doc(Establishes a wire routing along the given path in the given layout.
@@ -23728,15 +23704,6 @@ Parameter ``other``:
 
 Returns:
     `true` iff both sources and targets match.)doc";
-
-static const char *__doc_mockturtle_edge_operator_ne =
-R"doc(Inequality operator.
-
-Parameter ``other``:
-    Edge to compare to.
-
-Returns:
-    `true` iff this edge is not equal to other.)doc";
 
 static const char *__doc_mockturtle_edge_source = R"doc()doc";
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,11 @@ Changed
       ``operator==`` on ``mockturtle::edge`` (relying on C++20 rewritten candidates instead of a
       hand-written ``operator!=``). Extended the same modernization to ``test/utils/routing_utils.cpp``
       (``std::ranges`` and designated initializers)
+    - Continued the incremental C++20 modernization in ``include/fiction/networks/``: ``std::ranges``
+      algorithms (``std::ranges::find``, ``std::ranges::find_if``, ``std::ranges::copy``,
+      ``std::ranges::for_each``, ``std::ranges::sort``, ``std::ranges::distance``) in place of hand-rolled
+      loops and iterator-pair algorithm calls in ``technology_network.hpp``, ``virtual_pi_network.hpp``,
+      ``views/bfs_topo_view.hpp``, and ``views/mutable_rank_view.hpp``
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
 - Continuous integration:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,11 @@ Changed
       algorithms (``std::ranges::find``, ``std::ranges::find_if``, ``std::ranges::copy``,
       ``std::ranges::for_each``, ``std::ranges::sort``, ``std::ranges::distance``) in place of hand-rolled
       loops and iterator-pair algorithm calls in ``technology_network.hpp``, ``virtual_pi_network.hpp``,
-      ``views/bfs_topo_view.hpp``, and ``views/mutable_rank_view.hpp``
+      ``views/bfs_topo_view.hpp``, and ``views/mutable_rank_view.hpp``. This module has no
+      ``static_assert(std::is_*)`` type checks or hand-written ``operator==``/``operator!=`` to modernize
+      into concepts/defaulted comparisons; extended a designated initializer to
+      ``test/networks/views/static_depth_view.cpp``, the only aggregate-initialization opportunity found in
+      this module's tests
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
 - Continuous integration:

--- a/include/fiction/networks/technology_network.hpp
+++ b/include/fiction/networks/technology_network.hpp
@@ -5,7 +5,19 @@
 #ifndef FICTION_TECHNOLOGY_NETWORK_HPP
 #define FICTION_TECHNOLOGY_NETWORK_HPP
 
+#include <kitty/constructors.hpp>
+#include <kitty/dynamic_truth_table.hpp>
+#include <kitty/operations.hpp>
 #include <mockturtle/networks/klut.hpp>
+#include <mockturtle/utils/algorithm.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iterator>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace fiction
 {
@@ -57,8 +69,8 @@ class technology_network : public mockturtle::klut_network
      */
     [[nodiscard]] bool is_po(const node& n) const
     {
-        return std::find_if(_storage->outputs.cbegin(), _storage->outputs.cend(), [this, &n](const auto& p)
-                            { return this->get_node(p.index) == n; }) != _storage->outputs.cend();
+        return std::ranges::find_if(_storage->outputs, [this, &n](const auto& p)
+                                    { return this->get_node(p.index) == n; }) != _storage->outputs.cend();
     }
 
 #pragma endregion
@@ -189,24 +201,18 @@ class technology_network : public mockturtle::klut_network
     signal _create_node(const std::vector<signal>& children, uint32_t literal)
     {
         storage::element_type::node_type node_data;
-        std::copy(children.begin(), children.end(), std::back_inserter(node_data.children));
+        std::ranges::copy(children, std::back_inserter(node_data.children));
         node_data.data[1].h1 = literal;
 
         const auto index = _storage->nodes.size();
         _storage->nodes.push_back(node_data);
 
         /* increase ref-count to children */
-        for (auto c : children)
-        {
-            _storage->nodes[c].data[0].h1++;
-        }
+        std::ranges::for_each(children, [this](const auto& c) { _storage->nodes[c].data[0].h1++; });
 
         set_value(index, 0);
 
-        for (auto const& fn : _events->on_add)
-        {
-            (*fn)(index);
-        }
+        std::ranges::for_each(_events->on_add, [&index](const auto& fn) { (*fn)(index); });
 
         return index;
     }

--- a/include/fiction/networks/views/bfs_topo_view.hpp
+++ b/include/fiction/networks/views/bfs_topo_view.hpp
@@ -10,8 +10,10 @@
 #include <mockturtle/views/fanout_view.hpp>
 #include <mockturtle/views/immutable_view.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <iterator>
 #include <queue>
 #include <unordered_map>
 #include <vector>
@@ -112,8 +114,7 @@ class bfs_topo_view<Ntk, false> : public mockturtle::immutable_view<Ntk>
      */
     uint32_t node_to_index(const node& n) const
     {
-        return static_cast<uint32_t>(
-            std::distance(std::cbegin(topo_order), std::find(std::cbegin(topo_order), std::cend(topo_order), n)));
+        return static_cast<uint32_t>(std::ranges::distance(topo_order.cbegin(), std::ranges::find(topo_order, n)));
     }
 
     /**

--- a/include/fiction/networks/views/mutable_rank_view.hpp
+++ b/include/fiction/networks/views/mutable_rank_view.hpp
@@ -264,13 +264,13 @@ class mutable_rank_view<Ntk, false> : public fiction::static_depth_view<Ntk>
         assert(rank.size() == nodes.size());
         auto sort_rank  = rank;
         auto sort_nodes = nodes;
-        std::sort(sort_rank.begin(), sort_rank.end());
-        std::sort(sort_nodes.begin(), sort_nodes.end());
+        std::ranges::sort(sort_rank);
+        std::ranges::sort(sort_nodes);
         assert(sort_rank == sort_nodes);
 
         // assign new ranks
         rank = nodes;
-        std::for_each(rank.cbegin(), rank.cend(), [this, i = 0u](auto const& n) mutable { rank_pos[n] = i++; });
+        std::ranges::for_each(rank, [this, i = 0u](auto const& n) mutable { rank_pos[n] = i++; });
     }
 
     /**
@@ -381,8 +381,8 @@ class mutable_rank_view<Ntk, false> : public fiction::static_depth_view<Ntk>
 
         auto& rank = ranks[level];
 
-        std::sort(rank.begin(), rank.end(), cmp);
-        std::for_each(rank.cbegin(), rank.cend(), [this, i = 0u](auto const& n) mutable { rank_pos[n] = i++; });
+        std::ranges::sort(rank, cmp);
+        std::ranges::for_each(rank, [this, i = 0u](auto const& n) mutable { rank_pos[n] = i++; });
     }
 
     /**
@@ -469,8 +469,7 @@ class mutable_rank_view<Ntk, false> : public fiction::static_depth_view<Ntk>
         pis.reserve(this->num_pis());
 
         fiction::static_depth_view<Ntk>::foreach_pi([&pis](auto const& pi) { pis.push_back(pi); });
-        std::sort(pis.begin(), pis.end(),
-                  [this](auto const& n1, auto const& n2) { return rank_pos.at(n1) < rank_pos.at(n2); });
+        std::ranges::sort(pis, [this](auto const& n1, auto const& n2) { return rank_pos.at(n1) < rank_pos.at(n2); });
         mockturtle::detail::foreach_element(pis.cbegin(), pis.cend(), std::forward<Fn>(fn));
     }
 
@@ -523,8 +522,7 @@ class mutable_rank_view<Ntk, false> : public fiction::static_depth_view<Ntk>
         pis.reserve(this->num_pis());
 
         fiction::static_depth_view<Ntk>::foreach_ci([&pis](auto const& pi) { pis.push_back(pi); });
-        std::sort(pis.begin(), pis.end(),
-                  [this](auto const& n1, auto const& n2) { return rank_pos.at(n1) < rank_pos.at(n2); });
+        std::ranges::sort(pis, [this](auto const& n1, auto const& n2) { return rank_pos.at(n1) < rank_pos.at(n2); });
         mockturtle::detail::foreach_element(pis.cbegin(), pis.cend(), std::forward<Fn>(fn));
     }
     /**

--- a/include/fiction/networks/virtual_pi_network.hpp
+++ b/include/fiction/networks/virtual_pi_network.hpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <cstdlib>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -124,8 +123,7 @@ class virtual_pi_network : public Ntk
      */
     [[nodiscard]] bool is_virtual_pi(node const& n) const
     {
-        return std::find(v_storage->virtual_inputs.cbegin(), v_storage->virtual_inputs.cend(), n) !=
-               v_storage->virtual_inputs.cend();
+        return std::ranges::find(v_storage->virtual_inputs, n) != v_storage->virtual_inputs.cend();
     }
 
     /**
@@ -166,8 +164,7 @@ class virtual_pi_network : public Ntk
      */
     [[nodiscard]] bool is_virtual_ci(node const& n) const
     {
-        return std::find(v_storage->virtual_inputs.cbegin(), v_storage->virtual_inputs.cend(), n) !=
-               v_storage->virtual_inputs.cend();
+        return std::ranges::find(v_storage->virtual_inputs, n) != v_storage->virtual_inputs.cend();
     }
 
     /**

--- a/include/fiction/networks/virtual_pi_network.hpp
+++ b/include/fiction/networks/virtual_pi_network.hpp
@@ -33,6 +33,8 @@ template <typename Ntk>
 class virtual_pi_network : public Ntk
 {
   public:
+    // name is part of a SFINAE detection idiom used across fiction::traits and cannot be renamed to satisfy
+    // NOLINTNEXTLINE(readability-identifier-naming)
     static constexpr bool is_virtual_network_type = true;
 
     using storage = typename Ntk::storage;

--- a/test/networks/views/static_depth_view.cpp
+++ b/test/networks/views/static_depth_view.cpp
@@ -97,8 +97,7 @@ TEST_CASE("Compute depth and levels for AIG with inverter costs", "[static-depth
     const auto              f4 = aig.create_nand(f2, f3);
     aig.create_po(f4);
 
-    depth_view_params ps;
-    ps.count_complements = true;
+    const depth_view_params ps{.count_complements = true};
     const static_depth_view depth_aig{aig, {}, ps};
     CHECK(depth_aig.depth() == 6);
     CHECK(depth_aig.level(aig.get_node(a)) == 0);


### PR DESCRIPTION
## Summary

Continues the incremental C++20 modernization effort started in #1039 (`include/fiction/utils/`), now applied to `include/fiction/networks/` and its tests.

Scope: the two lowest-connectivity top-level files (`technology_network.hpp`, `virtual_pi_network.hpp`) plus two of the four `networks/views/*.hpp` files that had actual ripe patterns (`bfs_topo_view.hpp`, `mutable_rank_view.hpp`). `edge_color_view.hpp` and `static_depth_view.hpp` were surveyed and contain no `std::algorithm`/hand-rolled-loop patterns worth touching, so they were left untouched.

Beyond `std::ranges`, this module was also surveyed for the other C++20 idioms adopted in #1039 (concepts, defaulted comparisons, designated initializers):
- No `static_assert(std::is_*)` type checks exist anywhere in `include/fiction/networks/` → nothing to convert to concepts
- No hand-written `operator==`/`operator!=` exist in this module → nothing to convert to a defaulted comparison
- `test/networks/` and `test/networks/views/` were checked for `std::algorithm` patterns (none found) and aggregate-initialization opportunities — one was found and converted (`depth_view_params` in `test/networks/views/static_depth_view.cpp`)

## Changes

- `technology_network.hpp`:
  - `std::find_if` → `std::ranges::find_if` in `is_po`
  - `std::copy(...iterators..., std::back_inserter(...))` → `std::ranges::copy` in `_create_node`
  - Two hand-rolled `for` loops in `_create_node` → `std::ranges::for_each`
  - Added direct includes for `kitty::dynamic_truth_table`/`kitty::constructors`/`kitty::operations`, `mockturtle::tree_reduce`, `std::back_inserter`, and `assert` — previously only available transitively (surfaced by Clang-Tidy's `misc-include-cleaner`, which lints the whole file once any line is touched)
- `virtual_pi_network.hpp`:
  - `std::find` → `std::ranges::find` in `is_virtual_pi` and `is_virtual_ci`
  - Removed unused `<cstdlib>` include (`misc-include-cleaner`)
  - Suppressed a pre-existing `readability-identifier-naming` finding on `is_virtual_network_type` (a `static constexpr bool` used as a SFINAE detection idiom across `fiction::traits` and tests — renaming it would be an API-breaking change out of scope for a mechanical modernization PR), surfaced by CI's Clang-Tidy once the file was touched
- `views/bfs_topo_view.hpp`:
  - `std::distance(..., std::find(...))` → `std::ranges::distance(..., std::ranges::find(...))` in `node_to_index`
- `views/mutable_rank_view.hpp`:
  - Several `std::sort`/`std::for_each` calls → `std::ranges::sort`/`std::ranges::for_each` in `set_ranks`, `sort_rank`, `foreach_pi`, and `foreach_ci`
- `test/networks/views/static_depth_view.cpp`:
  - `depth_view_params ps; ps.count_complements = true;` → `const depth_view_params ps{.count_complements = true};`

## Verification

- Rebuilt and ran the corresponding Catch2 test binaries locally — all pass:
  - `test_technology_network` (295 assertions, 20 test cases)
  - `test_virtual_pi_network` (31 assertions, 6 test cases)
  - `test_bfs_topo_view` (26 assertions, 5 test cases)
  - `test_mutable_rank_view` (303 assertions, 25 test cases)
  - `test_static_depth_view` (87 assertions, 9 test cases)
- Ran Clang-Tidy locally against all touched files after each change; fixed the one CI-caught failure (the `is_virtual_network_type` naming finding) and all missing-include-cleaner findings. Remaining local-only warnings are pre-existing version-noise categories cross-checked against CI in #1039 (`cppcoreguidelines-pro-bounds-avoid-unchecked-container-access`, `bugprone-derived-method-shadowing-base-method`, `readability-redundant-typename`) — not enforced under CI's Clang-Tidy version and unrelated to the touched lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)