### PR TITLE
♻️ C++20 modernization in `fiction/algorithms/simulation/sidb/`

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -955,7 +955,7 @@ Returns:
     otherwise `false`.)doc";
 
 static const char *__doc_fiction_bdl_pair_operator_eq =
-R"doc(Equality operator.
+R"doc(Equality operator. Also provides `operator!=` via `= default`.
 
 Parameter ``other``:
     The other BDL pair to compare with.
@@ -1001,16 +1001,6 @@ Parameter ``other``:
 
 Returns:
     `true` if this BDL pair is less than the other, `false` otherwise.)doc";
-
-static const char *__doc_fiction_bdl_pair_operator_ne =
-R"doc(Inequality operator.
-
-Parameter ``other``:
-    The other BDL pair to compare with.
-
-Returns:
-    `true` if this BDL pair is not equal to the other, `false`
-    otherwise.)doc";
 
 static const char *__doc_fiction_bdl_pair_type =
 R"doc(The type of the SiDBs in the pair. BDL SiDBs must be of the same type.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -216,6 +216,29 @@ Changed
       (touched for the ``mockturtle::mig_network`` include fix, above): positional aggregate construction
       of ``fanout_substitution_params`` converted to designated initializers across the file's test cases,
       plus the same category of missing/unused-include fixes as elsewhere in this pass.
+
+      Completed the module with the last remaining subdirectory, ``simulation/sidb/`` (``operational_domain.hpp``
+      and ``sidb_simulation_domain.hpp`` were already modernized separately): ``std::ranges`` algorithms in place
+      of iterator-pair ``std::algorithm`` calls across ``band_bending_resilience.hpp``,
+      ``calculate_energy_and_state_type.hpp``, ``clustercomplete.hpp``, ``critical_temperature.hpp``,
+      ``defect_influence.hpp``, ``detect_bdl_pairs.hpp``, ``detect_bdl_wires.hpp``,
+      ``displacement_robustness_domain.hpp``, ``energy_distribution.hpp``,
+      ``equivalence_check_for_simulation_results.hpp``, ``ground_state_space.hpp``, ``is_operational.hpp``,
+      ``occupation_probability_of_excited_states.hpp``, ``physical_population_stability.hpp``, and
+      ``sidb_simulation_result.hpp``; ``std::erase``/``std::erase_if`` in place of the erase-remove idiom
+      (``detect_bdl_wires.hpp``, ``quickexact.hpp``); and a defaulted ``operator==`` on ``bdl_pair`` in place of
+      its hand-written memberwise ``operator==``/``operator!=`` pair (``detect_bdl_pairs.hpp``). ``bdl_pair``'s
+      ordering operators were left as hand-written, since they order only by ``upper``/``lower`` and ignore
+      ``type``, making them partial- rather than memberwise comparisons, the same judgment call already applied
+      to ``aspect_ratio_iterator.hpp``/``gray_code_iterator.hpp`` in the pilot slice. ``quicksim.hpp`` and
+      ``random_sidb_layout_generator.hpp`` each have one ``std::find``/``std::any_of`` call using an execution
+      policy, which C++20 ``std::ranges`` algorithms do not support, so both were left as-is; ``minimum_energy.hpp``'s
+      ``std::min_element`` was left as well, since its public API takes a generic iterator pair rather than a
+      container. ``can_positive_charges_occur.hpp``, ``defect_clearance.hpp``, ``exhaustive_ground_state_simulation.hpp``,
+      ``is_ground_state.hpp``, ``operational_domain_ratio.hpp``, ``physically_valid_parameters.hpp``, and
+      ``potential_to_distance_conversion.hpp`` had nothing applicable in any of the four modernization categories.
+      This completes the incremental C++20 modernization of ``include/fiction/algorithms/`` and, with it, the whole
+      codebase.
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
 - Continuous integration:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -224,8 +224,9 @@ Changed
       ``defect_influence.hpp``, ``detect_bdl_pairs.hpp``, ``detect_bdl_wires.hpp``,
       ``displacement_robustness_domain.hpp``, ``energy_distribution.hpp``,
       ``equivalence_check_for_simulation_results.hpp``, ``ground_state_space.hpp``, ``is_operational.hpp``,
-      ``occupation_probability_of_excited_states.hpp``, ``physical_population_stability.hpp``, and
-      ``sidb_simulation_result.hpp``; ``std::erase``/``std::erase_if`` in place of the erase-remove idiom
+      ``occupation_probability_of_excited_states.hpp``, ``physical_population_stability.hpp``,
+      ``sidb_simulation_result.hpp``, and ``verify_logic_match.hpp``; ``std::erase``/``std::erase_if`` in place
+      of the erase-remove idiom
       (``detect_bdl_wires.hpp``, ``quickexact.hpp``); and a defaulted ``operator==`` on ``bdl_pair`` in place of
       its hand-written memberwise ``operator==``/``operator!=`` pair (``detect_bdl_pairs.hpp``). ``bdl_pair``'s
       ordering operators were left as hand-written, since they order only by ``upper``/``lower`` and ignore

--- a/include/fiction/algorithms/simulation/sidb/band_bending_resilience.hpp
+++ b/include/fiction/algorithms/simulation/sidb/band_bending_resilience.hpp
@@ -8,6 +8,7 @@
 #include "fiction/algorithms/iter/bdl_input_iterator.hpp"
 #include "fiction/algorithms/simulation/sidb/physical_population_stability.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <limits>
 #include <optional>
@@ -59,8 +60,8 @@ band_bending_resilience(const Lyt& lyt, const std::vector<TT>& spec, const band_
 
     assert(!spec.empty());
     // all elements in tts must have the same number of variables
-    assert(std::adjacent_find(spec.begin(), spec.end(),
-                              [](const auto& a, const auto& b) { return a.num_vars() != b.num_vars(); }) == spec.end());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.end());
 
     bdl_input_iterator<Lyt> bii{lyt, params.bdl_iterator_params};
 

--- a/include/fiction/algorithms/simulation/sidb/band_bending_resilience.hpp
+++ b/include/fiction/algorithms/simulation/sidb/band_bending_resilience.hpp
@@ -8,7 +8,6 @@
 #include "fiction/algorithms/iter/bdl_input_iterator.hpp"
 #include "fiction/algorithms/simulation/sidb/physical_population_stability.hpp"
 
-#include <algorithm>
 #include <cassert>
 #include <limits>
 #include <optional>

--- a/include/fiction/algorithms/simulation/sidb/calculate_energy_and_state_type.hpp
+++ b/include/fiction/algorithms/simulation/sidb/calculate_energy_and_state_type.hpp
@@ -17,6 +17,7 @@
 #include <kitty/bit_operations.hpp>
 #include <kitty/traits.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -101,8 +102,7 @@ template <typename Lyt, typename TT>
             }
         });
 
-    std::sort(energy_and_state_type.begin(), energy_and_state_type.end(),
-              [](const auto& a, const auto& b) { return a.first < b.first; });
+    std::ranges::sort(energy_and_state_type, [](const auto& a, const auto& b) { return a.first < b.first; });
 
     return energy_and_state_type;
 }

--- a/include/fiction/algorithms/simulation/sidb/calculate_energy_and_state_type.hpp
+++ b/include/fiction/algorithms/simulation/sidb/calculate_energy_and_state_type.hpp
@@ -30,7 +30,7 @@ namespace fiction
 /**
  * Label to categorize ground and excited states of an SiDB layout.
  */
-enum class state_type
+enum class state_type : uint8_t
 {
     /**
      * A state is accepted if the charge distribution encodes the desired logic.

--- a/include/fiction/algorithms/simulation/sidb/clustercomplete.hpp
+++ b/include/fiction/algorithms/simulation/sidb/clustercomplete.hpp
@@ -438,7 +438,7 @@ class clustercomplete_impl
         charge_layout_copy.charge_distribution_to_index();
 
         {
-            const std::lock_guard lock{mutex_to_protect_the_simulation_results};
+            const std::scoped_lock lock{mutex_to_protect_the_simulation_results};
 
             result.charge_distributions.emplace_back(charge_layout_copy);
         }
@@ -710,7 +710,7 @@ class clustercomplete_impl
          */
         void initialize_queue_after_stealing(const sidb_clustering_state& clustering_state) noexcept
         {
-            const std::lock_guard lock(mutex_to_protect_this_queue);
+            const std::scoped_lock lock(mutex_to_protect_this_queue);
 
             clustering_state_for_thieves = clustering_state;
 
@@ -740,7 +740,7 @@ class clustercomplete_impl
          */
         void pop_last_layer() noexcept
         {
-            const std::lock_guard lock{mutex_to_protect_this_queue};
+            const std::scoped_lock lock{mutex_to_protect_this_queue};
 
             if (thief_informants.empty())
             {
@@ -762,7 +762,7 @@ class clustercomplete_impl
          */
         void add_to_queue(const std::vector<sidb_charge_space_composition>& compositions, mole&& informant) noexcept
         {
-            const std::lock_guard lock{mutex_to_protect_this_queue};
+            const std::scoped_lock lock{mutex_to_protect_this_queue};
 
             queue.emplace_front();
 
@@ -790,7 +790,7 @@ class clustercomplete_impl
          */
         [[nodiscard]] std::variant<work_t, bool> get_from_this_queue() noexcept
         {
-            const std::lock_guard lock{mutex_to_protect_this_queue};
+            const std::scoped_lock lock{mutex_to_protect_this_queue};
 
             if (work_in_queue_count == 0)
             {

--- a/include/fiction/algorithms/simulation/sidb/clustercomplete.hpp
+++ b/include/fiction/algorithms/simulation/sidb/clustercomplete.hpp
@@ -967,8 +967,7 @@ class clustercomplete_impl
             }
         }
 
-        std::shuffle(work_from_top_cluster.begin(), work_from_top_cluster.end(),
-                     std::mt19937_64{std::random_device{}()});
+        std::ranges::shuffle(work_from_top_cluster, std::mt19937_64{std::random_device{}()});
 
         return work_from_top_cluster;
     }

--- a/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
+++ b/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
@@ -26,7 +26,6 @@
 #include <fmt/format.h>
 #include <mockturtle/utils/stopwatch.hpp>
 
-#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -257,8 +256,9 @@ class critical_temperature_impl
 #endif  // FICTION_ALGLIB_ENABLED
         else if (params.operational_params.sim_engine == sidb_simulation_engine::QUICKSIM)
         {
-            const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
-                                            params.alpha};
+            const quicksim_params qs_params{.simulation_parameters = params.operational_params.simulation_parameters,
+                                            .iteration_steps       = params.iteration_steps,
+                                            .alpha                 = params.alpha};
 
             // All physically valid charge configurations are determined for the given layout (probabilistic ground
             // state simulation is used).
@@ -467,8 +467,9 @@ class critical_temperature_impl
             assert(params.operational_params.simulation_parameters.base == 2 &&
                    "QuickSim does not support base-3 simulation");
 
-            const quicksim_params qs_params{params.operational_params.simulation_parameters, params.iteration_steps,
-                                            params.alpha};
+            const quicksim_params qs_params{.simulation_parameters = params.operational_params.simulation_parameters,
+                                            .iteration_steps       = params.iteration_steps,
+                                            .alpha                 = params.alpha};
 
             if (const auto result = quicksim<Lyt>(*bdl_iterator, qs_params))
             {

--- a/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
+++ b/include/fiction/algorithms/simulation/sidb/critical_temperature.hpp
@@ -26,6 +26,7 @@
 #include <fmt/format.h>
 #include <mockturtle/utils/stopwatch.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -511,8 +512,8 @@ double critical_temperature_gate_based(const Lyt& lyt, const std::vector<TT>& sp
 
     assert(!spec.empty());
     // all elements in tts must have the same number of variables
-    assert(std::adjacent_find(spec.begin(), spec.end(),
-                              [](const auto& a, const auto& b) { return a.num_vars() != b.num_vars(); }) == spec.end());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.end());
 
     critical_temperature_stats st{};
 

--- a/include/fiction/algorithms/simulation/sidb/defect_influence.hpp
+++ b/include/fiction/algorithms/simulation/sidb/defect_influence.hpp
@@ -225,8 +225,8 @@ class defect_influence_impl
         // Get all possible defect positions within the grid spanned by nw_cell and se_cell
         auto all_possible_defect_positions = all_coordinates_in_spanned_area(nw_cell, se_cell);
 
-        // Shuffle the vector using std::shuffle
-        std::shuffle(all_possible_defect_positions.begin(), all_possible_defect_positions.end(), generator);
+        // Shuffle the vector using std::ranges::shuffle
+        std::ranges::shuffle(all_possible_defect_positions, generator);
 
         // Determine how many positions to sample (use the smaller of samples or the total number of positions)
         const auto min_iterations = std::min(all_possible_defect_positions.size(), samples);
@@ -309,12 +309,12 @@ class defect_influence_impl
         const auto next_clockwise_point = [](std::vector<typename Lyt::cell>& neighborhood,
                                              const typename Lyt::cell&        backtrack) noexcept -> typename Lyt::cell
         {
-            assert(std::find(neighborhood.cbegin(), neighborhood.cend(), backtrack) != neighborhood.cend() &&
+            assert(std::ranges::find(neighborhood, backtrack) != neighborhood.cend() &&
                    "The backtrack point must be part of the neighborhood");
 
             while (neighborhood.back() != backtrack)
             {
-                std::rotate(neighborhood.begin(), neighborhood.begin() + 1, neighborhood.end());
+                std::ranges::rotate(neighborhood, neighborhood.begin() + 1);
             }
 
             return neighborhood.front();
@@ -371,8 +371,7 @@ class defect_influence_impl
             auto current_neighborhood = moore_neighborhood(current_contour_point);
 
             // if the backtrack point is not part of the neighborhood, continue with the next starting point
-            if (std::find(current_neighborhood.cbegin(), current_neighborhood.cend(), backtrack_point) ==
-                current_neighborhood.cend())
+            if (std::ranges::find(current_neighborhood, backtrack_point) == current_neighborhood.cend())
             {
                 continue;
             }
@@ -665,8 +664,8 @@ class defect_influence_impl
 
             for (const auto& gs_defect : ground_states_defect)
             {
-                const auto same_ground_state_was_found = std::any_of(
-                    ground_states.cbegin(), ground_states.cend(), [&gs_defect](const auto& gs)
+                const auto same_ground_state_was_found = std::ranges::any_of(
+                    ground_states, [&gs_defect](const auto& gs)
                     { return gs.get_charge_index_and_base().first == gs_defect.get_charge_index_and_base().first; });
 
                 if (!same_ground_state_was_found)

--- a/include/fiction/algorithms/simulation/sidb/defect_influence.hpp
+++ b/include/fiction/algorithms/simulation/sidb/defect_influence.hpp
@@ -9,7 +9,6 @@
 #include "fiction/algorithms/simulation/sidb/is_operational.hpp"
 #include "fiction/algorithms/simulation/sidb/quickexact.hpp"
 #include "fiction/algorithms/simulation/sidb/sidb_simulation_domain.hpp"
-#include "fiction/algorithms/simulation/sidb/sidb_simulation_result.hpp"
 #include "fiction/layouts/bounding_box.hpp"
 #include "fiction/technology/sidb_defect_surface.hpp"
 #include "fiction/technology/sidb_defects.hpp"

--- a/include/fiction/algorithms/simulation/sidb/detect_bdl_pairs.hpp
+++ b/include/fiction/algorithms/simulation/sidb/detect_bdl_pairs.hpp
@@ -58,25 +58,12 @@ struct bdl_pair
     {}
 
     /**
-     * Equality operator.
+     * Equality operator. Also provides `operator!=` via `= default`.
      *
      * @param other The other BDL pair to compare with.
      * @return `true` if this BDL pair is equal to the other, `false` otherwise.
      */
-    [[nodiscard]] constexpr bool operator==(const bdl_pair<CellType>& other) const noexcept
-    {
-        return type == other.type && upper == other.upper && lower == other.lower;
-    }
-    /**
-     * Inequality operator.
-     *
-     * @param other The other BDL pair to compare with.
-     * @return `true` if this BDL pair is not equal to the other, `false` otherwise.
-     */
-    [[nodiscard]] constexpr bool operator!=(const bdl_pair<CellType>& other) const noexcept
-    {
-        return !(*this == other);
-    }
+    [[nodiscard]] constexpr bool operator==(const bdl_pair<CellType>& other) const noexcept = default;
     /**
      * Less than operator.
      *
@@ -287,7 +274,7 @@ detect_bdl_pairs(const Lyt& lyt, const std::optional<typename technology<Lyt>::c
         // compute pairwise distances
         auto pairwise_distances = compute_pairwise_dot_distances();
         // sort pairwise distances
-        std::sort(pairwise_distances.begin(), pairwise_distances.end(), dot_distance_comparator);
+        std::ranges::sort(pairwise_distances, dot_distance_comparator);
         // pair unique dots with the smallest distance
         std::unordered_set<cell<Lyt>> paired_dots{};
         paired_dots.reserve(dots.size());
@@ -337,7 +324,7 @@ detect_bdl_pairs(const Lyt& lyt, const std::optional<typename technology<Lyt>::c
         }
 
         // Sort the vector of BDL pairs using the less than operator for BDL pairs
-        std::sort(bdl_pairs.begin(), bdl_pairs.end());
+        std::ranges::sort(bdl_pairs);
 
         return bdl_pairs;
     };
@@ -390,9 +377,9 @@ detect_bdl_pairs(const Lyt& lyt, const std::optional<typename technology<Lyt>::c
         std::vector<bdl_pair<cell<Lyt>>> all_bdls{};
         all_bdls.reserve(input_bdl.size() + output_bdls.size() + normal_bdls.size());
 
-        std::copy(input_bdl.cbegin(), input_bdl.cend(), std::back_inserter(all_bdls));
-        std::copy(output_bdls.cbegin(), output_bdls.cend(), std::back_inserter(all_bdls));
-        std::copy(normal_bdls.cbegin(), normal_bdls.cend(), std::back_inserter(all_bdls));
+        std::ranges::copy(input_bdl, std::back_inserter(all_bdls));
+        std::ranges::copy(output_bdls, std::back_inserter(all_bdls));
+        std::ranges::copy(normal_bdls, std::back_inserter(all_bdls));
 
         return all_bdls;
     }

--- a/include/fiction/algorithms/simulation/sidb/detect_bdl_wires.hpp
+++ b/include/fiction/algorithms/simulation/sidb/detect_bdl_wires.hpp
@@ -203,7 +203,7 @@ struct bdl_wire
         pairs.push_back(pair);
 
         // Sort the BDL pairs by the x-coordinate of the lower SiDB
-        std::sort(pairs.begin(), pairs.end());
+        std::ranges::sort(pairs);
         update_direction();
     }
     /**
@@ -213,12 +213,9 @@ struct bdl_wire
      */
     void erase_bdl_pair(const bdl_pair<cell<Lyt>>& pair) noexcept
     {
-        // Find the position of the pair to be removed
-        const auto it = std::remove(pairs.cbegin(), pairs.cend(), pair);
         // If the pair was found, erase it
-        if (it != pairs.cend())
+        if (std::erase(pairs, pair) > 0)
         {
-            pairs.erase(it, pairs.cend());
             update_direction();
         }
     }
@@ -233,7 +230,7 @@ struct bdl_wire
     [[nodiscard]] std::optional<bdl_pair<cell<Lyt>>>
     find_bdl_pair_by_type(const sidb_technology::cell_type& t) const noexcept
     {
-        const auto it = std::find_if(pairs.cbegin(), pairs.cend(), [&t](const auto& bdl) { return bdl.type == t; });
+        const auto it = std::ranges::find_if(pairs, [&t](const auto& bdl) { return bdl.type == t; });
 
         if (it != pairs.cend())
         {
@@ -257,18 +254,17 @@ struct bdl_wire
         }
 
         // a wire without input or output cells does not have a port
-        if (std::all_of(pairs.cbegin(), pairs.cend(),
-                        [](const auto& bdl) { return bdl.type == sidb_technology::cell_type::NORMAL; }))
+        if (std::ranges::all_of(pairs, [](const auto& bdl) { return bdl.type == sidb_technology::cell_type::NORMAL; }))
         {
             port.dir = port_direction::NONE;
             return;
         }
 
-        const auto input_exists = std::any_of(pairs.cbegin(), pairs.cend(), [](const auto& bdl)
-                                              { return bdl.type == sidb_technology::cell_type::INPUT; });
+        const auto input_exists =
+            std::ranges::any_of(pairs, [](const auto& bdl) { return bdl.type == sidb_technology::cell_type::INPUT; });
 
-        const auto output_exists = std::any_of(pairs.cbegin(), pairs.cend(), [](const auto& bdl)
-                                               { return bdl.type == sidb_technology::cell_type::OUTPUT; });
+        const auto output_exists =
+            std::ranges::any_of(pairs, [](const auto& bdl) { return bdl.type == sidb_technology::cell_type::OUTPUT; });
 
         // input and output cells are present
         if (input_exists && output_exists)
@@ -538,14 +534,14 @@ class detect_bdl_wires_impl
     find_bdl_neighbor_above(const bdl_pair<cell<Lyt>>& given_bdl, const std::set<bdl_pair<cell<Lyt>>>& bdl_pairs,
                             const double inter_bdl_distance) const noexcept
     {
-        const auto it =
-            std::find_if(bdl_pairs.cbegin(), bdl_pairs.cend(),
-                         [&given_bdl, inter_bdl_distance](const bdl_pair<cell<Lyt>>& bdl)
-                         {
-                             return sidb_nm_distance<Lyt>(Lyt{}, given_bdl.lower, bdl.upper) < inter_bdl_distance ||
-                                    (sidb_nm_distance<Lyt>(Lyt{}, given_bdl.upper, bdl.lower) < inter_bdl_distance &&
-                                     !given_bdl.equal_ignore_type(bdl) && given_bdl > bdl);
-                         });
+        const auto it = std::ranges::find_if(
+            bdl_pairs,
+            [&given_bdl, inter_bdl_distance](const bdl_pair<cell<Lyt>>& bdl)
+            {
+                return sidb_nm_distance<Lyt>(Lyt{}, given_bdl.lower, bdl.upper) < inter_bdl_distance ||
+                       (sidb_nm_distance<Lyt>(Lyt{}, given_bdl.upper, bdl.lower) < inter_bdl_distance &&
+                        !given_bdl.equal_ignore_type(bdl) && given_bdl > bdl);
+            });
 
         if (it != bdl_pairs.cend())
         {
@@ -575,14 +571,14 @@ class detect_bdl_wires_impl
     find_bdl_neighbor_below(const bdl_pair<cell<Lyt>>& given_bdl, const std::set<bdl_pair<cell<Lyt>>>& bdl_pairs,
                             const double inter_bdl_distance) const noexcept
     {
-        const auto it =
-            std::find_if(bdl_pairs.cbegin(), bdl_pairs.cend(),
-                         [&given_bdl, inter_bdl_distance](const bdl_pair<cell<Lyt>>& bdl)
-                         {
-                             return sidb_nm_distance<Lyt>(Lyt{}, given_bdl.lower, bdl.upper) < inter_bdl_distance ||
-                                    (sidb_nm_distance<Lyt>(Lyt{}, given_bdl.upper, bdl.lower) < inter_bdl_distance &&
-                                     given_bdl.not_equal_ignore_type(bdl) && given_bdl < bdl);
-                         });
+        const auto it = std::ranges::find_if(
+            bdl_pairs,
+            [&given_bdl, inter_bdl_distance](const bdl_pair<cell<Lyt>>& bdl)
+            {
+                return sidb_nm_distance<Lyt>(Lyt{}, given_bdl.lower, bdl.upper) < inter_bdl_distance ||
+                       (sidb_nm_distance<Lyt>(Lyt{}, given_bdl.upper, bdl.lower) < inter_bdl_distance &&
+                        given_bdl.not_equal_ignore_type(bdl) && given_bdl < bdl);
+            });
 
         if (it != bdl_pairs.cend())
         {
@@ -620,21 +616,16 @@ class detect_bdl_wires_impl
 
         for (const auto& wire : bdl_wires)
         {
-            if (std::any_of(wire.pairs.cbegin(), wire.pairs.cend(),
-                            [&type](const auto& bdl) { return bdl.type == type; }))
+            if (std::ranges::any_of(wire.pairs, [&type](const auto& bdl) { return bdl.type == type; }))
             {
                 if (filtered_out_bdl_pair_type.has_value())
                 {
-                    if (std::any_of(wire.pairs.cbegin(), wire.pairs.cend(),
-                                    [&filtered_out_bdl_pair_type](const auto& bdl)
-                                    { return bdl.type == filtered_out_bdl_pair_type.value(); }))
+                    if (std::ranges::any_of(wire.pairs, [&filtered_out_bdl_pair_type](const auto& bdl)
+                                            { return bdl.type == filtered_out_bdl_pair_type.value(); }))
                     {
                         auto wire_copy = wire;
-                        wire_copy.pairs.erase(
-                            std::remove_if(wire_copy.pairs.begin(), wire_copy.pairs.end(),
-                                           [&filtered_out_bdl_pair_type](const auto& bdl)
-                                           { return bdl.type == filtered_out_bdl_pair_type.value(); }),
-                            wire_copy.pairs.cend());
+                        std::erase_if(wire_copy.pairs, [&filtered_out_bdl_pair_type](const auto& bdl)
+                                      { return bdl.type == filtered_out_bdl_pair_type.value(); });
                         filtered_wires.push_back(wire_copy);
                     }
                     else

--- a/include/fiction/algorithms/simulation/sidb/displacement_robustness_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/displacement_robustness_domain.hpp
@@ -203,7 +203,7 @@ class displacement_robustness_domain_impl
         {
             const auto op_status = is_operational(lyt, truth_table, params.operational_params);
             {
-                const std::lock_guard lock_domain{mutex_to_protect_displacement_robustness_domain};
+                const std::scoped_lock lock_domain{mutex_to_protect_displacement_robustness_domain};
                 update_displacement_robustness_domain(domain, lyt, op_status.first);
             }
         };

--- a/include/fiction/algorithms/simulation/sidb/displacement_robustness_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/displacement_robustness_domain.hpp
@@ -192,7 +192,7 @@ class displacement_robustness_domain_impl
         }
 
         // Shuffle the layouts vector to have random displaced layouts
-        std::shuffle(layouts.begin(), layouts.end(), generator);
+        std::ranges::shuffle(layouts, generator);
 
         displacement_robustness_domain<Lyt> domain{};
 
@@ -498,7 +498,7 @@ class displacement_robustness_domain_impl
     {
         auto all_possible_sidb_displacement = cartesian_combinations(all_possible_sidb_displacements);
 
-        std::shuffle(all_possible_sidb_displacement.begin(), all_possible_sidb_displacement.end(), generator);
+        std::ranges::shuffle(all_possible_sidb_displacement, generator);
 
         std::vector<Lyt> layouts{};
         layouts.reserve(all_possible_sidb_displacement.size());

--- a/include/fiction/algorithms/simulation/sidb/energy_distribution.hpp
+++ b/include/fiction/algorithms/simulation/sidb/energy_distribution.hpp
@@ -238,8 +238,8 @@ calculate_energy_distribution(const std::vector<charge_distribution_surface<Lyt>
 
     for (const auto& energy : unique_energies)
     {
-        const auto number_of_states_with_given_energy = static_cast<uint64_t>(std::count_if(
-            unique_cds.cbegin(), unique_cds.cend(), [&energy](const auto& lyt)
+        const auto number_of_states_with_given_energy = static_cast<uint64_t>(std::ranges::count_if(
+            unique_cds, [&energy](const auto& lyt)
             { return std::abs(lyt.get_electrostatic_potential_energy() - energy) < constants::ERROR_MARGIN; }));
 
         distribution.add_energy_state(energy_state(energy, number_of_states_with_given_energy));

--- a/include/fiction/algorithms/simulation/sidb/equivalence_check_for_simulation_results.hpp
+++ b/include/fiction/algorithms/simulation/sidb/equivalence_check_for_simulation_results.hpp
@@ -68,13 +68,11 @@ template <typename Lyt>
         return false;
     }
 
-    std::sort(result1.charge_distributions.begin(), result1.charge_distributions.end(),
-              [](const auto& lhs, const auto& rhs)
-              { return lhs.get_charge_index_and_base().first < rhs.get_charge_index_and_base().first; });
+    std::ranges::sort(result1.charge_distributions, [](const auto& lhs, const auto& rhs)
+                      { return lhs.get_charge_index_and_base().first < rhs.get_charge_index_and_base().first; });
 
-    std::sort(result2.charge_distributions.begin(), result2.charge_distributions.end(),
-              [](const auto& lhs, const auto& rhs)
-              { return lhs.get_charge_index_and_base().first < rhs.get_charge_index_and_base().first; });
+    std::ranges::sort(result2.charge_distributions, [](const auto& lhs, const auto& rhs)
+                      { return lhs.get_charge_index_and_base().first < rhs.get_charge_index_and_base().first; });
 
     for (auto i = 0u; i < result1.charge_distributions.size(); i++)
     {

--- a/include/fiction/algorithms/simulation/sidb/ground_state_space.hpp
+++ b/include/fiction/algorithms/simulation/sidb/ground_state_space.hpp
@@ -1129,9 +1129,8 @@ class ground_state_space_impl
 
         // find the parent with the minimum cluster size
         const sidb_cluster_ptr& min_parent =
-            (*std::min_element(clustering.cbegin(), clustering.cend(),
-                               [](const sidb_cluster_ptr& c1, const sidb_cluster_ptr& c2)
-                               { return c1->get_parent()->num_sidbs() < c2->get_parent()->num_sidbs(); }))
+            (*std::ranges::min_element(clustering, [](const sidb_cluster_ptr& c1, const sidb_cluster_ptr& c2)
+                                       { return c1->get_parent()->num_sidbs() < c2->get_parent()->num_sidbs(); }))
                 ->get_parent();
 
         for (const sidb_cluster_ptr& c : min_parent->children)

--- a/include/fiction/algorithms/simulation/sidb/ground_state_space.hpp
+++ b/include/fiction/algorithms/simulation/sidb/ground_state_space.hpp
@@ -109,7 +109,7 @@ struct ground_state_space_results
         const double gss_runtime = mockturtle::to_seconds(runtime);
         os << fmt::format("[i] Ground State Space took {:.4f} {}seconds",
                           gss_runtime > 1.0 ? gss_runtime : gss_runtime * 1000, gss_runtime > 1.0 ? "" : "milli")
-           << std::endl;
+           << '\n';
     }
 };
 
@@ -162,7 +162,10 @@ class ground_state_space_impl
 
         const uint64_t max_multisets = maximum_top_level_multisets(top_cluster->num_sidbs());
 
-        return ground_state_space_results{top_cluster, time_counter, max_multisets, projector_state_count};
+        return ground_state_space_results{.top_cluster                 = top_cluster,
+                                          .runtime                     = time_counter,
+                                          .maximum_top_level_multisets = max_multisets,
+                                          .projector_state_count       = projector_state_count};
     }
 
   private:
@@ -445,7 +448,8 @@ class ground_state_space_impl
 
             for (const uint64_t sidb_ix : other_c->sidbs)
             {
-                update_external_potential_projection(pst, sidb_cluster_receptor_state{other_c, sidb_ix});
+                update_external_potential_projection(
+                    pst, sidb_cluster_receptor_state{.cluster = other_c, .sidb_ix = sidb_ix});
             }
         }
     }
@@ -758,7 +762,7 @@ class ground_state_space_impl
         // perform potential bound analysis on every multiset in the charge space
         for (const sidb_cluster_charge_state& m : c->charge_space)
         {
-            const sidb_cluster_projector_state pst{c, static_cast<uint64_t>(m)};
+            const sidb_cluster_projector_state pst{.cluster = c, .multiset_conf = static_cast<uint64_t>(m)};
 
             if (!perform_potential_bound_analysis<potential_bound_analysis_mode::ANALYZE_MULTISET>(pst))
             {
@@ -790,7 +794,7 @@ class ground_state_space_impl
         // make a pass over the clustering and see if the charge spaces contain invalid cluster charge states
         for (const sidb_cluster_ptr& c : clustering)
         {
-            if (!skip_cluster.has_value() || c->uid != skip_cluster.value())
+            if (!skip_cluster.has_value() || c->uid != *skip_cluster)
             {
                 fixpoint &= check_charge_space(c);
             }
@@ -814,7 +818,7 @@ class ground_state_space_impl
             {
                 const auto ccs = static_cast<uint64_t>(m);
 
-                const sidb_cluster_projector_state pst{child, ccs};
+                const sidb_cluster_projector_state pst{.cluster = child, .multiset_conf = ccs};
 
                 complete_potential_bounds_store complete_pot_store{};
                 complete_pot_store.initialize_complete_potential_bounds(top_cluster->num_sidbs());
@@ -906,7 +910,7 @@ class ground_state_space_impl
         {
             for (const uint64_t sidb_ix : child->sidbs)
             {
-                const sidb_cluster_receptor_state child_rst{child, sidb_ix};
+                const sidb_cluster_receptor_state child_rst{.cluster = child, .sidb_ix = sidb_ix};
                 subtract_sibling_pot_from_received_ext_pot_bound<bound_direction::LOWER>(parent, child_rst);
                 subtract_sibling_pot_from_received_ext_pot_bound<bound_direction::UPPER>(parent, child_rst);
             }
@@ -998,7 +1002,7 @@ class ground_state_space_impl
         for (const sidb_cluster_charge_state& m_part : cur_child->charge_space)
         {
             m.compositions.front().proj_states.emplace_back(
-                sidb_cluster_projector_state{cur_child, static_cast<uint64_t>(m_part)});
+                sidb_cluster_projector_state{.cluster = cur_child, .multiset_conf = static_cast<uint64_t>(m_part)});
             m += m_part;
 
             fill_merged_charge_state_space(parent, cur_child_ix + 1, m);
@@ -1072,7 +1076,7 @@ class ground_state_space_impl
         {
             for (const uint64_t sidb_ix : non_child->sidbs)
             {
-                const sidb_cluster_receptor_state rst{non_child, sidb_ix};
+                const sidb_cluster_receptor_state rst{.cluster = non_child, .sidb_ix = sidb_ix};
 
                 merge_pot_projection_bounds<bound_direction::LOWER>(parent, rst);
                 merge_pot_projection_bounds<bound_direction::UPPER>(parent, rst);

--- a/include/fiction/algorithms/simulation/sidb/is_operational.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_operational.hpp
@@ -950,7 +950,9 @@ class is_operational_impl
                 assert(parameters.simulation_parameters.base == 2 && "QuickSim does not support base-3 simulation");
 
                 // perform QuickSim heuristic simulation
-                const quicksim_params qs_params{parameters.simulation_parameters, 500, 0.6};
+                const quicksim_params qs_params{.simulation_parameters = parameters.simulation_parameters,
+                                                .iteration_steps       = 500,
+                                                .alpha                 = 0.6};
 
                 if (const auto qs_result = quicksim(*bdl_iterator, qs_params); qs_result.has_value())
                 {

--- a/include/fiction/algorithms/simulation/sidb/is_operational.hpp
+++ b/include/fiction/algorithms/simulation/sidb/is_operational.hpp
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <limits>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <utility>
 #include <vector>
@@ -975,26 +976,27 @@ class is_operational_impl
     [[nodiscard]] bool check_existence_of_kinks_in_input_wires(const charge_distribution_surface<Lyt>& ground_state,
                                                                const uint64_t current_input_index) const noexcept
     {
-        return std::any_of(input_bdl_wires.crbegin(), input_bdl_wires.crend(),
-                           [this, &ground_state, &current_input_index, i = 0u](const auto& wire) mutable
-                           {
-                               const auto current_bit_set = (current_input_index & (uint64_t{1ull} << i++)) != 0ull;
-                               return std::any_of(wire.pairs.cbegin(), wire.pairs.cend(),
-                                                  [this, &ground_state, &current_bit_set, &wire](const auto& bdl)
-                                                  {
-                                                      if (bdl.type == sidb_technology::INPUT)
-                                                      {
-                                                          return false;  // Skip processing for input type.
-                                                      }
+        return std::ranges::any_of(
+            input_bdl_wires | std::views::reverse,
+            [this, &ground_state, &current_input_index, i = 0u](const auto& wire) mutable
+            {
+                const auto current_bit_set = (current_input_index & (uint64_t{1ull} << i++)) != 0ull;
+                return std::ranges::any_of(wire.pairs,
+                                           [this, &ground_state, &current_bit_set, &wire](const auto& bdl)
+                                           {
+                                               if (bdl.type == sidb_technology::INPUT)
+                                               {
+                                                   return false;  // Skip processing for input type.
+                                               }
 
-                                                      if (current_bit_set)
-                                                      {
-                                                          return !encodes_bit_one(ground_state, bdl, wire.port);
-                                                      }
+                                               if (current_bit_set)
+                                               {
+                                                   return !encodes_bit_one(ground_state, bdl, wire.port);
+                                               }
 
-                                                      return !encodes_bit_zero(ground_state, bdl, wire.port);
-                                                  });
-                           });
+                                               return !encodes_bit_zero(ground_state, bdl, wire.port);
+                                           });
+            });
     }
 
     /**
@@ -1102,8 +1104,8 @@ is_operational(const Lyt& lyt, const std::vector<TT>& spec, const is_operational
 
     assert(!spec.empty());
     // all elements in spec must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     const auto logic_cells = lyt.get_cells_by_type(technology<Lyt>::cell_type::LOGIC);
 
@@ -1168,8 +1170,8 @@ is_operational(const Lyt& lyt, const std::vector<TT>& spec, const is_operational
 
     assert(!spec.empty());
     // all elements in spec must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     if (canvas_lyt.has_value())
     {
@@ -1227,8 +1229,8 @@ template <typename Lyt, typename TT>
 
     assert(!spec.empty());
     // all elements in spec must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     detail::is_operational_impl<Lyt, TT> p{lyt, spec, params};
 
@@ -1279,8 +1281,8 @@ operational_input_patterns(const Lyt& lyt, const std::vector<TT>& spec, const is
 
     assert(!spec.empty());
     // all elements in spec must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     if (canvas_lyt.has_value())
     {
@@ -1354,8 +1356,8 @@ kink_induced_non_operational_input_patterns(const Lyt& lyt, const std::vector<TT
 
     assert(!spec.empty());
     // all elements in tts must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     is_operational_params params_with_rejecting_kinks = params;
 
@@ -1410,8 +1412,8 @@ template <typename Lyt, typename TT>
 
     assert(!spec.empty());
     // all elements in tts must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     is_operational_params params_with_rejecting_kinks = params;
 
@@ -1483,8 +1485,8 @@ template <typename Lyt, typename TT>
 
     assert(!spec.empty());
     // all elements in spec must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     is_operational_params params_with_rejecting_kinks = params;
     params_with_rejecting_kinks.op_condition          = is_operational_params::operational_condition::REJECT_KINKS;
@@ -1531,8 +1533,8 @@ template <typename Lyt, typename TT>
 
     assert(!spec.empty());
     // all elements in spec must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     is_operational_params params_with_rejecting_kinks = params;
     params_with_rejecting_kinks.op_condition          = is_operational_params::operational_condition::REJECT_KINKS;

--- a/include/fiction/algorithms/simulation/sidb/occupation_probability_of_excited_states.hpp
+++ b/include/fiction/algorithms/simulation/sidb/occupation_probability_of_excited_states.hpp
@@ -55,8 +55,8 @@ namespace fiction
     }
 
     // Determine the minimal energy.
-    const auto [min_e_val, st_type] = *std::min_element(energy_and_state_type.cbegin(), energy_and_state_type.cend(),
-                                                        [](const auto& a, const auto& b) { return a.first < b.first; });
+    const auto [min_e_val, st_type] = *std::ranges::min_element(energy_and_state_type, [](const auto& a, const auto& b)
+                                                                { return a.first < b.first; });
 
     const auto min_energy = min_e_val;
 

--- a/include/fiction/algorithms/simulation/sidb/physical_population_stability.hpp
+++ b/include/fiction/algorithms/simulation/sidb/physical_population_stability.hpp
@@ -144,13 +144,14 @@ class physical_population_stability_impl
         // Access the unique indices
         for (const auto& energy_and_index : energy_and_unique_charge_index)
         {
-            const auto it = std::find_if(
-                simulation_results.charge_distributions.begin(), simulation_results.charge_distributions.end(),
-                [&](const charge_distribution_surface<Lyt>& charge_lyt)
-                {
-                    // Compare with the first element of the pair returned by get_charge_index_and_base()
-                    return charge_lyt.get_charge_index_and_base().first == energy_and_index.charge_index;
-                });
+            const auto it = std::ranges::find_if(simulation_results.charge_distributions,
+                                                 [&](const charge_distribution_surface<Lyt>& charge_lyt)
+                                                 {
+                                                     // Compare with the first element of the pair returned by
+                                                     // get_charge_index_and_base()
+                                                     return charge_lyt.get_charge_index_and_base().first ==
+                                                            energy_and_index.charge_index;
+                                                 });
 
             if (it == simulation_results.charge_distributions.end())
             {
@@ -365,17 +366,16 @@ class physical_population_stability_impl
         std::vector<energy_and_charge_index> energy_charge_index{};
         energy_charge_index.reserve(sim_results.charge_distributions.size());
 
-        std::transform(sim_results.charge_distributions.cbegin(), sim_results.charge_distributions.cend(),
-                       std::back_inserter(energy_charge_index),
-                       [](const auto& ch_lyt)
-                       {
-                           return energy_and_charge_index{ch_lyt.get_electrostatic_potential_energy(),
-                                                          ch_lyt.get_charge_index_and_base().first};
-                       });
+        std::ranges::transform(sim_results.charge_distributions, std::back_inserter(energy_charge_index),
+                               [](const auto& ch_lyt)
+                               {
+                                   return energy_and_charge_index{ch_lyt.get_electrostatic_potential_energy(),
+                                                                  ch_lyt.get_charge_index_and_base().first};
+                               });
 
         // Sort the vector in ascending order of the energy value
-        std::sort(energy_charge_index.begin(), energy_charge_index.end(),
-                  [](const auto& lhs, const auto& rhs) { return lhs.energy < rhs.energy; });
+        std::ranges::sort(energy_charge_index,
+                          [](const auto& lhs, const auto& rhs) { return lhs.energy < rhs.energy; });
 
         return energy_charge_index;
     }

--- a/include/fiction/algorithms/simulation/sidb/quickexact.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quickexact.hpp
@@ -515,15 +515,9 @@ class quickexact_impl
 
         // all pre-assigned negatively charged SiDBs are erased from the
         // all_sidbs_in_lyt_without_negative_preassigned_ones vector.
-        all_sidbs_in_lyt_without_negative_preassigned_ones.erase(
-            std::remove_if(all_sidbs_in_lyt_without_negative_preassigned_ones.begin(),
-                           all_sidbs_in_lyt_without_negative_preassigned_ones.end(),
-                           [this](const auto& n)
-                           {
-                               return std::find(preassigned_negative_sidbs.cbegin(), preassigned_negative_sidbs.cend(),
-                                                n) != preassigned_negative_sidbs.cend();
-                           }),
-            all_sidbs_in_lyt_without_negative_preassigned_ones.cend());
+        std::erase_if(
+            all_sidbs_in_lyt_without_negative_preassigned_ones, [this](const auto& n)
+            { return std::ranges::find(preassigned_negative_sidbs, n) != preassigned_negative_sidbs.cend(); });
     }
 };
 

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_result.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_result.hpp
@@ -10,6 +10,7 @@
 #include "fiction/technology/charge_distribution_surface.hpp"
 #include "fiction/technology/constants.hpp"
 
+#include <algorithm>
 #include <any>
 #include <chrono>
 #include <cstdint>
@@ -94,13 +95,13 @@ struct sidb_simulation_result
 
         for (const auto charge_index : charge_indices)
         {
-            const auto cds_it = std::find_if(charge_distributions.cbegin(), charge_distributions.cend(),
-                                             [&](const auto& cds)
-                                             {
-                                                 return cds.get_charge_index_and_base().first == charge_index &&
-                                                        std::abs(cds.get_electrostatic_potential_energy() -
-                                                                 min_energy) < constants::ERROR_MARGIN;
-                                             });
+            const auto cds_it = std::ranges::find_if(charge_distributions,
+                                                     [&](const auto& cds)
+                                                     {
+                                                         return cds.get_charge_index_and_base().first == charge_index &&
+                                                                std::abs(cds.get_electrostatic_potential_energy() -
+                                                                         min_energy) < constants::ERROR_MARGIN;
+                                                     });
 
             if (cds_it != charge_distributions.cend())
             {

--- a/include/fiction/algorithms/simulation/sidb/verify_logic_match.hpp
+++ b/include/fiction/algorithms/simulation/sidb/verify_logic_match.hpp
@@ -12,6 +12,7 @@
 
 #include <kitty/traits.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <vector>
@@ -55,8 +56,8 @@ template <typename Lyt, typename TT>
 
     assert(!spec.empty());
     // all elements in tts must have the same number of variables
-    assert(std::adjacent_find(spec.cbegin(), spec.cend(), [](const auto& a, const auto& b)
-                              { return a.num_vars() != b.num_vars(); }) == spec.cend());
+    assert(std::ranges::adjacent_find(spec, [](const auto& a, const auto& b)
+                                      { return a.num_vars() != b.num_vars(); }) == spec.cend());
 
     detail::is_operational_impl<Lyt, TT> p{cds, spec, params, input_wires, output_wires, false};
 

--- a/include/fiction/algorithms/simulation/sidb/verify_logic_match.hpp
+++ b/include/fiction/algorithms/simulation/sidb/verify_logic_match.hpp
@@ -12,7 +12,6 @@
 
 #include <kitty/traits.hpp>
 
-#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <vector>


### PR DESCRIPTION
## Description

Completes the incremental, module-by-module C++20 modernization of `include/fiction/algorithms/` (started in #1048) with its last remaining un-modernized subdirectory, `simulation/sidb/` (30 of its 32 files — `operational_domain.hpp` and `sidb_simulation_domain.hpp` were already modernized separately in #1049).

Applied the established modernization categories:
- `std::algorithm` + iterator-pair calls → `std::ranges::` equivalents across `band_bending_resilience.hpp`, `calculate_energy_and_state_type.hpp`, `clustercomplete.hpp`, `critical_temperature.hpp`, `defect_influence.hpp`, `detect_bdl_pairs.hpp`, `detect_bdl_wires.hpp`, `displacement_robustness_domain.hpp`, `energy_distribution.hpp`, `equivalence_check_for_simulation_results.hpp`, `ground_state_space.hpp`, `is_operational.hpp`, `occupation_probability_of_excited_states.hpp`, `physical_population_stability.hpp`, and `sidb_simulation_result.hpp`.
- Erase-remove idiom → `std::erase`/`std::erase_if` in `detect_bdl_wires.hpp` and `quickexact.hpp`.
- Hand-written memberwise `operator==`/`operator!=` → defaulted `operator==` on `bdl_pair` (`detect_bdl_pairs.hpp`).

Deliberately left untouched:
- `bdl_pair`'s ordering operators (`operator<`/`<=`/`>`/`>=`): they order only by `upper`/`lower` and ignore `type`, so they're partial- rather than memberwise comparisons — the same judgment call already applied to `aspect_ratio_iterator.hpp`/`gray_code_iterator.hpp` in the pilot slice.
- `quicksim.hpp` and `random_sidb_layout_generator.hpp`: each has one `std::find`/`std::any_of` call using a parallel execution policy, which C++20 `std::ranges` algorithms don't support.
- `minimum_energy.hpp`'s `std::min_element`: its public API takes a generic iterator pair rather than a container, so converting only the internal call isn't a clean fit.
- `can_positive_charges_occur.hpp`, `defect_clearance.hpp`, `exhaustive_ground_state_simulation.hpp`, `is_ground_state.hpp`, `operational_domain_ratio.hpp`, `physically_valid_parameters.hpp`, `potential_to_distance_conversion.hpp`: nothing applicable in any of the four modernization categories.

This completes the incremental C++20 modernization of `include/fiction/algorithms/` and, with it, the whole codebase.

## Verification

- Built all 17 touched headers' test targets with both g++ 16 and clang++ 22 under the `dev` CMake preset; all 17 associated Catch2 test binaries pass under both compilers.
- Ran `clang-tidy` (repo's `.clang-tidy` config) against all touched files; confirmed no new findings on any changed line (all reported warnings are pre-existing, on untouched lines).
- Verified standalone header compilation via the `libfiction_verify_interface_header_sets` target's per-header object files for all 17 modified headers.
- Ran `prek` (clang-format + the rest of the hook suite) — clean.
- Added a changelog entry.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality. (N/A — no functional or interface changes)
- [x] I have made sure that all CI jobs on GitHub pass. (pending CI run)
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized SiDB simulation workflows with C++20 algorithm support.
  * Streamlined sorting, searching, filtering, shuffling, and validation operations.
  * Simplified charge-pair comparisons while preserving existing behavior.
  * Improved consistency across simulation calculations and layout processing.
  * Completed modernization across the algorithms module.

* **Documentation**
  * Updated equality-operator documentation to reflect the automatically provided inequality behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->