### PR TITLE
📝 Require agents to work in their own git worktree under `.ai/`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,14 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
   description why the existing one does not fit.
 - Test the documented contract, not provisional implementation choices. A test that pins
   down an internal detail blocks the next refactor without protecting a user.
+- **Work in your own git worktree, always.** Create it with
+  `git worktree add .ai/worktrees/<task> -b <branch>` and work there, never directly in the
+  primary checkout. Two agents that share a working directory overwrite each other's
+  uncommitted edits and switch the branch under each other, and neither notices. `.ai/` is
+  gitignored, so the worktree stays out of `git status`. Remove it with
+  `git worktree remove` when the task is done.
 - Inspect the working tree before editing, and never revert or overwrite a change you did
-  not make.
+  not make. If you find edits you did not write, stop and ask instead of reverting them.
 - Remove scaffolding before handoff: debug output, commented-out code, and `NOLINT`
   suppressions. A suppression that has to stay names the technical reason in a comment.
 - Warn when you spot a sub-par design decision, including in existing code, and say what
@@ -166,8 +172,8 @@ enforces the following:
     `docs/AGENTS.md` for the entry style.
   - Satisfy every box in `.github/pull_request_template.md` before calling a PR done.
   - Use `const` correctness and braced initialization.
-  - Keep plans, notes, and analyses in `.ai/` (gitignored). Never write them to the
-    repository root and never commit them.
+  - Keep plans, notes, analyses, and worktrees in `.ai/` (gitignored). Never write them to
+    the repository root and never commit them.
 - ⚠️ **Ask First**:
   - Before adding a new third-party dependency, whether vendored under `vendors/` or
     fetched from `CMakeLists.txt`.


### PR DESCRIPTION
## Description

Two agents that share the primary checkout overwrite each other's uncommitted edits and switch the branch under each other, and neither notices.

This is not hypothetical. While #1069 was in progress, a second agent running in the same working directory:

- left its in-progress edits to `include/fiction/algorithms/simulation/sidb/is_operational.hpp` in the other agent's working tree, in a state that did not compile;
- checked out its own branch there, which left the other agent on a detached `HEAD` and discarded an unfinished merge conflict resolution that existed only in the index.

Nothing was lost, but only because the collision happened to be noticed. Both agents were following the existing rules.

Two changes to `AGENTS.md`:

1. Require each agent to work in its own worktree, created with `git worktree add .ai/worktrees/<task> -b <branch>`. `.ai/` is already the documented home for agent plans and notes and is already gitignored, so the worktree stays out of `git status`.
2. Extend the neighbouring "never revert or overwrite a change you did not make" rule with what to do instead when foreign edits do turn up: stop and ask. Forbidding the revert without naming an alternative leaves no next step.

Verified that `git worktree add .ai/worktrees/<task>` works from the primary checkout and leaves `git status` clean there.

`.ai/` was chosen over `.claude/` — which some tooling already uses for worktrees — because `AGENTS.md` names `.ai/` as the agent directory and the in-repo agent configuration is deliberately provider-agnostic.

Fixes # (no issue)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Tests, changelog, and bindings are not applicable: this changes only the agent instructions, which are not user-facing and have no test surface.

---

Drafted with AI assistance. The `git worktree add` path was executed locally to confirm it behaves as documented; the incident described above is one I was directly involved in.
