### PR TITLE
:zap: Parallelize flood fill

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3352,6 +3352,12 @@ static const char *__doc_fiction_coord_iterator =
 R"doc(An iterator type that allows to enumerate coordinates in order within
 a boundary.
 
+@note Only `offset::ucoord_t`, `cube::coord_t`, and `siqad::coord_t`
+are supported. This is enforced on the boundary-and-start constructor
+via a `requires` clause rather than on the class itself, so that the
+default constructor (required for `std::semiregular`) remains usable
+for any `CoordinateType`.
+
 Template parameter ``CoordinateType``:
     Type of coordinate to enumerate.)doc";
 
@@ -9214,17 +9220,38 @@ operational domain with multiple islands is investigated.
 
 The function starts at the given starting point and performs flood
 fill to mark all points that are reachable from the starting point
-until it encounters the non-operational edges.
+until it encounters the traced contour.
+
+The flood fill expands over the von Neumann (4-connected)
+neighborhood, while the given contour is a closed 8-connected curve.
+Since a 4-connected path cannot cross an 8-connected closed curve, the
+inference is guaranteed to stay within the area enclosed by the
+contour. Points on the contour itself are marked, but not expanded
+from.
 
 Note that no physical simulation is conducted by this function!
 
 Parameter ``starting_point``:
     Step point at which to start the inference. If `starting_point` is
-    non-operational, this function might invoke undefined behavior.)doc";
+    non-operational, this function might invoke undefined behavior.
+
+Parameter ``contour``:
+    The step points visited by the contour trace that encloses
+    `starting_point`.)doc";
 
 static const char *__doc_fiction_detail_operational_domain_impl_inferred_op_domain =
 R"doc(All the points inferred (assumed) to be operational but not actually
 simulated.)doc";
+
+static const char *__doc_fiction_detail_operational_domain_impl_inferred_operational_parameter_points =
+R"doc(Returns the parameter points that were inferred (assumed) to be
+operational because they are enclosed by a contour traced by
+`contour_tracing`. These points have not been simulated and are,
+therefore, not part of the returned operational domain. They are
+exposed to enable inspection of the enclosure inference.
+
+Returns:
+    The parameter points that have been inferred to be operational.)doc";
 
 static const char *__doc_fiction_detail_operational_domain_impl_input_bdl_wires = R"doc(Input BDL wires.)doc";
 
@@ -9475,6 +9502,21 @@ Returns:
 static const char *__doc_fiction_detail_operational_domain_impl_truth_table = R"doc(The logical specification of the layout.)doc";
 
 static const char *__doc_fiction_detail_operational_domain_impl_values = R"doc(All dimension values.)doc";
+
+static const char *__doc_fiction_detail_operational_domain_impl_von_neumann_neighborhood_2d =
+R"doc(Returns the 2D von Neumann neighborhood of the step point at `sp = (x,
+y)`. The 2D von Neumann neighborhood is the set of all points that are
+adjacent to `(x, y)` in the plane excluding the diagonals. Thereby,
+the 2D von Neumann neighborhood contains up to 4 points as points
+outside of the parameter range are not gathered. The points are
+returned in no particular order.
+
+Parameter ``sp``:
+    Step point to get the 2D von Neumann neighborhood of.
+
+Returns:
+    The 2D von Neumann neighborhood of the step point at `sp = (x,
+    y)`.)doc";
 
 static const char *__doc_fiction_detail_optimize_output_positions =
 R"doc(Utility function that moves outputs from the last row to the previous
@@ -23332,9 +23374,9 @@ static const char *__doc_fmt_formatter_parse = R"doc()doc";
 
 static const char *__doc_fmt_formatter_parse_2 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1105_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1109_8 = R"doc()doc";
 
-static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1121_8 = R"doc()doc";
+static const char *__doc_fmt_unnamed_struct_at_include_fiction_layouts_coordinates_hpp_1125_8 = R"doc()doc";
 
 static const char *__doc_fmt_unnamed_struct_at_include_fiction_technology_cell_ports_hpp_295_8 = R"doc()doc";
 

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -9162,6 +9162,13 @@ random non-operational points as well as all operational points that
 are reachable via flood fill from the found operational points plus a
 one pixel wide border around the domain.
 
+Both phases are parallelized. The flood fill itself uses a pool of
+worker threads that share a single work queue, since the points to
+explore are only discovered as the exploration proceeds. Each step
+point is scheduled at most once, so no parameter point is simulated
+twice. The result does not depend on the order in which the points are
+explored and is, therefore, independent of the thread scheduling.
+
 Parameter ``samples``:
     Maximum number of random samples to be taken before flood fill.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,15 +13,18 @@ Changed
 - Parallelized ``operational_domain_flood_fill``. Previously, only the initial random sampling ran in
   parallel while the flood fill itself explored the parameter space on a single thread, which could make
   it slower in wall-clock time than a grid search on machines with many cores despite needing far fewer
-  simulations. The exploration now runs on a pool of ``std::jthread`` workers that share a single work
-  queue, using ``std::stop_source``/``std::stop_token`` and the C++20
-  ``std::condition_variable_any::wait`` stop-token overload for shutdown. One mutex guards the queue, the
+  simulations. The exploration now runs on a pool of worker threads that share a single work queue. One
+  mutex guards the queue, the
   set of already-scheduled points, and the active-worker count, while the physical simulation itself runs
   without any lock held. Tracking scheduled points also removes a pre-existing inefficiency of the serial
   version, in which the same parameter point could be enqueued repeatedly. The result is independent of
-  the order of exploration and therefore unchanged by the parallelization. Also modernized
-  ``simulate_operational_status_in_parallel`` to ``std::jthread`` and ``std::ranges``, and added the
-  ``std::shuffle`` that flood fill was missing for load balancing across its sampling threads
+  the order of exploration and therefore unchanged by the parallelization. Also added the
+  ``std::shuffle`` that flood fill was missing for load balancing across its sampling threads.
+  ``std::jthread`` with ``std::stop_source``/``std::stop_token`` and the C++20
+  ``std::condition_variable_any::wait`` stop-token overload were used at first and then reverted:
+  Apple's ``libc++`` still gates ``<stop_token>`` and ``std::jthread`` behind ``-fexperimental-library``,
+  so both macOS CI jobs failed to compile them. A single portable implementation was preferred over a
+  feature-detected second copy of the termination logic
 - Code quality:
     - Adopted C++20 idioms across ``include/fiction/utils/`` as the first step of an incremental,
       module-by-module modernization: ``std::ranges`` algorithms (``std::ranges::for_each``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -87,6 +87,14 @@ Removed
 
 Fixed
 #####
+- Fixed the enclosure inference of ``operational_domain_contour_tracing``, which had never been active: an
+  inverted guard in ``infer_operational_status_in_enclosing_contour`` left the set of points assumed to be
+  operational by enclosure permanently empty, so every random sample landing in an already traced operational
+  island triggered another trace of the very same contour. Additionally, the inference's flood fill is now
+  bounded by the traced contour and expands over the von Neumann (4-connected) neighborhood instead of the
+  Moore (8-connected) one. Since a 4-connected path cannot cross an 8-connected closed curve, the inference is
+  now guaranteed to stay inside the traced contour and can no longer suppress the tracing of other operational
+  islands
 - Code quality:
     - Fixed several pre-existing ``fmt`` compile-time format-string misuses (passing a runtime string
       as the format-string argument with no substitution args) that were surfaced by the C++20 bump

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,18 @@ Unreleased
 
 Changed
 #######
+- Parallelized ``operational_domain_flood_fill``. Previously, only the initial random sampling ran in
+  parallel while the flood fill itself explored the parameter space on a single thread, which could make
+  it slower in wall-clock time than a grid search on machines with many cores despite needing far fewer
+  simulations. The exploration now runs on a pool of ``std::jthread`` workers that share a single work
+  queue, using ``std::stop_source``/``std::stop_token`` and the C++20
+  ``std::condition_variable_any::wait`` stop-token overload for shutdown. One mutex guards the queue, the
+  set of already-scheduled points, and the active-worker count, while the physical simulation itself runs
+  without any lock held. Tracking scheduled points also removes a pre-existing inefficiency of the serial
+  version, in which the same parameter point could be enqueued repeatedly. The result is independent of
+  the order of exploration and therefore unchanged by the parallelization. Also modernized
+  ``simulate_operational_status_in_parallel`` to ``std::jthread`` and ``std::ranges``, and added the
+  ``std::shuffle`` that flood fill was missing for load balancing across its sampling threads
 - Code quality:
     - Adopted C++20 idioms across ``include/fiction/utils/`` as the first step of an incremental,
       module-by-module modernization: ``std::ranges`` algorithms (``std::ranges::for_each``,

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -749,6 +749,10 @@ class operational_domain_impl
 
             auto current_contour_point = contour_starting_point;
 
+            // all step points visited by the contour trace; they form a closed 8-connected curve that encloses the
+            // operational area `starting_point` is located in
+            phmap::btree_set<step_point> contour{contour_starting_point};
+
             const auto x = current_contour_point.step_values[0];
             const auto y = current_contour_point.step_values[1];
 
@@ -773,6 +777,8 @@ class operational_domain_impl
                 {
                     backtrack_point       = current_contour_point;
                     current_contour_point = next_point;
+
+                    contour.insert(current_contour_point);
                 }
                 else
                 {
@@ -783,7 +789,7 @@ class operational_domain_impl
                 next_point           = next_clockwise_point(current_neighborhood, backtrack_point);
             }
 
-            infer_operational_status_in_enclosing_contour(starting_point);
+            infer_operational_status_in_enclosing_contour(starting_point, contour);
         }
 
         log_stats();
@@ -916,6 +922,23 @@ class operational_domain_impl
             });
 
         return suitable_params_domain;
+    }
+    /**
+     * Returns the parameter points that were inferred (assumed) to be operational because they are enclosed by a
+     * contour traced by `contour_tracing`. These points have not been simulated and are, therefore, not part of the
+     * returned operational domain. They are exposed to enable inspection of the enclosure inference.
+     *
+     * @return The parameter points that have been inferred to be operational.
+     */
+    [[nodiscard]] std::vector<parameter_point> inferred_operational_parameter_points() const noexcept
+    {
+        std::vector<parameter_point> parameter_points{};
+        parameter_points.reserve(inferred_op_domain.size());
+
+        std::transform(inferred_op_domain.cbegin(), inferred_op_domain.cend(), std::back_inserter(parameter_points),
+                       [this](const auto& sp) { return to_parameter_point(sp); });
+
+        return parameter_points;
     }
 
   private:
@@ -1517,7 +1540,61 @@ class operational_domain_impl
         }
 
         return neighbors;
-    };
+    }
+    /**
+     * Returns the 2D von Neumann neighborhood of the step point at `sp = (x, y)`. The 2D von Neumann neighborhood is
+     * the set of all points that are adjacent to `(x, y)` in the plane excluding the diagonals. Thereby, the 2D von
+     * Neumann neighborhood contains up to 4 points as points outside of the parameter range are not gathered. The
+     * points are returned in no particular order.
+     *
+     * @param sp Step point to get the 2D von Neumann neighborhood of.
+     * @return The 2D von Neumann neighborhood of the step point at `sp = (x, y)`.
+     */
+    [[nodiscard]] std::vector<step_point> von_neumann_neighborhood_2d(const step_point& sp) const noexcept
+    {
+        assert(num_dimensions == 2 && "2D von Neumann neighborhood is only supported for 2 dimensions");
+        assert(sp.step_values.size() == 2 && "Given step point must have 2 dimensions");
+
+        std::vector<step_point> neighbors{};
+        neighbors.reserve(4);
+
+        const auto emplace = [&neighbors](const auto x, const auto y) noexcept
+        { neighbors.emplace_back(std::vector<std::size_t>{x, y}); };
+
+        const auto x = sp.step_values[0];
+        const auto y = sp.step_values[1];
+
+        const auto num_x_indices = indices[0].size();
+        const auto num_y_indices = indices[1].size();
+
+        const auto decr_x = (x > 0) ? x - 1 : x;
+        const auto incr_x = (x + 1 < num_x_indices) ? x + 1 : x;
+        const auto decr_y = (y > 0) ? y - 1 : y;
+        const auto incr_y = (y + 1 < num_y_indices) ? y + 1 : y;
+
+        // right
+        if (x != incr_x)
+        {
+            emplace(incr_x, y);
+        }
+        // down
+        if (y != decr_y)
+        {
+            emplace(x, decr_y);
+        }
+        // left
+        if (x != decr_x)
+        {
+            emplace(decr_x, y);
+        }
+        // up
+        if (y != incr_y)
+        {
+            emplace(x, incr_y);
+        }
+
+        return neighbors;
+    }
     /**
      * Returns the 3D Moore neighborhood of the step point at `sp = (x, y, z)`. The 3D Moore neighborhood is the set of
      * all points that are adjacent to `(x, y, z)` in the 3D space including the diagonals. Thereby, the 3D Moore
@@ -1587,26 +1664,53 @@ class operational_domain_impl
      * e.g., contour tracing if an operational domain with multiple islands is investigated.
      *
      * The function starts at the given starting point and performs flood fill to mark all points that are reachable
-     * from the starting point until it encounters the non-operational edges.
+     * from the starting point until it encounters the traced contour.
+     *
+     * The flood fill expands over the von Neumann (4-connected) neighborhood, while the given contour is a closed
+     * 8-connected curve. Since a 4-connected path cannot cross an 8-connected closed curve, the inference is
+     * guaranteed to stay within the area enclosed by the contour. Points on the contour itself are marked, but not
+     * expanded from.
      *
      * Note that no physical simulation is conducted by this function!
      *
      * @param starting_point Step point at which to start the inference. If `starting_point` is non-operational, this
      * function might invoke undefined behavior.
+     * @param contour The step points visited by the contour trace that encloses `starting_point`.
      */
-    void infer_operational_status_in_enclosing_contour(const step_point& starting_point) noexcept
+    void infer_operational_status_in_enclosing_contour(const step_point&                   starting_point,
+                                                       const phmap::btree_set<step_point>& contour) noexcept
     {
         assert(num_dimensions == 2 && "This function is only supported for two dimensions");
         assert(is_step_point_operational(starting_point) == operational_status::OPERATIONAL &&
                "starting_point must be within the operational domain");
 
+        // if the starting point has already been inferred as operational, this area has been covered before
+        if (is_step_point_inferred_operational(starting_point))
+        {
+            return;
+        }
+
         // a queue of (x, y) dimension step points to be marked as inferred operational
         std::queue<step_point> queue{};
 
-        // a utility function that adds the adjacent points to the queue for further evaluation
-        const auto queue_next_points = [this, &queue](const step_point& sp) noexcept
+        // mark the starting point as inferred operational and use it to seed the flood fill
+        inferred_op_domain.insert(starting_point);
+        queue.push(starting_point);
+
+        // for each point in the queue
+        while (!queue.empty())
         {
-            for (const auto& m : moore_neighborhood_2d(sp))
+            // fetch the step point and remove it from the queue
+            const auto sp = queue.front();
+            queue.pop();
+
+            // the contour is the boundary of the enclosed area; do not expand beyond it
+            if (contour.count(sp) > 0)
+            {
+                continue;
+            }
+
+            for (const auto& m : von_neumann_neighborhood_2d(sp))
             {
                 // if the point has already been inferred as operational, continue with the next
                 if (is_step_point_inferred_operational(m))
@@ -1626,40 +1730,9 @@ class operational_domain_impl
                 }
 
                 // otherwise, it is either found operational or can be inferred as such
-                queue.push(m);
                 inferred_op_domain.insert(m);
+                queue.push(m);
             }
-        };
-
-        // if the starting point has not already been inferred as operational
-        if (is_step_point_inferred_operational(starting_point))
-        {
-            // mark the starting point as inferred operational
-            inferred_op_domain.insert(starting_point);
-
-            // add the starting point's neighbors to the queue
-            queue_next_points(starting_point);
-        }
-
-        // for each point in the queue
-        while (!queue.empty())
-        {
-            // fetch the step point and remove it from the queue
-            const auto sp = queue.front();
-            queue.pop();
-
-            // if the point is known to be non-operational, continue with the next
-            if (const auto operational_status = op_domain.contains(to_parameter_point(sp));
-                operational_status.has_value())
-            {
-                if (std::get<0>(operational_status.value()) == operational_status::NON_OPERATIONAL)
-                {
-                    continue;
-                }
-            }
-
-            // otherwise (operational or unknown), queue its neighbors
-            queue_next_points(sp);
         }
     }
     /**

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -650,7 +650,7 @@ class operational_domain_impl
         std::size_t active_workers = 0;
 
         // requesting a stop signals that the flood fill is complete, which wakes up all waiting workers
-        std::stop_source stop_src{};
+        const std::stop_source stop_src{};
 
         // a utility function that gathers the neighbors of `sp` that are not already known. This is the expensive part
         // of the discovery, so it is deliberately called without holding `queue_mutex`

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -359,8 +359,8 @@ struct operational_domain_params
      * dimension, the second dimension is the y dimension, etc.
      */
     std::vector<operational_domain_value_range> sweep_dimensions{
-        operational_domain_value_range{sweep_parameter::EPSILON_R, 1.0, 10.0, 0.1},
-        operational_domain_value_range{sweep_parameter::LAMBDA_TF, 1.0, 10.0, 0.1}};
+        operational_domain_value_range{.dimension = sweep_parameter::EPSILON_R, .min = 1.0, .max = 10.0, .step = 0.1},
+        operational_domain_value_range{.dimension = sweep_parameter::LAMBDA_TF, .min = 1.0, .max = 10.0, .step = 0.1}};
 };
 /**
  * Statistics for the operational domain computation. The statistics are used across the different operational domain
@@ -889,7 +889,9 @@ class operational_domain_impl
                     else if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
                     {
                         // perform a heuristic simulation
-                        const quicksim_params qs_params{simulation_parameters, 500, 0.6};
+                        const quicksim_params qs_params{.simulation_parameters = simulation_parameters,
+                                                        .iteration_steps       = 500,
+                                                        .alpha                 = 0.6};
 
                         if (const auto result = quicksim(lyt, qs_params); result.has_value())
                         {
@@ -1231,7 +1233,7 @@ class operational_domain_impl
         if constexpr (std::is_same_v<OpDomain, critical_temperature_domain>)
         {
             const auto ct = critical_temperature_gate_based(
-                layout, truth_table, critical_temperature_params{op_params_set_dimension_values});
+                layout, truth_table, critical_temperature_params{.operational_params = op_params_set_dimension_values});
 
             return operational(ct);
         }
@@ -1646,9 +1648,8 @@ class operational_domain_impl
                     const int64_t dz = static_cast<int64_t>(z) + z_offset;
 
                     // check if the new coordinate is within the bounds
-                    if ((dx >= 0 && dx < static_cast<int64_t>(num_x_indices)) &&
-                        (dy >= 0 && dy < static_cast<int64_t>(num_y_indices)) &&
-                        (dz >= 0 && dz < static_cast<int64_t>(num_z_indices)))
+                    if ((dx >= 0 && std::cmp_less(dx, num_x_indices)) &&
+                        (dy >= 0 && std::cmp_less(dy, num_y_indices)) && (dz >= 0 && std::cmp_less(dz, num_z_indices)))
                     {
                         emplace(static_cast<uint64_t>(dx), static_cast<uint64_t>(dy), static_cast<uint64_t>(dz));
                     }

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -1561,11 +1561,13 @@ class operational_domain_impl
         const auto emplace = [&neighbors](const auto x, const auto y) noexcept
         { neighbors.emplace_back(std::vector<std::size_t>{x, y}); };
 
-        const auto x = sp.step_values[0];
-        const auto y = sp.step_values[1];
+        // both containers hold exactly two elements in the 2-dimensional case asserted above, so the first and the
+        // last element are the x and the y dimension, respectively
+        const auto x = sp.step_values.front();
+        const auto y = sp.step_values.back();
 
-        const auto num_x_indices = indices[0].size();
-        const auto num_y_indices = indices[1].size();
+        const auto num_x_indices = indices.front().size();
+        const auto num_y_indices = indices.back().size();
 
         const auto decr_x = (x > 0) ? x - 1 : x;
         const auto incr_x = (x + 1 < num_x_indices) ? x + 1 : x;
@@ -1677,6 +1679,7 @@ class operational_domain_impl
      * function might invoke undefined behavior.
      * @param contour The step points visited by the contour trace that encloses `starting_point`.
      */
+    // NOLINTNEXTLINE(bugprone-exception-escape): only allocation can throw, as in the calling `contour_tracing`
     void infer_operational_status_in_enclosing_contour(const step_point&                   starting_point,
                                                        const phmap::btree_set<step_point>& contour) noexcept
     {

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -31,16 +31,20 @@
 #include <atomic>
 #include <cassert>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
+#include <deque>
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <mutex>
 #include <numeric>
 #include <optional>
 #include <queue>
 #include <random>
 #include <stdexcept>
+#include <stop_token>
 #include <thread>
 #include <tuple>
 #include <type_traits>
@@ -602,6 +606,11 @@ class operational_domain_impl
      * operational points that are reachable via flood fill from the found operational points plus a one pixel wide
      * border around the domain.
      *
+     * Both phases are parallelized. The flood fill itself uses a pool of worker threads that share a single work
+     * queue, since the points to explore are only discovered as the exploration proceeds. Each step point is scheduled
+     * at most once, so no parameter point is simulated twice. The result does not depend on the order in which the
+     * points are explored and is, therefore, independent of the thread scheduling.
+     *
      * @param samples Maximum number of random samples to be taken before flood fill.
      * @param given_parameter_point Optional parameter point in the parameter space. If it lies within the
      * operational region, it is used as a starting point for flood fill.
@@ -623,67 +632,131 @@ class operational_domain_impl
             step_point_samples.push_back(to_step_point(given_parameter_point.value()));
         }
 
+        // the samples are generated in lexicographic order, which distributes poorly over the slice-based thread
+        // assignment; shuffle them for better load balancing. The order is irrelevant for the flood fill itself
+        std::ranges::shuffle(step_point_samples, std::mt19937_64{std::random_device{}()});
+
         simulate_operational_status_in_parallel(step_point_samples);
 
-        // a queue of (x, y[, z]) dimension step points to be evaluated
-        std::queue<step_point> queue{};
+        // a queue of (x, y[, z]) dimension step points to be evaluated, and the set of step points that have already
+        // been scheduled for evaluation. Both are guarded by `queue_mutex` together with `active_workers` below
+        std::deque<step_point>       queue{};
+        phmap::btree_set<step_point> scheduled{};
 
-        // a utility function that adds the adjacent points to the queue for further evaluation
-        const auto queue_next_points = [this, &queue](const step_point& sp)
+        std::mutex                  queue_mutex{};
+        std::condition_variable_any queue_cv{};
+
+        // the number of workers that popped a step point but have not yet reported back their discovered neighbors
+        std::size_t active_workers = 0;
+
+        // requesting a stop signals that the flood fill is complete, which wakes up all waiting workers
+        std::stop_source stop_src{};
+
+        // a utility function that gathers the neighbors of `sp` that are not already known. This is the expensive part
+        // of the discovery, so it is deliberately called without holding `queue_mutex`
+        const auto unknown_neighborhood = [this](const step_point& sp) noexcept
         {
-            if (num_dimensions == 2)
+            std::vector<step_point> unknown{};
+
+            const auto neighborhood = num_dimensions == 2 ? moore_neighborhood_2d(sp) : moore_neighborhood_3d(sp);
+
+            std::ranges::copy_if(neighborhood, std::back_inserter(unknown),
+                                 [this](const auto& m) noexcept { return !op_domain.contains(to_parameter_point(m)); });
+
+            return unknown;
+        };
+
+        // a utility function that adds the given step points to the queue for further evaluation. Each step point is
+        // scheduled at most once, which ensures that no parameter point is simulated twice. Must be called under lock
+        const auto schedule_points = [&queue, &scheduled](const std::vector<step_point>& step_points) noexcept
+        {
+            for (const auto& sp : step_points)
             {
-                for (const auto& m : moore_neighborhood_2d(sp))
+                if (scheduled.insert(sp).second)
                 {
-                    if (!op_domain.contains(to_parameter_point(m)))
-                    {
-                        queue.push(m);
-                    }
-                }
-            }
-            else  // num_dimensions == 3
-            {
-                for (const auto& m : moore_neighborhood_3d(sp))
-                {
-                    if (!op_domain.contains(to_parameter_point(m)))
-                    {
-                        queue.push(m);
-                    }
+                    queue.push_back(sp);
                 }
             }
         };
 
-        // add the neighbors of each operational point to the queue
+        // seed the queue with the neighbors of each operational sample
         op_domain.for_each(
-            [this, &queue_next_points](const auto& param_point, const auto& status)
+            [this, &schedule_points, &unknown_neighborhood](const auto& param_point, const auto& status) noexcept
             {
                 if (std::get<0>(status) == operational_status::OPERATIONAL)
                 {
-                    queue_next_points(to_step_point(param_point));
+                    schedule_points(unknown_neighborhood(to_step_point(param_point)));
                 }
             });
 
-        // for each point in the queue
-        while (!queue.empty())
+        // if random sampling did not find a single operational point, there is nothing to flood fill
+        if (!queue.empty())
         {
-            // fetch the step point and remove it from the queue
-            const auto sp = queue.front();
-            queue.pop();
-
-            // if the point has already been sampled, continue with the next
-            if (op_domain.contains(to_parameter_point(sp)))
+            const auto worker = [&](const std::stop_token& stop_token) noexcept
             {
-                continue;
+                while (true)
+                {
+                    std::unique_lock lock{queue_mutex};
+
+                    // returns false iff a stop has been requested, i.e., iff the flood fill is complete
+                    if (!queue_cv.wait(lock, stop_token, [&queue]() noexcept { return !queue.empty(); }))
+                    {
+                        return;
+                    }
+
+                    // fetch the step point and remove it from the queue
+                    const auto sp = queue.front();
+                    queue.pop_front();
+
+                    ++active_workers;
+
+                    lock.unlock();
+
+                    // determine the operational status and, if the point is operational, its yet unknown neighbors.
+                    // No lock is held here, which is what enables the parallelism in the first place
+                    const auto discovered = is_step_point_operational(sp) == operational_status::OPERATIONAL ?
+                                                unknown_neighborhood(sp) :
+                                                std::vector<step_point>{};
+
+                    lock.lock();
+
+                    schedule_points(discovered);
+
+                    --active_workers;
+
+                    // the flood fill is complete only once the queue has run dry and no worker is left that could
+                    // still discover new points
+                    const auto complete = queue.empty() && active_workers == 0;
+
+                    if (!complete && !queue.empty())
+                    {
+                        queue_cv.notify_all();
+                    }
+
+                    lock.unlock();
+
+                    // signal completion only after the lock has been released: requesting a stop synchronously runs
+                    // the stop callbacks that `queue_cv.wait` registered, which must not happen under `queue_mutex`
+                    if (complete)
+                    {
+                        stop_src.request_stop();
+                    }
+                }
+            };
+
+            const auto num_workers = std::max(number_of_threads, std::size_t{1});
+
+            std::vector<std::jthread> workers{};
+            workers.reserve(num_workers);
+
+            for (std::size_t i = 0; i < num_workers; ++i)
+            {
+                // a nullary callable, so that `std::jthread` does not inject its own per-thread stop token. All
+                // workers must observe the one shared stop source
+                workers.emplace_back([&worker, stop_token = stop_src.get_token()]() noexcept { worker(stop_token); });
             }
 
-            // check if the point is operational
-            const auto operational_status = is_step_point_operational(sp);
-
-            // if the point is operational, add its eight neighbors to the queue
-            if (operational_status == operational_status::OPERATIONAL)
-            {
-                queue_next_points(sp);
-            }
+            // the `std::jthread` destructors join all workers here
         }
 
         log_stats();
@@ -1365,7 +1438,7 @@ class operational_domain_impl
 
         const auto slice_size = (step_points.size() + num_threads - 1) / num_threads;
 
-        std::vector<std::thread> threads{};
+        std::vector<std::jthread> threads{};
         threads.reserve(num_threads);
 
         // launch threads, each with its own slice of random step points
@@ -1382,22 +1455,13 @@ class operational_domain_impl
             threads.emplace_back(
                 [this, start, end, &step_points]
                 {
-                    for (auto it = step_points.cbegin() + static_cast<int64_t>(start);
-                         it != step_points.cbegin() + static_cast<int64_t>(end); ++it)
-                    {
-                        is_step_point_operational(*it);
-                    }
+                    std::ranges::for_each(std::ranges::subrange{step_points.cbegin() + static_cast<int64_t>(start),
+                                                                step_points.cbegin() + static_cast<int64_t>(end)},
+                                          [this](const auto& sp) { is_step_point_operational(sp); });
                 });
         }
 
-        // wait for all threads to complete
-        for (auto& thread : threads)
-        {
-            if (thread.joinable())
-            {
-                thread.join();
-            }
-        }
+        // the `std::jthread` destructors join all threads here
     }
     /**
      * Performs random sampling to find any operational parameter combination. This function is useful if a single

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -43,8 +43,8 @@
 #include <optional>
 #include <queue>
 #include <random>
+#include <ranges>
 #include <stdexcept>
-#include <stop_token>
 #include <thread>
 #include <tuple>
 #include <type_traits>
@@ -643,14 +643,14 @@ class operational_domain_impl
         std::deque<step_point>       queue{};
         phmap::btree_set<step_point> scheduled{};
 
-        std::mutex                  queue_mutex{};
-        std::condition_variable_any queue_cv{};
+        std::mutex              queue_mutex{};
+        std::condition_variable queue_cv{};
 
         // the number of workers that popped a step point but have not yet reported back their discovered neighbors
         std::size_t active_workers = 0;
 
-        // requesting a stop signals that the flood fill is complete, which wakes up all waiting workers
-        const std::stop_source stop_src{};
+        // set once the flood fill is complete, which lets all waiting workers terminate
+        bool finished = false;
 
         // a utility function that gathers the neighbors of `sp` that are not already known. This is the expensive part
         // of the discovery, so it is deliberately called without holding `queue_mutex`
@@ -692,14 +692,16 @@ class operational_domain_impl
         // if random sampling did not find a single operational point, there is nothing to flood fill
         if (!queue.empty())
         {
-            const auto worker = [&](const std::stop_token& stop_token) noexcept
+            const auto worker = [&]() noexcept
             {
                 while (true)
                 {
                     std::unique_lock lock{queue_mutex};
 
-                    // returns false iff a stop has been requested, i.e., iff the flood fill is complete
-                    if (!queue_cv.wait(lock, stop_token, [&queue]() noexcept { return !queue.empty(); }))
+                    queue_cv.wait(lock, [&queue, &finished]() noexcept { return !queue.empty() || finished; });
+
+                    // the queue can only be empty here once the flood fill is complete
+                    if (queue.empty())
                     {
                         return;
                     }
@@ -726,37 +728,29 @@ class operational_domain_impl
 
                     // the flood fill is complete only once the queue has run dry and no worker is left that could
                     // still discover new points
-                    const auto complete = queue.empty() && active_workers == 0;
+                    finished = queue.empty() && active_workers == 0;
 
-                    if (!complete && !queue.empty())
+                    if (finished || !queue.empty())
                     {
                         queue_cv.notify_all();
-                    }
-
-                    lock.unlock();
-
-                    // signal completion only after the lock has been released: requesting a stop synchronously runs
-                    // the stop callbacks that `queue_cv.wait` registered, which must not happen under `queue_mutex`
-                    if (complete)
-                    {
-                        stop_src.request_stop();
                     }
                 }
             };
 
             const auto num_workers = std::max(number_of_threads, std::size_t{1});
 
-            std::vector<std::jthread> workers{};
+            std::vector<std::thread> workers{};
             workers.reserve(num_workers);
 
             for (std::size_t i = 0; i < num_workers; ++i)
             {
-                // a nullary callable, so that `std::jthread` does not inject its own per-thread stop token. All
-                // workers must observe the one shared stop source
-                workers.emplace_back([&worker, stop_token = stop_src.get_token()]() noexcept { worker(stop_token); });
+                workers.emplace_back(worker);
             }
 
-            // the `std::jthread` destructors join all workers here
+            for (auto& w : workers)
+            {
+                w.join();
+            }
         }
 
         log_stats();
@@ -1438,7 +1432,7 @@ class operational_domain_impl
 
         const auto slice_size = (step_points.size() + num_threads - 1) / num_threads;
 
-        std::vector<std::jthread> threads{};
+        std::vector<std::thread> threads{};
         threads.reserve(num_threads);
 
         // launch threads, each with its own slice of random step points
@@ -1461,7 +1455,11 @@ class operational_domain_impl
                 });
         }
 
-        // the `std::jthread` destructors join all threads here
+        // wait for all threads to complete
+        for (auto& thread : threads)
+        {
+            thread.join();
+        }
     }
     /**
      * Performs random sampling to find any operational parameter combination. This function is useful if a single

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -163,18 +163,18 @@ TEST_CASE("Error handling of operational domain algorithms", "[operational-domai
         zero_dimensional_params.sweep_dimensions = {};
 
         // 1-dimensional
-        one_dimensional_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}};
+        one_dimensional_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R}};
 
         // 3-dimensional
-        three_dimensional_params.sweep_dimensions = {{sweep_parameter::EPSILON_R},
-                                                     {sweep_parameter::LAMBDA_TF},
-                                                     {sweep_parameter::MU_MINUS}};
+        three_dimensional_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R},
+                                                     {.dimension = sweep_parameter::LAMBDA_TF},
+                                                     {.dimension = sweep_parameter::MU_MINUS}};
 
         // 4-dimensional
-        four_dimensional_params.sweep_dimensions = {{sweep_parameter::EPSILON_R},
-                                                    {sweep_parameter::LAMBDA_TF},
-                                                    {sweep_parameter::MU_MINUS},
-                                                    {sweep_parameter::EPSILON_R}};
+        four_dimensional_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R},
+                                                    {.dimension = sweep_parameter::LAMBDA_TF},
+                                                    {.dimension = sweep_parameter::MU_MINUS},
+                                                    {.dimension = sweep_parameter::EPSILON_R}};
 
         SECTION("flood_fill")
         {
@@ -206,21 +206,22 @@ TEST_CASE("Error handling of operational domain algorithms", "[operational-domai
         SECTION("min/max mismatch")
         {
             // 1-dimensional with invalid min/max on 1st dimension
-            invalid_params_1.sweep_dimensions         = {{sweep_parameter::EPSILON_R}};
+            invalid_params_1.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R}};
             invalid_params_1.sweep_dimensions[0].min  = 10.0;
             invalid_params_1.sweep_dimensions[0].max  = 1.0;
             invalid_params_1.sweep_dimensions[0].step = 0.1;
 
             // 2-dimensional with invalid min/max on 2nd dimension
-            invalid_params_2.sweep_dimensions         = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+            invalid_params_2.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF}};
             invalid_params_2.sweep_dimensions[1].min  = 5.5;
             invalid_params_2.sweep_dimensions[1].max  = 5.4;
             invalid_params_2.sweep_dimensions[1].step = 0.1;
 
             // 3-dimensional with invalid min/max on 3rd dimension
-            invalid_params_3.sweep_dimensions         = {{sweep_parameter::EPSILON_R},
-                                                         {sweep_parameter::LAMBDA_TF},
-                                                         {sweep_parameter::MU_MINUS}};
+            invalid_params_3.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF},
+                                                         {.dimension = sweep_parameter::MU_MINUS}};
             invalid_params_3.sweep_dimensions[2].min  = -0.4;
             invalid_params_3.sweep_dimensions[2].max  = -0.5;
             invalid_params_3.sweep_dimensions[2].step = 0.01;
@@ -253,21 +254,22 @@ TEST_CASE("Error handling of operational domain algorithms", "[operational-domai
         SECTION("negative step size")
         {
             // 1-dimensional with negative step size on 1st dimension
-            invalid_params_1.sweep_dimensions         = {{sweep_parameter::EPSILON_R}};
+            invalid_params_1.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R}};
             invalid_params_1.sweep_dimensions[0].min  = 1.0;
             invalid_params_1.sweep_dimensions[0].max  = 10.0;
             invalid_params_1.sweep_dimensions[0].step = -0.5;
 
             // 2-dimensional with negative step size on 2nd dimension
-            invalid_params_2.sweep_dimensions         = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+            invalid_params_2.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF}};
             invalid_params_2.sweep_dimensions[1].min  = 5.5;
             invalid_params_2.sweep_dimensions[1].max  = 5.6;
             invalid_params_2.sweep_dimensions[1].step = -0.1;
 
             // 3-dimensional with negative step size on 3rd dimension
-            invalid_params_3.sweep_dimensions         = {{sweep_parameter::EPSILON_R},
-                                                         {sweep_parameter::LAMBDA_TF},
-                                                         {sweep_parameter::MU_MINUS}};
+            invalid_params_3.sweep_dimensions         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                         {.dimension = sweep_parameter::LAMBDA_TF},
+                                                         {.dimension = sweep_parameter::MU_MINUS}};
             invalid_params_3.sweep_dimensions[2].min  = -0.4;
             invalid_params_3.sweep_dimensions[2].max  = -0.5;
             invalid_params_3.sweep_dimensions[2].step = -0.01;
@@ -307,8 +309,8 @@ TEST_CASE("SiQAD OR gate", "[operational-domain]")
 
     operational_domain_params op_domain_params{};
 
-    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R, 7, 8, 0.01},
-                                         {sweep_parameter::LAMBDA_TF, 5.5, 6, 0.01}};
+    op_domain_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 7, .max = 8, .step = 0.01},
+                                         {.dimension = sweep_parameter::LAMBDA_TF, .min = 5.5, .max = 6, .step = 0.01}};
 
     op_domain_params.operational_params.simulation_parameters.mu_minus                                        = -0.28;
     op_domain_params.operational_params.input_bdl_iterator_params.bdl_wire_params.threshold_bdl_interdistance = 1.5;
@@ -350,7 +352,8 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+    op_domain_params.sweep_dimensions                         = {{.dimension = sweep_parameter::EPSILON_R},
+                                                                 {.dimension = sweep_parameter::LAMBDA_TF}};
 
     CHECK(op_domain_params.sweep_dimensions[0].dimension == sweep_parameter::EPSILON_R);
     CHECK(op_domain_params.sweep_dimensions[1].dimension == sweep_parameter::LAMBDA_TF);
@@ -418,8 +421,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.32, -0.32, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.32,
+                                                                            .max       = -0.32,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -460,8 +465,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.32, -0.32, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.32,
+                                                                            .max       = -0.32,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -502,8 +509,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.32, -0.32, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.32,
+                                                                            .max       = -0.32,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -660,8 +669,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.35, -0.29, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.35,
+                                                                            .max       = -0.29,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -702,8 +713,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.35, -0.29, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.35,
+                                                                            .max       = -0.29,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -744,8 +757,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.35, -0.29, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.35,
+                                                                            .max       = -0.29,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -820,8 +835,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.14, -0.10, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.14,
+                                                                            .max       = -0.10,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -862,8 +879,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.14, -0.10, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.14,
+                                                                            .max       = -0.10,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -904,8 +923,10 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
 
             SECTION("3-dimensional")
             {
-                constexpr auto z_dimension =
-                    operational_domain_value_range{sweep_parameter::MU_MINUS, -0.14, -0.10, 0.01};
+                constexpr auto z_dimension = operational_domain_value_range{.dimension = sweep_parameter::MU_MINUS,
+                                                                            .min       = -0.14,
+                                                                            .max       = -0.10,
+                                                                            .step      = 0.01};
 
                 op_domain_params.sweep_dimensions.push_back(z_dimension);
 
@@ -1171,8 +1192,9 @@ TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domai
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.1, 6.0, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.5, 5.4, 0.1}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.1, .max = 6.0, .step = 0.1},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.5, .max = 5.4, .step = 0.1}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1288,8 +1310,9 @@ TEST_CASE("SiQAD's AND gate operational domain computation, using cube coordinat
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.1, 6.0, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.5, 5.4, 0.1}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.1, .max = 6.0, .step = 0.1},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.5, .max = 5.4, .step = 0.1}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1373,8 +1396,9 @@ TEMPLATE_TEST_CASE("AND gate on the H-Si(111)-1x1 surface", "[operational-domain
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.60, 5.61, 0.01},
-                                                                 {sweep_parameter::LAMBDA_TF, 5.0, 5.01, 0.01}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.60, .max = 5.61, .step = 0.01},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 5.0, .max = 5.01, .step = 0.01}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1462,8 +1486,9 @@ TEMPLATE_TEST_CASE("AND gate with Bestagon shape and kink states at default phys
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 4.0, 6.0, 0.4},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.0, 6.0, 0.4}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 4.0, .max = 6.0, .step = 0.4},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.0, .max = 6.0, .step = 0.4}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1508,8 +1533,9 @@ TEMPLATE_TEST_CASE("Grid search to determine the operational domain. The operati
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 4.0, 6.0, 0.4},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.0, 6.0, 0.4}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 4.0, .max = 6.0, .step = 0.4},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.0, .max = 6.0, .step = 0.4}};
 
     op_domain_params.operational_params.op_condition = is_operational_params::operational_condition::REJECT_KINKS;
 
@@ -1592,8 +1618,9 @@ TEST_CASE("Bestagon AND gate operational domain and temperature computation, usi
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 5.6, 5.8, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 4.9, 5.1, 0.1}};
+    op_domain_params.sweep_dimensions                         = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 5.6, .max = 5.8, .step = 0.1},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.9, .max = 5.1, .step = 0.1}};
 
     operational_domain_stats op_domain_stats{};
 
@@ -1618,8 +1645,9 @@ TEST_CASE("Bestagon AND gate operational domain and temperature computation, usi
     }
     SECTION("random_sampling in non-operational regime")
     {
-        op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R, 5.0, 5.2, 0.1},
-                                             {sweep_parameter::LAMBDA_TF, 4.9, 5.1, 0.1}};
+        op_domain_params.sweep_dimensions = {
+            {.dimension = sweep_parameter::EPSILON_R, .min = 5.0, .max = 5.2, .step = 0.1},
+            {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.9, .max = 5.1, .step = 0.1}};
 
         const auto op_domain = critical_temperature_domain_random_sampling(lyt, std::vector{create_and_tt()}, 10,
                                                                            op_domain_params, &op_domain_stats);
@@ -1638,8 +1666,9 @@ TEST_CASE("Bestagon AND gate operational domain and temperature computation, usi
     }
     SECTION("flood_fill")
     {
-        op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R, 5.6, 5.8, 0.1},
-                                             {sweep_parameter::LAMBDA_TF, 4.9, 5.1, 0.1}};
+        op_domain_params.sweep_dimensions = {
+            {.dimension = sweep_parameter::EPSILON_R, .min = 5.6, .max = 5.8, .step = 0.1},
+            {.dimension = sweep_parameter::LAMBDA_TF, .min = 4.9, .max = 5.1, .step = 0.1}};
 
         const auto op_domain = critical_temperature_domain_flood_fill(lyt, std::vector{create_and_tt()}, 1,
                                                                       op_domain_params, &op_domain_stats);
@@ -1677,8 +1706,8 @@ TEST_CASE("Two BDL pair wire with degeneracy for input 1", "[operational-domain]
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions                         = {{sweep_parameter::EPSILON_R, 1, 10, 0.1},
-                                                                 {sweep_parameter::LAMBDA_TF, 1, 10, 0.1}};
+    op_domain_params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 1, .max = 10, .step = 0.1},
+                                         {.dimension = sweep_parameter::LAMBDA_TF, .min = 1, .max = 10, .step = 0.1}};
 
     SECTION("grid search, input is set via the distance of the perturbers")
     {

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -20,8 +20,11 @@
 
 #include <mockturtle/utils/stopwatch.hpp>
 
+#include <algorithm>
+#include <functional>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 using namespace fiction;
@@ -1189,16 +1192,10 @@ TEST_CASE("Parallel flood fill yields deterministic results", "[operational-doma
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
-
     // 16 x 16 steps; the operational area is a single connected island of 80 parameter points
-    op_domain_params.sweep_dimensions[0].min  = 0.5;
-    op_domain_params.sweep_dimensions[0].max  = 4.25;
-    op_domain_params.sweep_dimensions[0].step = 0.25;
-
-    op_domain_params.sweep_dimensions[1].min  = 0.5;
-    op_domain_params.sweep_dimensions[1].max  = 4.25;
-    op_domain_params.sweep_dimensions[1].step = 0.25;
+    op_domain_params.sweep_dimensions = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 0.5, .max = 4.25, .step = 0.25},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 0.5, .max = 4.25, .step = 0.25}};
 
     // ground truth to compare the flood fill results against
     const auto grid_search_domain = operational_domain_grid_search(lat, std::vector{create_id_tt()}, op_domain_params);
@@ -1217,8 +1214,7 @@ TEST_CASE("Parallel flood fill yields deterministic results", "[operational-doma
 
     REQUIRE(operational_points.size() == 80);
 
-    std::sort(operational_points.begin(), operational_points.end(),
-              [](const auto& lhs, const auto& rhs) { return lhs.get_parameters() < rhs.get_parameters(); });
+    std::ranges::sort(operational_points, std::ranges::less{}, &parameter_point::get_parameters);
 
     // seeding the flood fill with a known operational point and taking no random samples makes it fully
     // deterministic, so any run-to-run difference can only stem from the parallelization
@@ -1240,8 +1236,7 @@ TEST_CASE("Parallel flood fill yields deterministic results", "[operational-doma
         op_domain.for_each([&result](const auto& coord, const auto& op_value)
                            { result.emplace_back(coord, std::get<0>(op_value)); });
 
-        std::sort(result.begin(), result.end(), [](const auto& lhs, const auto& rhs)
-                  { return lhs.first.get_parameters() < rhs.first.get_parameters(); });
+        std::ranges::sort(result, std::ranges::less{}, [](const auto& entry) { return entry.first.get_parameters(); });
 
         // every point the parallel flood fill reports must match the ground truth
         for (const auto& [pp, status] : result)
@@ -1249,7 +1244,12 @@ TEST_CASE("Parallel flood fill yields deterministic results", "[operational-doma
             const auto ground_truth = grid_search_domain.contains(pp);
 
             REQUIRE(ground_truth.has_value());
-            CHECK(status == std::get<0>(ground_truth.value()));
+
+            // the `REQUIRE` above already aborts on an empty optional, but the static analyzer cannot see that
+            if (ground_truth.has_value())
+            {
+                CHECK(status == std::get<0>(*ground_truth));
+            }
         }
 
         // the single operational island is connected, so flood fill must find all 80 of its points
@@ -1266,13 +1266,7 @@ TEST_CASE("Parallel flood fill yields deterministic results", "[operational-doma
         {
             // the explored set does not depend on the order of exploration, so every run must produce the exact same
             // result regardless of how the work happened to be distributed among the threads
-            REQUIRE(result.size() == reference->size());
-
-            for (std::size_t j = 0; j < result.size(); ++j)
-            {
-                CHECK(result[j].first == (*reference)[j].first);
-                CHECK(result[j].second == (*reference)[j].second);
-            }
+            CHECK(result == *reference);
         }
     }
 }

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -1161,6 +1161,122 @@ TEST_CASE("Contour tracing does not retrace an already enclosed area", "[operati
     }
 }
 
+TEST_CASE("Parallel flood fill yields deterministic results", "[operational-domain]")
+{
+    using layout = sidb_cell_clk_lyt_siqad;
+
+    layout lyt{{24, 0}, "BDL wire"};
+
+    lyt.assign_cell_type({0, 0, 0}, sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type({3, 0, 0}, sidb_technology::cell_type::INPUT);
+
+    lyt.assign_cell_type({6, 0, 0}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({8, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    lyt.assign_cell_type({12, 0, 0}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({14, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    lyt.assign_cell_type({18, 0, 0}, sidb_technology::cell_type::OUTPUT);
+    lyt.assign_cell_type({20, 0, 0}, sidb_technology::cell_type::OUTPUT);
+
+    // output perturber
+    lyt.assign_cell_type({24, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    const sidb_100_cell_clk_lyt_siqad lat{lyt};
+
+    sidb_simulation_parameters sim_params{};
+    sim_params.base = 2;
+
+    operational_domain_params op_domain_params{};
+    op_domain_params.operational_params.simulation_parameters = sim_params;
+    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+
+    // 16 x 16 steps; the operational area is a single connected island of 80 parameter points
+    op_domain_params.sweep_dimensions[0].min  = 0.5;
+    op_domain_params.sweep_dimensions[0].max  = 4.25;
+    op_domain_params.sweep_dimensions[0].step = 0.25;
+
+    op_domain_params.sweep_dimensions[1].min  = 0.5;
+    op_domain_params.sweep_dimensions[1].max  = 4.25;
+    op_domain_params.sweep_dimensions[1].step = 0.25;
+
+    // ground truth to compare the flood fill results against
+    const auto grid_search_domain = operational_domain_grid_search(lat, std::vector{create_id_tt()}, op_domain_params);
+
+    // collect all operational parameter points of the ground truth in a deterministic order
+    std::vector<parameter_point> operational_points{};
+
+    grid_search_domain.for_each(
+        [&operational_points](const auto& coord, const auto& op_value)
+        {
+            if (std::get<0>(op_value) == operational_status::OPERATIONAL)
+            {
+                operational_points.push_back(coord);
+            }
+        });
+
+    REQUIRE(operational_points.size() == 80);
+
+    std::sort(operational_points.begin(), operational_points.end(),
+              [](const auto& lhs, const auto& rhs) { return lhs.get_parameters() < rhs.get_parameters(); });
+
+    // seeding the flood fill with a known operational point and taking no random samples makes it fully
+    // deterministic, so any run-to-run difference can only stem from the parallelization
+    const auto& seed_point = operational_points.front();
+
+    std::optional<std::vector<std::pair<parameter_point, operational_status>>> reference{};
+
+    for (auto i = 0; i < 10; ++i)
+    {
+        operational_domain_stats op_domain_stats{};
+
+        detail::operational_domain_impl<sidb_100_cell_clk_lyt_siqad, tt, operational_domain> impl{
+            lat, std::vector{create_id_tt()}, op_domain_params, op_domain_stats};
+
+        const auto op_domain = impl.flood_fill(0, seed_point);
+
+        std::vector<std::pair<parameter_point, operational_status>> result{};
+
+        op_domain.for_each([&result](const auto& coord, const auto& op_value)
+                           { result.emplace_back(coord, std::get<0>(op_value)); });
+
+        std::sort(result.begin(), result.end(), [](const auto& lhs, const auto& rhs)
+                  { return lhs.first.get_parameters() < rhs.first.get_parameters(); });
+
+        // every point the parallel flood fill reports must match the ground truth
+        for (const auto& [pp, status] : result)
+        {
+            const auto ground_truth = grid_search_domain.contains(pp);
+
+            REQUIRE(ground_truth.has_value());
+            CHECK(status == std::get<0>(ground_truth.value()));
+        }
+
+        // the single operational island is connected, so flood fill must find all 80 of its points
+        CHECK(op_domain_stats.num_operational_parameter_combinations == 80);
+
+        // no parameter point may be simulated twice
+        CHECK(op_domain_stats.num_evaluated_parameter_combinations == op_domain.size());
+
+        if (!reference.has_value())
+        {
+            reference = result;
+        }
+        else
+        {
+            // the explored set does not depend on the order of exploration, so every run must produce the exact same
+            // result regardless of how the work happened to be distributed among the threads
+            REQUIRE(result.size() == reference->size());
+
+            for (std::size_t j = 0; j < result.size(); ++j)
+            {
+                CHECK(result[j].first == (*reference)[j].first);
+                CHECK(result[j].second == (*reference)[j].second);
+            }
+        }
+    }
+}
+
 TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
 {
     using layout = sidb_cell_clk_lyt_siqad;

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -1057,6 +1057,90 @@ TEST_CASE("BDL wire operational domain computation", "[operational-domain]")
     }
 }
 
+TEST_CASE("Contour tracing does not retrace an already enclosed area", "[operational-domain]")
+{
+    using layout = sidb_cell_clk_lyt_siqad;
+
+    layout lyt{{24, 0}, "BDL wire"};
+
+    lyt.assign_cell_type({0, 0, 0}, sidb_technology::cell_type::INPUT);
+    lyt.assign_cell_type({3, 0, 0}, sidb_technology::cell_type::INPUT);
+
+    lyt.assign_cell_type({6, 0, 0}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({8, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    lyt.assign_cell_type({12, 0, 0}, sidb_technology::cell_type::NORMAL);
+    lyt.assign_cell_type({14, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    lyt.assign_cell_type({18, 0, 0}, sidb_technology::cell_type::OUTPUT);
+    lyt.assign_cell_type({20, 0, 0}, sidb_technology::cell_type::OUTPUT);
+
+    // output perturber
+    lyt.assign_cell_type({24, 0, 0}, sidb_technology::cell_type::NORMAL);
+
+    const sidb_100_cell_clk_lyt_siqad lat{lyt};
+
+    sidb_simulation_parameters sim_params{};
+    sim_params.base = 2;
+
+    operational_domain_params op_domain_params{};
+    op_domain_params.operational_params.simulation_parameters = sim_params;
+    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
+
+    // 16 x 16 steps; the operational area is a single connected island of 80 parameter points
+    op_domain_params.sweep_dimensions[0].min  = 0.5;
+    op_domain_params.sweep_dimensions[0].max  = 4.25;
+    op_domain_params.sweep_dimensions[0].step = 0.25;
+
+    op_domain_params.sweep_dimensions[1].min  = 0.5;
+    op_domain_params.sweep_dimensions[1].max  = 4.25;
+    op_domain_params.sweep_dimensions[1].step = 0.25;
+
+    // ground truth to compare the contour tracing results against
+    const auto grid_search_domain = operational_domain_grid_search(lat, std::vector{create_id_tt()}, op_domain_params);
+
+    // the random samples are drawn from an unseeded generator; repeat to make the assertions meaningful
+    for (auto i = 0; i < 5; ++i)
+    {
+        operational_domain_stats op_domain_stats{};
+
+        detail::operational_domain_impl<sidb_100_cell_clk_lyt_siqad, tt, operational_domain> impl{
+            lat, std::vector{create_id_tt()}, op_domain_params, op_domain_stats};
+
+        const auto op_domain = impl.contour_tracing(50);
+
+        const auto inferred_points = impl.inferred_operational_parameter_points();
+
+        // the contour must have been traced at all
+        REQUIRE(op_domain_stats.num_operational_parameter_combinations > 0);
+
+        // once a contour has been traced, the area it encloses must be marked as inferred operational so that further
+        // samples landing inside it do not trigger another trace of the very same contour
+        CHECK(!inferred_points.empty());
+
+        // the inference must not leak out of the traced contour, i.e., it must never assume a non-operational
+        // parameter point to be operational
+        for (const auto& pp : inferred_points)
+        {
+            const auto ground_truth = grid_search_domain.contains(pp);
+
+            REQUIRE(ground_truth.has_value());
+            CHECK(std::get<0>(ground_truth.value()) == operational_status::OPERATIONAL);
+        }
+
+        // inferred points are never added to the operational domain, so every reported status must match the ground
+        // truth
+        op_domain.for_each(
+            [&grid_search_domain](const auto& coord, const auto& op_value)
+            {
+                const auto ground_truth = grid_search_domain.contains(coord);
+
+                REQUIRE(ground_truth.has_value());
+                CHECK(std::get<0>(op_value) == std::get<0>(ground_truth.value()));
+            });
+    }
+}
+
 TEST_CASE("SiQAD's AND gate operational domain computation", "[operational-domain]")
 {
     using layout = sidb_cell_clk_lyt_siqad;

--- a/test/algorithms/simulation/sidb/operational_domain.cpp
+++ b/test/algorithms/simulation/sidb/operational_domain.cpp
@@ -1085,16 +1085,10 @@ TEST_CASE("Contour tracing does not retrace an already enclosed area", "[operati
 
     operational_domain_params op_domain_params{};
     op_domain_params.operational_params.simulation_parameters = sim_params;
-    op_domain_params.sweep_dimensions = {{sweep_parameter::EPSILON_R}, {sweep_parameter::LAMBDA_TF}};
-
     // 16 x 16 steps; the operational area is a single connected island of 80 parameter points
-    op_domain_params.sweep_dimensions[0].min  = 0.5;
-    op_domain_params.sweep_dimensions[0].max  = 4.25;
-    op_domain_params.sweep_dimensions[0].step = 0.25;
-
-    op_domain_params.sweep_dimensions[1].min  = 0.5;
-    op_domain_params.sweep_dimensions[1].max  = 4.25;
-    op_domain_params.sweep_dimensions[1].step = 0.25;
+    op_domain_params.sweep_dimensions = {
+        {.dimension = sweep_parameter::EPSILON_R, .min = 0.5, .max = 4.25, .step = 0.25},
+        {.dimension = sweep_parameter::LAMBDA_TF, .min = 0.5, .max = 4.25, .step = 0.25}};
 
     // ground truth to compare the contour tracing results against
     const auto grid_search_domain = operational_domain_grid_search(lat, std::vector{create_id_tt()}, op_domain_params);
@@ -1125,7 +1119,12 @@ TEST_CASE("Contour tracing does not retrace an already enclosed area", "[operati
             const auto ground_truth = grid_search_domain.contains(pp);
 
             REQUIRE(ground_truth.has_value());
-            CHECK(std::get<0>(ground_truth.value()) == operational_status::OPERATIONAL);
+
+            // the `REQUIRE` above already aborts on an empty optional, but the static analyzer cannot see that
+            if (ground_truth.has_value())
+            {
+                CHECK(std::get<0>(*ground_truth) == operational_status::OPERATIONAL);
+            }
         }
 
         // inferred points are never added to the operational domain, so every reported status must match the ground


### PR DESCRIPTION
> **Depends on #1045.** Its base branch is `fix/contour-tracing-enclosure-inference`, so this PR's diff shows only the flood-fill change. Merge #1045 first; GitHub then retargets this one to `main` automatically.

## Description

`operational_domain_flood_fill` needs far fewer simulations than a grid search, but it spent them **serially**: only the initial random sampling ran in parallel, while the BFS that does the actual work (`operational_domain.hpp`, the `while (!queue.empty())` loop) ran on a single thread. On a machine with many cores, grid search — which simulates *every* parameter point but spreads them across all hardware threads — could therefore finish sooner in wall-clock time despite doing several times more work.

The frontier here is discovered as exploration proceeds: a point's neighbors only become interesting once that point turns out to be operational. So the static slice split used by `simulate_operational_status_in_parallel` does not apply. Instead, a pool of workers now shares a single work queue.

### Locking

One `std::mutex` guards three things together — the queue, the set of already-scheduled step points, and the active-worker count. Everything expensive (the physical simulation, the neighborhood lookups, the `op_domain` probes) happens with no lock held.

### Termination

Workers wait on a `std::condition_variable` for either work or a `finished` flag, which is set — under the same lock — only once the queue has run dry **and** no worker is still simulating. A busy worker may yet discover new points, so an empty queue alone is not a termination condition. An explicit join loop tears the pool down.

> **Note:** this originally used `std::jthread`, a shared `std::stop_source`, and the C++20 `std::condition_variable_any::wait(lock, stop_token, pred)` overload, which express this much more directly. Both macOS CI jobs then failed to compile it — Apple's `libc++` still gates `<stop_token>` and `std::jthread` behind `-fexperimental-library`, and the jobs use `/usr/bin/clang++`. Rather than carry a feature-detected second copy of the termination logic that only the macOS jobs would ever exercise, the whole thing is now written with portable primitives. The revert is recorded in the changelog.

### Side effects

- Scheduling each step point at most once removes a pre-existing inefficiency: the serial version could enqueue the same point many times and only filter it on pop. The new test asserts `num_evaluated_parameter_combinations == op_domain.size()`.
- `simulate_operational_status_in_parallel` modernized to use `std::ranges`.
- Added the sample shuffle that flood fill was missing before its parallel sampling phase; grid search already does this, and the helper's own doc comment warns that lexicographically ordered input balances poorly across the slices.

The set of explored points does not depend on the order of exploration, so **the result is unchanged** by the parallelization.

## Runtime

`experiments/operational_domain/operational_domain_siqad.cpp` (5 SiQAD gates, 181x181 sweep each, `QUICKEXACT`), 16-core machine. Ten interleaved before/after runs, mean of the `Total` row in seconds:

| | Grid search | Random sampling | **Flood fill** | Contour tracing |
|---|---|---|---|---|
| before | 2.97 | 0.29 | **3.98** | 0.57 |
| after | 2.84 | 0.28 | **1.01** | 0.98 |

Flood fill is **~3.9x faster**, and — the actual point of this PR — it goes from **slower than grid search** (3.98 s vs 2.97 s, despite ~95 k simulator calls against grid search's ~235 k) to **~2.8x faster** than it. Simulator call counts are unchanged, as expected.

### On the contour-tracing column

Contour tracing moved from 0.57 s to 0.98 s. Its code is untouched by this PR, and the only code it shares with the change is `simulate_operational_status_in_parallel` — which grid search drives with 32 761 points against contour tracing's ~100, without regressing.

This is an artifact of the experiment's fixed order (GS -> RS -> FF -> CT) within one process: flood fill now saturates all 16 cores for a second immediately before the largely-serial contour trace begins, whereas previously it ran single-threaded and left the package cool.

Confirmed with both binaries pinned to a single core (`taskset -c 0`), where flood fill cannot saturate anything and so cannot depress the boost clock for what follows:

| pinned to 1 core | Grid search | **Flood fill** | Contour tracing |
|---|---|---|---|
| before | 8.77 | **2.99** | 0.54 |
| after | 8.89 | **3.10** | 0.53 |

With the parallelism removed, contour tracing is identical (0.54 vs 0.53) and so is flood fill (2.99 vs 3.10) — the same total work, just no cores to spread it over. The contour-tracing difference therefore appears only when flood fill is actually parallel, and disappears when it is not, with the code identical in both cases.

## Testing

- New test `Parallel flood fill yields deterministic results`. `flood_fill(0, given_parameter_point)` takes no random samples and is therefore fully deterministic, which makes exact assertions possible: ten runs must produce byte-identical results, agree with a grid search over the same range, find all 80 operational points of the single connected island, and simulate no parameter point twice.
- **ThreadSanitizer clean**: built with `-DFICTION_ENABLE_SANITIZER_THREAD=ON` (verified `libtsan` is actually linked) and ran the full `test_operational_domain` suite — no reports.
- `test_operational_domain` (incl. the 2D and 3D flood-fill sections and the exact-count `floating-point error` case), `test_operational_domain_ratio`, and `test_is_operational` all pass, repeated several times.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. (No binding changes needed — the change is internal to `fiction::detail`; no public signature changed.)
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fk99nQ4s3wrXbHYHfp6Wj




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Parallelized operational-domain flood-fill processing using worker threads for faster exploration and simulation.

* **Reliability**
  * Prevented duplicate point scheduling and simulations.
  * Ensured results remain deterministic and independent of processing order.

* **Testing**
  * Added regression coverage verifying complete discovery, consistent statuses, deterministic results, and duplicate-free simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->