### PR TITLE
:bug: Fix contour tracing retracing already enclosed operational areas

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3352,6 +3352,12 @@ static const char *__doc_fiction_coord_iterator =
 R"doc(An iterator type that allows to enumerate coordinates in order within
 a boundary.
 
+@note Only `offset::ucoord_t`, `cube::coord_t`, and `siqad::coord_t`
+are supported. This is enforced on the boundary-and-start constructor
+via a `requires` clause rather than on the class itself, so that the
+default constructor (required for `std::semiregular`) remains usable
+for any `CoordinateType`.
+
 Template parameter ``CoordinateType``:
     Type of coordinate to enumerate.)doc";
 
@@ -9214,17 +9220,38 @@ operational domain with multiple islands is investigated.
 
 The function starts at the given starting point and performs flood
 fill to mark all points that are reachable from the starting point
-until it encounters the non-operational edges.
+until it encounters the traced contour.
+
+The flood fill expands over the von Neumann (4-connected)
+neighborhood, while the given contour is a closed 8-connected curve.
+Since a 4-connected path cannot cross an 8-connected closed curve, the
+inference is guaranteed to stay within the area enclosed by the
+contour. Points on the contour itself are marked, but not expanded
+from.
 
 Note that no physical simulation is conducted by this function!
 
 Parameter ``starting_point``:
     Step point at which to start the inference. If `starting_point` is
-    non-operational, this function might invoke undefined behavior.)doc";
+    non-operational, this function might invoke undefined behavior.
+
+Parameter ``contour``:
+    The step points visited by the contour trace that encloses
+    `starting_point`.)doc";
 
 static const char *__doc_fiction_detail_operational_domain_impl_inferred_op_domain =
 R"doc(All the points inferred (assumed) to be operational but not actually
 simulated.)doc";
+
+static const char *__doc_fiction_detail_operational_domain_impl_inferred_operational_parameter_points =
+R"doc(Returns the parameter points that were inferred (assumed) to be
+operational because they are enclosed by a contour traced by
+`contour_tracing`. These points have not been simulated and are,
+therefore, not part of the returned operational domain. They are
+exposed to enable inspection of the enclosure inference.
+
+Returns:
+    The parameter points that have been inferred to be operational.)doc";
 
 static const char *__doc_fiction_detail_operational_domain_impl_input_bdl_wires = R"doc(Input BDL wires.)doc";
 
@@ -9475,6 +9502,21 @@ Returns:
 static const char *__doc_fiction_detail_operational_domain_impl_truth_table = R"doc(The logical specification of the layout.)doc";
 
 static const char *__doc_fiction_detail_operational_domain_impl_values = R"doc(All dimension values.)doc";
+
+static const char *__doc_fiction_detail_operational_domain_impl_von_neumann_neighborhood_2d =
+R"doc(Returns the 2D von Neumann neighborhood of the step point at `sp = (x,
+y)`. The 2D von Neumann neighborhood is the set of all points that are
+adjacent to `(x, y)` in the plane excluding the diagonals. Thereby,
+the 2D von Neumann neighborhood contains up to 4 points as points
+outside of the parameter range are not gathered. The points are
+returned in no particular order.
+
+Parameter ``sp``:
+    Step point to get the 2D von Neumann neighborhood of.
+
+Returns:
+    The 2D von Neumann neighborhood of the step point at `sp = (x,
+    y)`.)doc";
 
 static const char *__doc_fiction_detail_optimize_output_positions =
 R"doc(Utility function that moves outputs from the last row to the previous
@@ -23332,9 +23374,9 @@ static const char *__doc_fmt_formatter_parse = R"doc()doc";
 
 static const char *__doc_fmt_formatter_parse_2 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1105_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1109_8 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1121_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1125_8 = R"doc()doc";
 
 static const char *__doc_fmt_unnamed_struct_at_include_fiction_technology_cell_ports_hpp_295_8 = R"doc()doc";
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -87,6 +87,14 @@ Removed
 
 Fixed
 #####
+- Fixed the enclosure inference of ``operational_domain_contour_tracing``, which had never been active: an
+  inverted guard in ``infer_operational_status_in_enclosing_contour`` left the set of points assumed to be
+  operational by enclosure permanently empty, so every random sample landing in an already traced operational
+  island triggered another trace of the very same contour. Additionally, the inference's flood fill is now
+  bounded by the traced contour and expands over the von Neumann (4-connected) neighborhood instead of the
+  Moore (8-connected) one. Since a 4-connected path cannot cross an 8-connected closed curve, the inference is
+  now guaranteed to stay inside the traced contour and can no longer suppress the tracing of other operational
+  islands
 - Code quality:
     - Fixed several pre-existing ``fmt`` compile-time format-string misuses (passing a runtime string
       as the format-string argument with no substitution args) that were surfaced by the C++20 bump

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -749,6 +749,10 @@ class operational_domain_impl
 
             auto current_contour_point = contour_starting_point;
 
+            // all step points visited by the contour trace; they form a closed 8-connected curve that encloses the
+            // operational area `starting_point` is located in
+            phmap::btree_set<step_point> contour{contour_starting_point};
+
             const auto x = current_contour_point.step_values[0];
             const auto y = current_contour_point.step_values[1];
 
@@ -773,6 +777,8 @@ class operational_domain_impl
                 {
                     backtrack_point       = current_contour_point;
                     current_contour_point = next_point;
+
+                    contour.insert(current_contour_point);
                 }
                 else
                 {
@@ -783,7 +789,7 @@ class operational_domain_impl
                 next_point           = next_clockwise_point(current_neighborhood, backtrack_point);
             }
 
-            infer_operational_status_in_enclosing_contour(starting_point);
+            infer_operational_status_in_enclosing_contour(starting_point, contour);
         }
 
         log_stats();
@@ -916,6 +922,23 @@ class operational_domain_impl
             });
 
         return suitable_params_domain;
+    }
+    /**
+     * Returns the parameter points that were inferred (assumed) to be operational because they are enclosed by a
+     * contour traced by `contour_tracing`. These points have not been simulated and are, therefore, not part of the
+     * returned operational domain. They are exposed to enable inspection of the enclosure inference.
+     *
+     * @return The parameter points that have been inferred to be operational.
+     */
+    [[nodiscard]] std::vector<parameter_point> inferred_operational_parameter_points() const noexcept
+    {
+        std::vector<parameter_point> parameter_points{};
+        parameter_points.reserve(inferred_op_domain.size());
+
+        std::transform(inferred_op_domain.cbegin(), inferred_op_domain.cend(), std::back_inserter(parameter_points),
+                       [this](const auto& sp) { return to_parameter_point(sp); });
+
+        return parameter_points;
     }
 
   private:
@@ -1517,7 +1540,61 @@ class operational_domain_impl
         }
 
         return neighbors;
-    };
+    }
+    /**
+     * Returns the 2D von Neumann neighborhood of the step point at `sp = (x, y)`. The 2D von Neumann neighborhood is
+     * the set of all points that are adjacent to `(x, y)` in the plane excluding the diagonals. Thereby, the 2D von
+     * Neumann neighborhood contains up to 4 points as points outside of the parameter range are not gathered. The
+     * points are returned in no particular order.
+     *
+     * @param sp Step point to get the 2D von Neumann neighborhood of.
+     * @return The 2D von Neumann neighborhood of the step point at `sp = (x, y)`.
+     */
+    [[nodiscard]] std::vector<step_point> von_neumann_neighborhood_2d(const step_point& sp) const noexcept
+    {
+        assert(num_dimensions == 2 && "2D von Neumann neighborhood is only supported for 2 dimensions");
+        assert(sp.step_values.size() == 2 && "Given step point must have 2 dimensions");
+
+        std::vector<step_point> neighbors{};
+        neighbors.reserve(4);
+
+        const auto emplace = [&neighbors](const auto x, const auto y) noexcept
+        { neighbors.emplace_back(std::vector<std::size_t>{x, y}); };
+
+        const auto x = sp.step_values[0];
+        const auto y = sp.step_values[1];
+
+        const auto num_x_indices = indices[0].size();
+        const auto num_y_indices = indices[1].size();
+
+        const auto decr_x = (x > 0) ? x - 1 : x;
+        const auto incr_x = (x + 1 < num_x_indices) ? x + 1 : x;
+        const auto decr_y = (y > 0) ? y - 1 : y;
+        const auto incr_y = (y + 1 < num_y_indices) ? y + 1 : y;
+
+        // right
+        if (x != incr_x)
+        {
+            emplace(incr_x, y);
+        }
+        // down
+        if (y != decr_y)
+        {
+            emplace(x, decr_y);
+        }
+        // left
+        if (x != decr_x)
+        {
+            emplace(decr_x, y);
+        }
+        // up
+        if (y != incr_y)
+        {
+            emplace(x, incr_y);
+        }
+
+        return neighbors;
+    }
     /**
      * Returns the 3D Moore neighborhood of the step point at `sp = (x, y, z)`. The 3D Moore neighborhood is the set of
      * all points that are adjacent to `(x, y, z)` in the 3D space including the diagonals. Thereby, the 3D Moore
@@ -1587,26 +1664,53 @@ class operational_domain_impl
      * e.g., contour tracing if an operational domain with multiple islands is investigated.
      *
      * The function starts at the given starting point and performs flood fill to mark all points that are reachable
-     * from the starting point until it encounters the non-operational edges.
+     * from the starting point until it encounters the traced contour.
+     *
+     * The flood fill expands over the von Neumann (4-connected) neighborhood, while the given contour is a closed
+     * 8-connected curve. Since a 4-connected path cannot cross an 8-connected closed curve, the inference is
+     * guaranteed to stay within the area enclosed by the contour. Points on the contour itself are marked, but not
+     * expanded from.
      *
      * Note that no physical simulation is conducted by this function!
      *
      * @param starting_point Step point at which to start the inference. If `starting_point` is non-operational, this
      * function might invoke undefined behavior.
+     * @param contour The step points visited by the contour trace that encloses `starting_point`.
      */
-    void infer_operational_status_in_enclosing_contour(const step_point& starting_point) noexcept
+    void infer_operational_status_in_enclosing_contour(const step_point&                   starting_point,
+                                                       const phmap::btree_set<step_point>& contour) noexcept
     {
         assert(num_dimensions == 2 && "This function is only supported for two dimensions");
         assert(is_step_point_operational(starting_point) == operational_status::OPERATIONAL &&
                "starting_point must be within the operational domain");
 
+        // if the starting point has already been inferred as operational, this area has been covered before
+        if (is_step_point_inferred_operational(starting_point))
+        {
+            return;
+        }
+
         // a queue of (x, y) dimension step points to be marked as inferred operational
         std::queue<step_point> queue{};
 
-        // a utility function that adds the adjacent points to the queue for further evaluation
-        const auto queue_next_points = [this, &queue](const step_point& sp) noexcept
+        // mark the starting point as inferred operational and use it to seed the flood fill
+        inferred_op_domain.insert(starting_point);
+        queue.push(starting_point);
+
+        // for each point in the queue
+        while (!queue.empty())
         {
-            for (const auto& m : moore_neighborhood_2d(sp))
+            // fetch the step point and remove it from the queue
+            const auto sp = queue.front();
+            queue.pop();
+
+            // the contour is the boundary of the enclosed area; do not expand beyond it
+            if (contour.count(sp) > 0)
+            {
+                continue;
+            }
+
+            for (const auto& m : von_neumann_neighborhood_2d(sp))
             {
                 // if the point has already been inferred as operational, continue with the next
                 if (is_step_point_inferred_operational(m))
@@ -1626,40 +1730,9 @@ class operational_domain_impl
                 }
 
                 // otherwise, it is either found operational or can be inferred as such
-                queue.push(m);
                 inferred_op_domain.insert(m);
+                queue.push(m);
             }
-        };
-
-        // if the starting point has not already been inferred as operational
-        if (is_step_point_inferred_operational(starting_point))
-        {
-            // mark the starting point as inferred operational
-            inferred_op_domain.insert(starting_point);
-
-            // add the starting point's neighbors to the queue
-            queue_next_points(starting_point);
-        }
-
-        // for each point in the queue
-        while (!queue.empty())
-        {
-            // fetch the step point and remove it from the queue
-            const auto sp = queue.front();
-            queue.pop();
-
-            // if the point is known to be non-operational, continue with the next
-            if (const auto operational_status = op_domain.contains(to_parameter_point(sp));
-                operational_status.has_value())
-            {
-                if (std::get<0>(operational_status.value()) == operational_status::NON_OPERATIONAL)
-                {
-                    continue;
-                }
-            }
-
-            // otherwise (operational or unknown), queue its neighbors
-            queue_next_points(sp);
         }
     }
     /**

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -359,8 +359,8 @@ struct operational_domain_params
      * dimension, the second dimension is the y dimension, etc.
      */
     std::vector<operational_domain_value_range> sweep_dimensions{
-        operational_domain_value_range{sweep_parameter::EPSILON_R, 1.0, 10.0, 0.1},
-        operational_domain_value_range{sweep_parameter::LAMBDA_TF, 1.0, 10.0, 0.1}};
+        operational_domain_value_range{.dimension = sweep_parameter::EPSILON_R, .min = 1.0, .max = 10.0, .step = 0.1},
+        operational_domain_value_range{.dimension = sweep_parameter::LAMBDA_TF, .min = 1.0, .max = 10.0, .step = 0.1}};
 };
 /**
  * Statistics for the operational domain computation. The statistics are used across the different operational domain
@@ -889,7 +889,9 @@ class operational_domain_impl
                     else if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
                     {
                         // perform a heuristic simulation
-                        const quicksim_params qs_params{simulation_parameters, 500, 0.6};
+                        const quicksim_params qs_params{.simulation_parameters = simulation_parameters,
+                                                        .iteration_steps       = 500,
+                                                        .alpha                 = 0.6};
 
                         if (const auto result = quicksim(lyt, qs_params); result.has_value())
                         {
@@ -1231,7 +1233,7 @@ class operational_domain_impl
         if constexpr (std::is_same_v<OpDomain, critical_temperature_domain>)
         {
             const auto ct = critical_temperature_gate_based(
-                layout, truth_table, critical_temperature_params{op_params_set_dimension_values});
+                layout, truth_table, critical_temperature_params{.operational_params = op_params_set_dimension_values});
 
             return operational(ct);
         }
@@ -1646,9 +1648,8 @@ class operational_domain_impl
                     const int64_t dz = static_cast<int64_t>(z) + z_offset;
 
                     // check if the new coordinate is within the bounds
-                    if ((dx >= 0 && dx < static_cast<int64_t>(num_x_indices)) &&
-                        (dy >= 0 && dy < static_cast<int64_t>(num_y_indices)) &&
-                        (dz >= 0 && dz < static_cast<int64_t>(num_z_indices)))
+                    if ((dx >= 0 && std::cmp_less(dx, num_x_indices)) &&
+                        (dy >= 0 && std::cmp_less(dy, num_y_indices)) && (dz >= 0 && std::cmp_less(dz, num_z_indices)))
                     {
                         emplace(static_cast<uint64_t>(dx), static_cast<uint64_t>(dy), static_cast<uint64_t>(dz));
                     }

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -1561,11 +1561,13 @@ class operational_domain_impl
         const auto emplace = [&neighbors](const auto x, const auto y) noexcept
         { neighbors.emplace_back(std::vector<std::size_t>{x, y}); };
 
-        const auto x = sp.step_values[0];
-        const auto y = sp.step_values[1];
+        // both containers hold exactly two elements in the 2-dimensional case asserted above, so the first and the
+        // last element are the x and the y dimension, respectively
+        const auto x = sp.step_values.front();
+        const auto y = sp.step_values.back();
 
-        const auto num_x_indices = indices[0].size();
-        const auto num_y_indices = indices[1].size();
+        const auto num_x_indices = indices.front().size();
+        const auto num_y_indices = indices.back().size();
 
         const auto decr_x = (x > 0) ? x - 1 : x;
         const auto incr_x = (x + 1 < num_x_indices) ? x + 1 : x;
@@ -1677,6 +1679,7 @@ class operational_domain_impl
      * function might invoke undefined behavior.
      * @param contour The step points visited by the contour trace that encloses `starting_point`.
      */
+    // NOLINTNEXTLINE(bugprone-exception-escape): only allocation can throw, as in the calling `contour_tracing`
     void infer_operational_status_in_enclosing_contour(const step_point&                   starting_point,
                                                        const phmap::btree_set<step_point>& contour) noexcept
     {

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -163,18 +163,18 @@ TEST_CASE("Error handling of operational domain algorithms", "[operational-domai
         zero_dimensional_params.sweep_dimensions = {};
 
         // 1-dimensional
-        one_dimensional_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}};
+        one_dimensional_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R}};
 
         // 3-dimensional
-        three_dimensional_params.sweep_dimensions = {{sweep_parameter::EPSILON_R},
-                                                     {sweep_parameter::LAMBDA_TF},
-                                                     {sweep_parameter::MU_MINUS}};
+        three_dimensional_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R},
+                                                     {.dimension = sweep_parameter::LAMBDA_TF},
+                                                     {.dimension = sweep_parameter::MU_MINUS}};
 
         // 4-dimensional
-        four_dimensional_params.sweep_dimensions = {{sweep_parameter::EPSILON_R},
-                                                    {sweep_parameter::LAMBDA_TF},
-                                                    {sweep_parameter::MU_MINUS},
-                                                    {sweep_parameter::EPSILON_R}};
+        four_dimensional_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R},
+                                                    {.dimension = sweep_parameter::LAMBDA_TF},
+                                                    {.dimension = sweep_parameter::MU_MINUS},
+                                                    {.dimension = sweep_parameter::EPSILON_R}};
 
         SECTION("flood_fill")
         {
@@ -206,21 +206,22 @@ TEST_CASE("Error handling of operational domain algorithms", "[operational-domai
         SECTION("min/max mismatch")
         {
             // 1-dimensional with invalid min/max on 1st dimension
-            invalid_params_1.sweep_dimensions         = {{sweep_parameter::EPSILON_R}};
+            invalid_params_1.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R}};
             invalid_params_1.sweep_dimensions[0].min  = 10.0;
             invalid_params_1.sweep_dimensions[0].max  = 1.0;
             invalid_params_1.sweep_dimensions[0].step = 0.1;
 
             // 2-dimensional with invalid min/max on 2nd dimension
-            invalid_params_2.sweep_dimensions         = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+            invalid_params_2.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF}};
             invalid_params_2.sweep_dimensions[1].min  = 5.5;
             invalid_params_2.sweep_dimensions[1].max  = 5.4;
             invalid_params_2.sweep_dimensions[1].step = 0.1;
 
             // 3-dimensional with invalid min/max on 3rd dimension
-            invalid_params_3.sweep_dimensions         = {{sweep_parameter::EPSILON_R},
-                                                         {sweep_parameter::LAMBDA_TF},
-                                                         {sweep_parameter::MU_MINUS}};
+            invalid_params_3.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF},
+                                                         {.dimension = sweep_parameter::MU_MINUS}};
             invalid_params_3.sweep_dimensions[2].min  = -0.4;
             invalid_params_3.sweep_dimensions[2].max  = -0.5;
             invalid_params_3.sweep_dimensions[2].step = 0.01;
@@ -253,21 +254,22 @@ TEST_CASE("Error handling of operational domain algorithms", "[operational-domai
         SECTION("negative step size")
         {
             // 1-dimensional with negative step size on 1st dimension
-            invalid_params_1.sweep_dimensions         = {{sweep_parameter::EPSILON_R}};
+            invalid_params_1.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R}};
             invalid_params_1.sweep_dimensions[0].min  = 1.0;
             invalid_params_1.sweep_dimensions[0].max  = 10.0;
             invalid_params_1.sweep_dimensions[0].step = -0.5;
 
             // 2-dimensional with negative step size on 2nd dimension
-            invalid_params_2.sweep_dimensions         = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+            invalid_params_2.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF}};
             invalid_params_2.sweep_dimensions[1].min  = 5.5;
             invalid_params_2.sweep_dimensions[1].max  = 5.6;
             invalid_params_2.sweep_dimensions[1].step = -0.1;
 
             // 3-dimensional with negative step size on 3rd dimension
-            invalid_params_3.sweep_dimensions         = {{sweep_parameter::EPSILON_R},
-                                                         {sweep_parameter::LAMBDA_TF},
-                                                         {sweep_parameter::MU_MINUS}};
+            invalid_params_3.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF},
+                                                         {.dimension = sweep_parameter::MU_MINUS}};
             invalid_params_3.sweep_dimensions[2].min  = -0.4;
             invalid_params_3.sweep_dimensions[2].max  = -0.5;
             invalid_params_3.sweep_dimensions[2].step = -0.01;
@@ -307,8 +309,8 @@ TEST_CASE("SiQAD OR gate", "[operational-domain]")
 
     operational_domain_params op_domain_params{};
 
-    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R, 7, 8, 0.01},
-                                         {sweep_parameter::LAMBDA_TF, 5.5, 6, 0.01}};
+    op_domain_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 7, .max = 8, .step = 0.01},
+                                         {.dimension = sweep_parameter::LAMBDA_TF, .min = 5.5, .max = 6, .step = 0.01}};
 
     op_domain_params.operational_params.simulation_parameters.mu_minus                                        = -0.28;
     op_domain_params.operational_params.input_bdl_iterator_params.bdl_wire_params.threshold_bdl_interdistance = 1.5;
@@ -350,7 +352,8 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+    op_domain_params.sweep_dimensions                         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                                 {.dimension = sweep_parameter::LAMBDA_TF}};
 
     CHECK(op_domain_params.sweep_dimensions[0].dimension == sweep_parameter::EPSILON_R);
     CHECK(op_domain_params.sweep_dimensions[1].dimension == sweep_parameter::LAMBDA_TF);
@@ -418,8 +421,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.32, -0.32, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.32,
+                                                                            .max       = -0.32,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -460,8 +465,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.32, -0.32, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.32,
+                                                                            .max       = -0.32,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -502,8 +509,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.32, -0.32, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.32,
+                                                                            .max       = -0.32,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -660,8 +669,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.35, -0.29, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.35,
+                                                                            .max       = -0.29,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -702,8 +713,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.35, -0.29, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.35,
+                                                                            .max       = -0.29,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -744,8 +757,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.35, -0.29, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.35,
+                                                                            .max       = -0.29,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -820,8 +835,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.14, -0.10, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.14,
+                                                                            .max       = -0.10,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -862,8 +879,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.14, -0.10, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.14,
+                                                                            .max       = -0.10,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -904,8 +923,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.14, -0.10, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.14,
+                                                                            .max       = -0.10,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -1171,8 +1192,9 @@ TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domai
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.1, 6.0, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.5, 5.4, 0.1}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.1, .max = 6.0, .step = 0.1},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.5, .max = 5.4, .step = 0.1}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1288,8 +1310,9 @@ TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinat
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.1, 6.0, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.5, 5.4, 0.1}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.1, .max = 6.0, .step = 0.1},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.5, .max = 5.4, .step = 0.1}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1373,8 +1396,9 @@ TEMPLATE_TEST_CASE("AND gate on the H-Si(111)-1x1 surface", "[operational-domain
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.60, 5.61, 0.01},
-                                                                 {sweep_parameter::LAMBDA_TF, 5.0, 5.01, 0.01}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.60, .max = 5.61, .step = 0.01},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 5.0, .max = 5.01, .step = 0.01}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1462,8 +1486,9 @@ TEMPLATE_TEST_CASE("AND gate with Bestagon shape and kink states at default phys
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 4.0, 6.0, 0.4},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.0, 6.0, 0.4}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 4.0, .max = 6.0, .step = 0.4},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.0, .max = 6.0, .step = 0.4}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1508,8 +1533,9 @@ TEMPLATE_TEST_CASE("Grid search to determine the operational domain. The operati
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 4.0, 6.0, 0.4},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.0, 6.0, 0.4}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 4.0, .max = 6.0, .step = 0.4},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.0, .max = 6.0, .step = 0.4}};
 
     op_domain_params.operational_params.op_condition = is_operational_params::operational_condition::REJECT_KINKS;
 
@@ -1592,8 +1618,9 @@ TEST_CASE("Bestagon AND gate operational domain and temperature computation, usi
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.6, 5.8, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.9, 5.1, 0.1}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.6, .max = 5.8, .step = 0.1},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.9, .max = 5.1, .step = 0.1}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1618,8 +1645,9 @@ TEST_CASE("Bestagon AND gate operational domain and temperature computation, usi
     }
     SECTION("random_sampling in non-operational regime")
     {
-        op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R, 5.0, 5.2, 0.1},
-                                             {sweep_parameter::LAMBDA_TF, 4.9, 5.1, 0.1}};
+        op_domain_params.sweep_dimensions = {
+            {.dimension = sweep_parameter::EPSILON_R, .min = 5.0, .max = 5.2, .step = 0.1},
+            {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.9, .max = 5.1, .step = 0.1}};
 
         const auto op_domain = critical_temperature_domain_random_sampling(lyt, std::vector{create_and_tt()}, 10,
                                                                            op_domain_params, &op_domain_stats);
@@ -1638,8 +1666,9 @@ TEST_CASE("Bestagon AND gate operational domain and temperature computation, usi
     }
     SECTION("flood_fill")
     {
-        op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R, 5.6, 5.8, 0.1},
-                                             {sweep_parameter::LAMBDA_TF, 4.9, 5.1, 0.1}};
+        op_domain_params.sweep_dimensions = {
+            {.dimension = sweep_parameter::EPSILON_R, .min = 5.6, .max = 5.8, .step = 0.1},
+            {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.9, .max = 5.1, .step = 0.1}};
 
         const auto op_domain = critical_temperature_domain_flood_fill(lyt, std::vector{create_and_tt()}, 1,
                                                                       op_domain_params, &op_domain_stats);
@@ -1677,8 +1706,8 @@ TEST_CASE("Two BDL pair wire with degeneracy for input 1", "[operational-domain]
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 1, 10, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 1, 10, 0.1}};
+    op_domain_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 1, .max = 10, .step = 0.1},
+                                         {.dimension = sweep_parameter::LAMBDA_TF, .min = 1, .max = 10, .step = 0.1}};
 
     SECTION("grid search, input is set via the distance of the perturbers")
     {

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -1057,6 +1057,90 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
     }
 }
 
+TEST_CASE("Contour tracing does not retrace an already enclosed area", "[operational-domain]")
+{
+    using layout = sidb_cell_clk_lyt_siqad;
+
+    layout lyt{{24, 0}, "BDL wire"};
+
+    lyt.assign_cell_type({0, 0, 0}, sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type({3, 0, 0}, sidb_technology::cell_type::INPUT);
+
+    lyt.assign_cell_type({6, 0, 0}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({8, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    lyt.assign_cell_type({12, 0, 0}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({14, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    lyt.assign_cell_type({18, 0, 0}, sidb_technology::cell_type::OUTPUT);
+    lyt.assign_cell_type({20, 0, 0}, sidb_technology::cell_type::OUTPUT);
+
+    // output perturber
+    lyt.assign_cell_type({24, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    const sidb_100_cell_clk_lyt_siqad lat{lyt};
+
+    sidb_simulation_parameters sim_params{};
+    sim_params.base = 2;
+
+    operational_domain_params op_domain_params{};
+    op_domain_params.operational_params.simulation_parameters = sim_params;
+    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+
+    // 16 x 16 steps; the operational area is a single connected island of 80 parameter points
+    op_domain_params.sweep_dimensions[0].min  = 0.5;
+    op_domain_params.sweep_dimensions[0].max  = 4.25;
+    op_domain_params.sweep_dimensions[0].step = 0.25;
+
+    op_domain_params.sweep_dimensions[1].min  = 0.5;
+    op_domain_params.sweep_dimensions[1].max  = 4.25;
+    op_domain_params.sweep_dimensions[1].step = 0.25;
+
+    // ground truth to compare the contour tracing results against
+    const auto grid_search_domain = operational_domain_grid_search(lat, std::vector{create_id_tt()}, op_domain_params);
+
+    // the random samples are drawn from an unseeded generator; repeat to make the assertions meaningful
+    for (auto i = 0; i < 5; ++i)
+    {
+        operational_domain_stats op_domain_stats{};
+
+        detail::operational_domain_impl<sidb_100_cell_clk_lyt_siqad, tt, operational_domain> impl{
+            lat, std::vector{create_id_tt()}, op_domain_params, op_domain_stats};
+
+        const auto op_domain = impl.contour_tracing(50);
+
+        const auto inferred_points = impl.inferred_operational_parameter_points();
+
+        // the contour must have been traced at all
+        REQUIRE(op_domain_stats.num_operational_parameter_combinations > 0);
+
+        // once a contour has been traced, the area it encloses must be marked as inferred operational so that further
+        // samples landing inside it do not trigger another trace of the very same contour
+        CHECK(!inferred_points.empty());
+
+        // the inference must not leak out of the traced contour, i.e., it must never assume a non-operational
+        // parameter point to be operational
+        for (const auto& pp : inferred_points)
+        {
+            const auto ground_truth = grid_search_domain.contains(pp);
+
+            REQUIRE(ground_truth.has_value());
+            CHECK(std::get<0>(ground_truth.value()) == operational_status::OPERATIONAL);
+        }
+
+        // inferred points are never added to the operational domain, so every reported status must match the ground
+        // truth
+        op_domain.for_each(
+            [&grid_search_domain](const auto& coord, const auto& op_value)
+            {
+                const auto ground_truth = grid_search_domain.contains(coord);
+
+                REQUIRE(ground_truth.has_value());
+                CHECK(std::get<0>(op_value) == std::get<0>(ground_truth.value()));
+            });
+    }
+}
+
 TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
 {
     using layout = sidb_cell_clk_lyt_siqad;

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -1085,16 +1085,10 @@ TEST_CASE("Contour tracing does not retrace an already enclosed area", "[operati
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
-
     // 16 x 16 steps; the operational area is a single connected island of 80 parameter points
-    op_domain_params.sweep_dimensions[0].min  = 0.5;
-    op_domain_params.sweep_dimensions[0].max  = 4.25;
-    op_domain_params.sweep_dimensions[0].step = 0.25;
-
-    op_domain_params.sweep_dimensions[1].min  = 0.5;
-    op_domain_params.sweep_dimensions[1].max  = 4.25;
-    op_domain_params.sweep_dimensions[1].step = 0.25;
+    op_domain_params.sweep_dimensions = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 0.5, .max = 4.25, .step = 0.25},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 0.5, .max = 4.25, .step = 0.25}};
 
     // ground truth to compare the contour tracing results against
     const auto grid_search_domain = operational_domain_grid_search(lat, std::vector{create_id_tt()}, op_domain_params);
@@ -1125,7 +1119,12 @@ TEST_CASE("Contour tracing does not retrace an already enclosed area", "[operati
             const auto ground_truth = grid_search_domain.contains(pp);
 
             REQUIRE(ground_truth.has_value());
-            CHECK(std::get<0>(ground_truth.value()) == operational_status::OPERATIONAL);
+
+            // the `REQUIRE` above already aborts on an empty optional, but the static analyzer cannot see that
+            if (ground_truth.has_value())
+            {
+                CHECK(std::get<0>(*ground_truth) == operational_status::OPERATIONAL);
+            }
         }
 
         // inferred points are never added to the operational domain, so every reported status must match the ground


### PR DESCRIPTION
## Description

`operational_domain_contour_tracing` keeps a set of points that are *assumed* operational because they are enclosed by an already traced contour (`inferred_op_domain`), so that further random samples landing inside that island are skipped instead of re-tracing the very same contour. **That optimization has never worked.**

### The bug

`infer_operational_status_in_enclosing_contour` guarded its only queue-seeding block with a condition inverted relative to its own comment:

```cpp
// if the starting point has not already been inferred as operational
if (is_step_point_inferred_operational(starting_point))   // <-- missing '!'
{
    inferred_op_domain.insert(starting_point);
    queue_next_points(starting_point);
}
```

On the first call `inferred_op_domain` is empty, so the predicate is false, the block is skipped, and the BFS loop below it never runs — nothing is ever inserted. Because nothing is ever inserted, the predicate stays false on every subsequent call, too. `inferred_op_domain` is permanently empty and the skip check in `contour_tracing` always returns `false`, so every random sample that lands in an operational island re-traces its contour, which is visible in operational domain plots as repeated paths from random samples out to the edges.

`git log -S` shows the negated form never existed; the line has been this way since it was introduced in #493.

### Why the one-character fix is not enough

Restoring the `!` revives a flood fill that expands over the **Moore (8-connected)** neighborhood and only stops at points already simulated as non-operational. Moore-neighbor tracing does not probe every outside neighbor of every contour point, and an 8-connected flood can in any case slip diagonally through an 8-connected background ring. The fill could therefore leak out of the traced island and mark unrelated regions as inferred-operational, suppressing the tracing of genuine other islands — turning a missed optimization into missing results.

### The fix

- `contour_tracing` now collects the step points visited by the trace and passes them to the inference. These form a closed 8-connected curve.
- `infer_operational_status_in_enclosing_contour` takes that contour, stops at it (contour points are marked but not expanded from), and expands over the **von Neumann (4-connected)** neighborhood. A 4-connected path cannot cross an 8-connected closed curve, so containment is guaranteed. Under-filling a diagonally-pinched region is possible but harmless — it only forgoes some of the optimization, it never suppresses a needed trace.
- Adds `von_neumann_neighborhood_2d`, mirroring the existing `moore_neighborhood_2d` (including its range clipping), and an `inferred_operational_parameter_points()` accessor that exposes the inference result for inspection.

Note that the existing stats (`num_evaluated_parameter_combinations`, `num_simulator_invocations`) count only *uncached* work, so they barely separate the two behaviors — the wasted work was repeated traversal of already-simulated points, not repeated simulation. The new test therefore asserts the invariant directly.

## Testing

New test case `Contour tracing does not retrace an already enclosed area` (`[operational-domain]`) runs contour tracing on the 16x16 BDL wire instance (80 operational of 256 points, one island), five times to cover the unseeded sampling, and asserts that

1. the enclosure set is non-empty after a contour has been traced — this fails on `main` (`inferred_points.empty()` is always `true`), and
2. no inferred parameter point is one that a grid search over the identical parameters finds non-operational — this guards against a fill leaking out of the contour.

Verified: the test fails against the pre-fix logic and passes with the fix. `test_operational_domain`, `test_operational_domain_ratio`, `test_write_operational_domain`, and `test_is_operational` all pass, repeated several times for RNG stability.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. (No binding changes needed — all touched code lives in `fiction::detail`; the mkdoc docstrings are regenerated by CI.)
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fk99nQ4s3wrXbHYHfp6Wj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved operational-domain contour tracing to correctly identify enclosed regions.
  - Prevented duplicate tracing and unintended expansion across diagonal contour boundaries.
  - Preserved discovery of separate operational regions through bounded, 4-connected flood fill.

- **New Features**
  - Added access to inferred operational parameter points without modifying the simulated domain.

- **Tests**
  - Added regression coverage comparing contour-tracing results with grid-search ground truth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->