### PR TITLE
📝 Widen refactoring scope, sharpen writing rules, and shrink build trees

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,20 +22,23 @@
   customManagers: [
     {
       // Renovate has no native manager for CMake FetchContent, so the pinned
-      // GIT_TAG versions in cmake/Dependencies.cmake are tracked via regex
-      // managers instead, one per dependency, matching the GIT_REPOSITORY on
-      // the preceding line to disambiguate between blocks.
+      // versions in cmake/Dependencies.cmake are tracked via regex managers
+      // instead, one per dependency, matching the `set(<DEP>_VERSION ...)`
+      // block that feeds the download URL. The version variables hold a bare
+      // version, so extractVersionTemplate strips the leading "v" from tags
+      // that carry one.
       customType: "regex",
       description: "Update the nlohmann_json revision pinned for CMake FetchContent",
       managerFilePatterns: [
         "cmake/Dependencies.cmake"
       ],
       matchStrings: [
-        "GIT_REPOSITORY https://github\\.com/nlohmann/json\\.git\\s+GIT_TAG (?<currentValue>v[0-9.]+)"
+        "set\\(JSON_VERSION\\s+(?<currentValue>[0-9.]+)"
       ],
       depNameTemplate: "nlohmann/json",
       packageNameTemplate: "nlohmann/json",
       datasourceTemplate: "github-tags",
+      extractVersionTemplate: "^v(?<version>.+)$",
     },
     {
       customType: "regex",
@@ -44,11 +47,12 @@
         "cmake/Dependencies.cmake"
       ],
       matchStrings: [
-        "GIT_REPOSITORY https://github\\.com/catchorg/Catch2\\.git\\s+GIT_TAG (?<currentValue>v[0-9.]+)"
+        "set\\(CATCH2_VERSION\\s+(?<currentValue>[0-9.]+)"
       ],
       depNameTemplate: "catchorg/Catch2",
       packageNameTemplate: "catchorg/Catch2",
       datasourceTemplate: "github-tags",
+      extractVersionTemplate: "^v(?<version>.+)$",
     },
     {
       customType: "regex",
@@ -57,11 +61,12 @@
         "cmake/Dependencies.cmake"
       ],
       matchStrings: [
-        "GIT_REPOSITORY https://github\\.com/greg7mdp/parallel-hashmap\\.git\\s+GIT_TAG (?<currentValue>v[0-9.]+)"
+        "set\\(PARALLEL_HASHMAP_VERSION\\s+(?<currentValue>[0-9.]+)"
       ],
       depNameTemplate: "greg7mdp/parallel-hashmap",
       packageNameTemplate: "greg7mdp/parallel-hashmap",
       datasourceTemplate: "github-tags",
+      extractVersionTemplate: "^v(?<version>.+)$",
     },
     {
       customType: "regex",
@@ -70,7 +75,7 @@
         "cmake/Dependencies.cmake"
       ],
       matchStrings: [
-        "GIT_REPOSITORY https://github\\.com/leethomason/tinyxml2\\.git\\s+GIT_TAG (?<currentValue>[0-9.]+)"
+        "set\\(TINYXML2_VERSION\\s+(?<currentValue>[0-9.]+)"
       ],
       depNameTemplate: "leethomason/tinyxml2",
       packageNameTemplate: "leethomason/tinyxml2",
@@ -79,14 +84,15 @@
     {
       // alice and mockturtle are pinned to a commit SHA that tracks the head
       // of a branch (rather than a release tag), so these use the git-refs
-      // datasource against that branch instead of github-tags.
+      // datasource against that branch instead of github-tags. mockturtle is
+      // still fetched as a clone, so its manager matches GIT_TAG.
       customType: "regex",
       description: "Update the alice revision pinned for CMake FetchContent",
       managerFilePatterns: [
         "cmake/Dependencies.cmake"
       ],
       matchStrings: [
-        "GIT_REPOSITORY https://github\\.com/marcelwa/alice\\.git\\s+GIT_TAG (?<currentDigest>[0-9a-f]{40})"
+        "set\\(ALICE_REV\\s+(?<currentDigest>[0-9a-f]{40})"
       ],
       depNameTemplate: "marcelwa/alice",
       packageNameTemplate: "https://github.com/marcelwa/alice",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -195,6 +195,12 @@
       ],
       commitMessagePrefix: "⬆️📦",
       automerge: false,
+      // The archive-based dependencies pin a SHA-256 in cmake/Dependencies.cmake
+      // that Renovate cannot compute, so a version bump lands with a stale hash
+      // and fails the configure step until someone regenerates it.
+      prBodyNotes: [
+        "⚠️ If this bump touches a `*_VERSION` or `ALICE_REV` variable in `cmake/Dependencies.cmake`, the matching `*_SHA256` is now stale and CMake will fail with `Hash mismatch`. Run `python3 scripts/update_dependency_hashes.py` and commit the result."
+      ],
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
 
 ## Working Principles
 
-- Prefer the smallest change that fully solves the task. Keep unrelated cleanup,
-  reformatting, and dependency bumps out of the same pull request; open a separate one.
+- Prefer the smallest change that fully solves the task. Cleanup, reformatting, and dependency
+  bumps in code the task does not otherwise touch belong in their own pull request.
 - Do not add an abstraction, a template parameter, or a configuration option until a
   second concrete caller needs it. _fiction_ is header-only and template-heavy, so every
   added template parameter costs compile time and instantiation surface in every
@@ -21,14 +21,25 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
   `git worktree add .ai/worktrees/<task> -b <branch>` and work there, never directly in the
   primary checkout. Two agents that share a working directory overwrite each other's
   uncommitted edits and switch the branch under each other, and neither notices. `.ai/` is
-  gitignored, so the worktree stays out of `git status`. Remove it with
-  `git worktree remove` when the task is done.
+  gitignored, so the worktree stays out of `git status`.
+- **Configure one build preset per worktree, and tear the worktree down when you are done.**
+  A configured build tree costs 1 to 4 GB, so a worktree left behind is not free the way the
+  source checkout is — that is only ~45 MB against a shared `.git`. Use a preset from
+  `CMakePresets.json` rather than a hand-rolled `-B` directory, so the build tree carries a
+  recognizable `build-<preset>` name that the next reader can place. When the task is done,
+  run `git worktree remove <path>` — which deletes the build trees with it — followed by
+  `git worktree prune`.
 - Inspect the working tree before editing, and never revert or overwrite a change you did
   not make. If you find edits you did not write, stop and ask instead of reverting them.
 - Remove scaffolding before handoff: debug output, commented-out code, and `NOLINT`
   suppressions. A suppression that has to stay names the technical reason in a comment.
-- Warn when you spot a sub-par design decision, including in existing code, and say what
-  you would do instead. Do not act on it in the same change without asking.
+- **Report every streamlining, restructuring, simplification, and optimization you notice
+  while working, including in existing code.** Say what you would do and why. This is part
+  of the task, not a distraction from it: a feature request or a bug fix is the moment
+  someone reads the surrounding code closely, and staying quiet wastes that reading.
+- Implement such a change in the same pull request when it falls inside the code the task
+  already modifies. Beyond that radius, name it in the pull request description and open a
+  separate pull request; do not expand the diff to reach it.
 - Prioritize the architecture and maintainability of the project as a whole.
 
 ## Writing
@@ -42,9 +53,16 @@ code comments, and error messages.
   "empty layouts are now rejected".
 - No metaphors, no figures of speech, no filler openers ("Note that", "It is worth
   mentioning that", "Basically").
+- Keep sentences short and direct, and give each sentence one idea. Prefer an explicit noun
+  to a pronoun whose referent the reader has to reconstruct — "the layout", not "it".
 - Use the established domain term, and use one term per concept. Do not paraphrase `SiDB`,
   `defect`, `gate library`, or `operational domain` into everyday words, and do not switch
-  between synonyms for variety.
+  between synonyms for variety. Take terminology from the repository's own usage and from
+  established precedent in field-coupled nanocomputing, logic synthesis, and design
+  automation. Where those communities use different words for one concept, explain the
+  mapping once and then pick one.
+- Prefer everyday English to a jargon term where it costs no precision. Where it does cost
+  precision, keep the precise term.
 - Preserve the capitalization of project names: _fiction_, `pyfiction`, `nanobind`,
   `mockturtle`, `kitty`, `alice`, `Catch2`, `CMake`, `GitHub`, `SiDB`, `QCA`, `iNML`.
 - Write for the final design, not for the history of how you got there. Do not narrate
@@ -52,6 +70,39 @@ code comments, and error messages.
   rejected alternative is worth recording because a reader would otherwise retry it, put
   it in a code comment at the site or in the pull request — not in the changelog.
 - Break any of these rules rather than write something unclear or imprecise.
+
+### Documentation describes the status quo
+
+Documentation, Doxygen comments, and docstrings state what the code does now and why. They
+never describe what it used to do. A reader has no access to the earlier state, so a
+sentence that compares against it carries no information and goes stale the moment someone
+reads it cold.
+
+Do not write "this fixes the way it was before", "unlike the previous implementation",
+"now correctly handles", "changed to return", or "no longer crashes". Describe the behavior
+that exists: "returns `std::nullopt` when the layout is empty".
+
+The same holds for the reason a thing is the way it is. Record it as a present-tense
+constraint at the site, not as a story about a past attempt — "`std::unordered_map`
+is not usable here because the iteration order feeds the gate ordering", not "switched away
+from `std::unordered_map` because it broke the gate ordering".
+
+`docs/changelog.rst` is the one exception, because naming the delta between two releases is
+its whole purpose. The word "now" marks the boundary: "`hexagonalization` now rejects empty
+layouts" is a good changelog entry, and a bad Doxygen comment on `hexagonalization`, which
+should say that the function rejects empty layouts.
+
+### Descriptions match the implementation
+
+For any user-facing surface — an algorithm entry point, a CLI command, a `pyfiction`
+binding, a page under `docs/` — keep the summary aligned with what the code actually does:
+its scope, its defaults, its limitations, its failure modes, and what it deliberately does
+not handle. A description that claims more than the implementation delivers produces bug
+reports against behavior that was never promised in code.
+
+When a change adds or alters such a surface, say what a user can do that they could not do
+before, and how they can see it working. Over-explain the user-visible effect; leave the
+incidental implementation detail to the code.
 
 ## Project Map
 
@@ -147,6 +198,9 @@ imitate.
     classes, etc.).
   - Use modern Doxygen commands (`@brief`, `@param`, `@return`, `@tparam`, `@file`,
     `@author`, `@ref`, `@see`, `@throws` etc.).
+  - Describe the status quo, never the previous behavior, and keep the description true to
+    what the code does — see "Documentation describes the status quo" and "Descriptions
+    match the implementation" under `Writing`.
   - The current codebase uses `// Created by ...` comments. A migration to using `@file`
     and `@author` tags per file (with full name and GitHub handle) is planned. After
     migration, the new convention will be enforced and `// Created by ...` comments should
@@ -173,7 +227,10 @@ enforces the following:
   - Satisfy every box in `.github/pull_request_template.md` before calling a PR done.
   - Use `const` correctness and braced initialization.
   - Keep plans, notes, analyses, and worktrees in `.ai/` (gitignored). Never write them to
-    the repository root and never commit them.
+    the repository root and never commit them. `.claude/worktrees/` is a superseded
+    location; do not add to it.
+  - Remove your worktree and its build trees when the task is done (`git worktree remove`,
+    then `git worktree prune`).
 - ⚠️ **Ask First**:
   - Before adding a new third-party dependency, whether vendored under `vendors/` or
     fetched from `CMakeLists.txt`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,11 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
   uncommitted edits and switch the branch under each other, and neither notices. `.ai/` is
   gitignored, so the worktree stays out of `git status`.
 - **Configure one build preset per worktree, and tear the worktree down when you are done.**
-  A configured build tree costs 1 to 4 GB, so a worktree left behind is not free the way the
-  source checkout is — that is only ~45 MB against a shared `.git`. Use a preset from
-  `CMakePresets.json` rather than a hand-rolled `-B` directory, so the build tree carries a
-  recognizable `build-<preset>` name that the next reader can place. When the task is done,
-  run `git worktree remove <path>` — which deletes the build trees with it — followed by
+  A new worktree adds about 45 MB of source files and shares the existing `.git`. Each
+  configured build tree adds another 1 to 4 GB. The build trees are what make an abandoned
+  worktree expensive. Use a preset from `CMakePresets.json` rather than a hand-rolled `-B`
+  directory, so each build tree has a recognizable `build-<preset>` name. When the task is
+  done, run `git worktree remove <path>`, which deletes the build trees with it, then run
   `git worktree prune`.
 - Inspect the working tree before editing, and never revert or overwrite a change you did
   not make. If you find edits you did not write, stop and ask instead of reverting them.
@@ -100,9 +100,10 @@ its scope, its defaults, its limitations, its failure modes, and what it deliber
 not handle. A description that claims more than the implementation delivers produces bug
 reports against behavior that was never promised in code.
 
-When a change adds or alters such a surface, say what a user can do that they could not do
-before, and how they can see it working. Over-explain the user-visible effect; leave the
-incidental implementation detail to the code.
+When a change adds or alters such a surface, describe the capability the surface provides
+and how a user can verify it. Over-explain the user-visible effect; leave the incidental
+implementation detail to the code. The changelog entry for the same change is where the
+delta against the previous release belongs.
 
 ## Project Map
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -7,6 +7,11 @@ include(FetchContent)
 # that cost once per directory. mockturtle is the exception; see the note below
 # it.
 #
+# Every `URL` carries a `URL_HASH`. A `GIT_TAG` commit SHA verifies its own
+# content; a URL does not, and a tag can be repointed at different bytes, so the
+# hash is what keeps the switch from weakening the supply chain. When bumping a
+# version, recompute the hash with `sha256sum` over the downloaded archive.
+#
 # None of these declarations uses `FIND_PACKAGE_ARGS`. vendors/CMakeLists.txt
 # reads `<dep>_SOURCE_DIR` and the target names that FetchContent creates, so a
 # dependency satisfied by an installed package instead would break the configure
@@ -19,10 +24,15 @@ set(JSON_VERSION
 set(JSON_URL
     https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz
 )
+set(JSON_SHA256
+    42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa)
 set(JSON_BuildTests
     OFF
     CACHE INTERNAL "")
-FetchContent_Declare(nlohmann_json URL ${JSON_URL})
+FetchContent_Declare(
+  nlohmann_json
+  URL ${JSON_URL}
+  URL_HASH SHA256=${JSON_SHA256})
 FetchContent_MakeAvailable(nlohmann_json)
 
 # Catch2
@@ -33,7 +43,12 @@ if(FICTION_TEST)
   set(CATCH2_URL
       https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz
   )
-  FetchContent_Declare(Catch2 URL ${CATCH2_URL})
+  set(CATCH2_SHA256
+      b0299ae552918220a7a6e21e7de5b714777f4e8c883fb70c4bb23fe01df8c6e3)
+  FetchContent_Declare(
+    Catch2
+    URL ${CATCH2_URL}
+    URL_HASH SHA256=${CATCH2_SHA256})
   FetchContent_MakeAvailable(Catch2)
 endif()
 
@@ -51,7 +66,12 @@ set(PARALLEL_HASHMAP_VERSION
 set(PARALLEL_HASHMAP_URL
     https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v${PARALLEL_HASHMAP_VERSION}.tar.gz
 )
-FetchContent_Declare(parallel-hashmap URL ${PARALLEL_HASHMAP_URL})
+set(PARALLEL_HASHMAP_SHA256
+    4f462f51a3468166ea4cf87c80e001dc1999093264cf55cbda3492ca39a7730b)
+FetchContent_Declare(
+  parallel-hashmap
+  URL ${PARALLEL_HASHMAP_URL}
+  URL_HASH SHA256=${PARALLEL_HASHMAP_SHA256})
 FetchContent_MakeAvailable(parallel-hashmap)
 
 # tinyxml2
@@ -61,8 +81,13 @@ set(TINYXML2_VERSION
 set(TINYXML2_URL
     https://github.com/leethomason/tinyxml2/archive/refs/tags/${TINYXML2_VERSION}.tar.gz
 )
+set(TINYXML2_SHA256
+    5556deb5081fb246ee92afae73efd943c889cef0cafea92b0b82422d6a18f289)
 set(tinyxml2_BUILD_TESTING OFF)
-FetchContent_Declare(tinyxml2 URL ${TINYXML2_URL})
+FetchContent_Declare(
+  tinyxml2
+  URL ${TINYXML2_URL}
+  URL_HASH SHA256=${TINYXML2_SHA256})
 FetchContent_MakeAvailable(tinyxml2)
 
 # alice
@@ -70,13 +95,18 @@ set(ALICE_REV
     6b7f941ca44f38226f5e2545224fa1194940cd73
     CACHE STRING "alice revision -- head of the master branch")
 set(ALICE_URL https://github.com/marcelwa/alice/archive/${ALICE_REV}.tar.gz)
+set(ALICE_SHA256
+    38709e50db916639c4baf7b2a7e56449baa65d6b17e6616d62439853e65163d2)
 set(ALICE_EXAMPLES
     OFF
     CACHE BOOL "" FORCE)
 set(ALICE_TEST
     OFF
     CACHE BOOL "" FORCE)
-FetchContent_Declare(alice URL ${ALICE_URL})
+FetchContent_Declare(
+  alice
+  URL ${ALICE_URL}
+  URL_HASH SHA256=${ALICE_SHA256})
 FetchContent_MakeAvailable(alice)
 
 # mockturtle

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -9,8 +9,18 @@ include(FetchContent)
 #
 # Every `URL` carries a `URL_HASH`. A `GIT_TAG` commit SHA verifies its own
 # content; a URL does not, and a tag can be repointed at different bytes, so the
-# hash is what keeps the switch from weakening the supply chain. When bumping a
-# version, recompute the hash with `sha256sum` over the downloaded archive.
+# hash is what keeps the switch from weakening the supply chain.
+#
+# A version and its hash have to move together. Renovate bumps the `*_VERSION`
+# and `ALICE_REV` variables but cannot compute a hash, so a bump arrives with a
+# stale `*_SHA256` and fails the configure step with `Hash mismatch`. Run
+# `python3 scripts/update_dependency_hashes.py` to bring the hashes back in
+# line, and `--check` to verify them without writing.
+#
+# Each `*_URL` and `*_SHA256` default is guarded by `if(NOT DEFINED ...)` so a
+# caller can point the build at an internal mirror with `-D<DEP>_URL=...`. A
+# plain `set()` would shadow the `-D` value; a `CACHE` entry would go stale when
+# the version changes.
 #
 # None of these declarations uses `FIND_PACKAGE_ARGS`. vendors/CMakeLists.txt
 # reads `<dep>_SOURCE_DIR` and the target names that FetchContent creates, so a
@@ -21,11 +31,15 @@ include(FetchContent)
 set(JSON_VERSION
     3.12.0
     CACHE STRING "nlohmann_json version")
-set(JSON_URL
-    https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz
-)
-set(JSON_SHA256
-    42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa)
+if(NOT DEFINED JSON_URL)
+  set(JSON_URL
+      https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz
+  )
+endif()
+if(NOT DEFINED JSON_SHA256)
+  set(JSON_SHA256
+      42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa)
+endif()
 set(JSON_BuildTests
     OFF
     CACHE INTERNAL "")
@@ -40,11 +54,15 @@ if(FICTION_TEST)
   set(CATCH2_VERSION
       3.15.3
       CACHE STRING "Catch2 version")
-  set(CATCH2_URL
-      https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz
-  )
-  set(CATCH2_SHA256
-      b0299ae552918220a7a6e21e7de5b714777f4e8c883fb70c4bb23fe01df8c6e3)
+  if(NOT DEFINED CATCH2_URL)
+    set(CATCH2_URL
+        https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz
+    )
+  endif()
+  if(NOT DEFINED CATCH2_SHA256)
+    set(CATCH2_SHA256
+        b0299ae552918220a7a6e21e7de5b714777f4e8c883fb70c4bb23fe01df8c6e3)
+  endif()
   FetchContent_Declare(
     Catch2
     URL ${CATCH2_URL}
@@ -63,11 +81,15 @@ endif()
 set(PARALLEL_HASHMAP_VERSION
     2.0.0
     CACHE STRING "parallel-hashmap version")
-set(PARALLEL_HASHMAP_URL
-    https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v${PARALLEL_HASHMAP_VERSION}.tar.gz
-)
-set(PARALLEL_HASHMAP_SHA256
-    4f462f51a3468166ea4cf87c80e001dc1999093264cf55cbda3492ca39a7730b)
+if(NOT DEFINED PARALLEL_HASHMAP_URL)
+  set(PARALLEL_HASHMAP_URL
+      https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v${PARALLEL_HASHMAP_VERSION}.tar.gz
+  )
+endif()
+if(NOT DEFINED PARALLEL_HASHMAP_SHA256)
+  set(PARALLEL_HASHMAP_SHA256
+      4f462f51a3468166ea4cf87c80e001dc1999093264cf55cbda3492ca39a7730b)
+endif()
 FetchContent_Declare(
   parallel-hashmap
   URL ${PARALLEL_HASHMAP_URL}
@@ -78,11 +100,15 @@ FetchContent_MakeAvailable(parallel-hashmap)
 set(TINYXML2_VERSION
     11.0.0
     CACHE STRING "tinyxml2 version")
-set(TINYXML2_URL
-    https://github.com/leethomason/tinyxml2/archive/refs/tags/${TINYXML2_VERSION}.tar.gz
-)
-set(TINYXML2_SHA256
-    5556deb5081fb246ee92afae73efd943c889cef0cafea92b0b82422d6a18f289)
+if(NOT DEFINED TINYXML2_URL)
+  set(TINYXML2_URL
+      https://github.com/leethomason/tinyxml2/archive/refs/tags/${TINYXML2_VERSION}.tar.gz
+  )
+endif()
+if(NOT DEFINED TINYXML2_SHA256)
+  set(TINYXML2_SHA256
+      5556deb5081fb246ee92afae73efd943c889cef0cafea92b0b82422d6a18f289)
+endif()
 set(tinyxml2_BUILD_TESTING OFF)
 FetchContent_Declare(
   tinyxml2
@@ -94,9 +120,13 @@ FetchContent_MakeAvailable(tinyxml2)
 set(ALICE_REV
     6b7f941ca44f38226f5e2545224fa1194940cd73
     CACHE STRING "alice revision -- head of the master branch")
-set(ALICE_URL https://github.com/marcelwa/alice/archive/${ALICE_REV}.tar.gz)
-set(ALICE_SHA256
-    38709e50db916639c4baf7b2a7e56449baa65d6b17e6616d62439853e65163d2)
+if(NOT DEFINED ALICE_URL)
+  set(ALICE_URL https://github.com/marcelwa/alice/archive/${ALICE_REV}.tar.gz)
+endif()
+if(NOT DEFINED ALICE_SHA256)
+  set(ALICE_SHA256
+      38709e50db916639c4baf7b2a7e56449baa65d6b17e6616d62439853e65163d2)
+endif()
 set(ALICE_EXAMPLES
     OFF
     CACHE BOOL "" FORCE)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,21 +1,39 @@
 include(FetchContent)
 
+# Dependencies are fetched as release tarballs rather than as git clones
+# wherever that is possible. A clone carries the upstream history into every
+# build directory -- for nlohmann_json that is 273 MB of `.git` against 2 MB of
+# sources -- and a developer with several build directories or worktrees pays
+# that cost once per directory. mockturtle is the exception; see the note below
+# it.
+#
+# None of these declarations uses `FIND_PACKAGE_ARGS`. vendors/CMakeLists.txt
+# reads `<dep>_SOURCE_DIR` and the target names that FetchContent creates, so a
+# dependency satisfied by an installed package instead would break the configure
+# step. Supporting both paths means reworking vendors/CMakeLists.txt first.
+
 # nlohmann_json
+set(JSON_VERSION
+    3.12.0
+    CACHE STRING "nlohmann_json version")
+set(JSON_URL
+    https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz
+)
 set(JSON_BuildTests
     OFF
     CACHE INTERNAL "")
-FetchContent_Declare(
-  nlohmann_json
-  GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG v3.12.0)
+FetchContent_Declare(nlohmann_json URL ${JSON_URL})
 FetchContent_MakeAvailable(nlohmann_json)
 
 # Catch2
 if(FICTION_TEST)
-  FetchContent_Declare(
-    Catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.15.3)
+  set(CATCH2_VERSION
+      3.15.3
+      CACHE STRING "Catch2 version")
+  set(CATCH2_URL
+      https://github.com/catchorg/Catch2/archive/refs/tags/v${CATCH2_VERSION}.tar.gz
+  )
+  FetchContent_Declare(Catch2 URL ${CATCH2_URL})
   FetchContent_MakeAvailable(Catch2)
 endif()
 
@@ -27,35 +45,47 @@ endif()
 # configure run where that option is guaranteed to be known.
 
 # parallel-hashmap
-FetchContent_Declare(
-  parallel-hashmap
-  GIT_REPOSITORY https://github.com/greg7mdp/parallel-hashmap.git
-  GIT_TAG v2.0.0)
+set(PARALLEL_HASHMAP_VERSION
+    2.0.0
+    CACHE STRING "parallel-hashmap version")
+set(PARALLEL_HASHMAP_URL
+    https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v${PARALLEL_HASHMAP_VERSION}.tar.gz
+)
+FetchContent_Declare(parallel-hashmap URL ${PARALLEL_HASHMAP_URL})
 FetchContent_MakeAvailable(parallel-hashmap)
 
 # tinyxml2
+set(TINYXML2_VERSION
+    11.0.0
+    CACHE STRING "tinyxml2 version")
+set(TINYXML2_URL
+    https://github.com/leethomason/tinyxml2/archive/refs/tags/${TINYXML2_VERSION}.tar.gz
+)
 set(tinyxml2_BUILD_TESTING OFF)
-FetchContent_Declare(
-  tinyxml2
-  GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
-  GIT_TAG 11.0.0)
+FetchContent_Declare(tinyxml2 URL ${TINYXML2_URL})
 FetchContent_MakeAvailable(tinyxml2)
 
 # alice
+set(ALICE_REV
+    6b7f941ca44f38226f5e2545224fa1194940cd73
+    CACHE STRING "alice revision -- head of the master branch")
+set(ALICE_URL https://github.com/marcelwa/alice/archive/${ALICE_REV}.tar.gz)
 set(ALICE_EXAMPLES
     OFF
     CACHE BOOL "" FORCE)
 set(ALICE_TEST
     OFF
     CACHE BOOL "" FORCE)
-FetchContent_Declare(
-  alice
-  GIT_REPOSITORY https://github.com/marcelwa/alice.git
-  GIT_TAG 6b7f941ca44f38226f5e2545224fa1194940cd73 # Head of the master branch
-)
+FetchContent_Declare(alice URL ${ALICE_URL})
 FetchContent_MakeAvailable(alice)
 
 # mockturtle
+#
+# The one dependency still fetched as a clone. mockturtle carries
+# `lib/parallel-hashmap` as a git submodule, and a GitHub source archive leaves
+# submodule directories empty, so a tarball build fails on `#include
+# <parallel_hashmap/phmap.h>`. Do not convert this to a `URL` without first
+# arranging for that header to resolve.
 set(MOCKTURTLE_EXAMPLES
     OFF
     CACHE BOOL "" FORCE)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,8 @@ Changed
       independent of exploration order and therefore unchanged
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
+    - Fetch dependencies as release tarballs instead of git clones, which shrinks a configured
+      build directory by roughly 240 MB. ``mockturtle`` stays a clone because it uses a submodule
 - Code quality:
     - Modernized the entire code base for C++20, adopting ``std::ranges`` algorithms, concepts,
       defaulted comparison operators, and designated initializers throughout

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,8 +36,8 @@ Changed
       independent of exploration order and therefore unchanged
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
-    - Fetch dependencies as release tarballs instead of git clones, which shrinks a configured
-      build directory by roughly 240 MB. ``mockturtle`` stays a clone because it uses a submodule
+    - Fetch dependencies as release archives instead of git clones, which cuts ``tests-slim``'s
+      ``_deps`` from 504 MB to 262 MB. ``mockturtle`` stays a clone because it uses a submodule
 - Code quality:
     - Modernized the entire code base for C++20, adopting ``std::ranges`` algorithms, concepts,
       defaulted comparison operators, and designated initializers throughout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,7 @@ known-first-party = ["mnt.pyfiction"]
 "bindings/mnt/pyfiction/test/**" = ["T20", "ANN", "D"]
 "docs/**" = ["T20", "A"]
 "noxfile.py" = ["T20", "TID251"]
+"scripts/**" = ["T20"]  # maintenance scripts report progress on stdout
 "*.pyi" = ["D418", "PYI021"]  # pydocstyle
 "*.ipynb" = [
     "D", # pydocstyle

--- a/scripts/update_dependency_hashes.py
+++ b/scripts/update_dependency_hashes.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Recompute the ``URL_HASH`` values in ``cmake/Dependencies.cmake``.
+
+Renovate bumps the ``*_VERSION`` and ``ALICE_REV`` variables in that file but
+cannot compute an archive hash, so a dependency bump arrives with a stale
+``*_SHA256`` and fails the CMake configure step with ``Hash mismatch``. This
+script downloads each declared archive and writes the hash that matches it.
+
+Run it with no arguments to update the file in place, or with ``--check`` to
+verify the hashes and exit non-zero when any of them is stale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+DEPENDENCIES_CMAKE = REPOSITORY_ROOT / "cmake" / "Dependencies.cmake"
+
+# Every dependency fetched by URL, as (CMake variable prefix, display name).
+DEPENDENCIES = [
+    ("JSON", "nlohmann_json"),
+    ("CATCH2", "Catch2"),
+    ("PARALLEL_HASHMAP", "parallel-hashmap"),
+    ("TINYXML2", "tinyxml2"),
+    ("ALICE", "alice"),
+]
+
+DOWNLOAD_CHUNK_SIZE = 1 << 16
+
+
+def read_variable(text: str, name: str) -> str:
+    """Read the first value of a ``set()`` call.
+
+    Handles the plain form and the ``CACHE STRING "..."`` form, and tolerates
+    the line breaks that ``cmake-format`` introduces.
+
+    Args:
+        text: Contents of ``cmake/Dependencies.cmake``.
+        name: The CMake variable to look up.
+
+    Returns:
+        The variable's value, with ``${...}`` references left unexpanded.
+
+    Raises:
+        SystemExit: When the variable is absent, which means this script and
+            ``cmake/Dependencies.cmake`` have drifted apart.
+    """
+    match = re.search(rf"set\({name}\s+([^\s)]+)", text)
+    if match is None:
+        msg = f"{name} not found in {DEPENDENCIES_CMAKE.name}"
+        raise SystemExit(msg)
+    return match.group(1)
+
+
+def expand(value: str, text: str) -> str:
+    """Substitute ``${VAR}`` references using the variables in the file.
+
+    Args:
+        value: A value that may contain ``${VAR}`` references.
+        text: Contents of ``cmake/Dependencies.cmake``.
+
+    Returns:
+        The value with every reference replaced.
+    """
+    while (match := re.search(r"\$\{(\w+)\}", value)) is not None:
+        value = value.replace(match.group(0), read_variable(text, match.group(1)))
+    return value
+
+
+def sha256_of(url: str) -> str:
+    """Stream an archive and digest it without holding it in memory.
+
+    Args:
+        url: The archive to download.
+
+    Returns:
+        The archive's SHA-256 digest as a hexadecimal string.
+    """
+    digest = hashlib.sha256()
+    with urllib.request.urlopen(url) as response:
+        while chunk := response.read(DOWNLOAD_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    """Compare every recorded hash against its archive.
+
+    Returns:
+        ``0`` when the hashes match or were updated, ``1`` otherwise.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the hashes without writing; exit non-zero when one is stale",
+    )
+    arguments = parser.parse_args()
+
+    text = DEPENDENCIES_CMAKE.read_text()
+    updated = text
+    stale: list[str] = []
+
+    for prefix, name in DEPENDENCIES:
+        url = expand(read_variable(text, f"{prefix}_URL"), text)
+        if not url.startswith("https://"):
+            print(f"{name}: refusing to fetch over a non-HTTPS URL: {url}", file=sys.stderr)
+            return 1
+
+        recorded = read_variable(text, f"{prefix}_SHA256")
+        actual = sha256_of(url)
+
+        if recorded == actual:
+            print(f"{name}: up to date")
+            continue
+
+        stale.append(name)
+        print(f"{name}: recorded {recorded}")
+        print(f"{' ' * len(name)}  actual   {actual}")
+        updated = re.sub(
+            rf"(set\({prefix}_SHA256\s+){re.escape(recorded)}",
+            rf"\g<1>{actual}",
+            updated,
+        )
+
+    if not stale:
+        print("\nAll hashes match.")
+        return 0
+
+    if arguments.check:
+        print(f"\nStale hashes: {', '.join(stale)}", file=sys.stderr)
+        print("Run scripts/update_dependency_hashes.py to fix them.", file=sys.stderr)
+        return 1
+
+    DEPENDENCIES_CMAKE.write_text(updated)
+    print(f"\nUpdated {len(stale)} hash(es) in {DEPENDENCIES_CMAKE.relative_to(REPOSITORY_ROOT)}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Three adjustments to the agentic setup, plus a build-system change that cuts what a
checkout costs on disk.

**Refactoring is in scope, not something to hold back.** `AGENTS.md` said "Do not act on it
in the same change without asking" about sub-par design decisions found in passing, and
kept "unrelated cleanup" out of the pull request. Together those read as an instruction to
stay quiet. Reporting a streamlining, restructuring, simplification, or optimization noticed
while working is now part of the task, and implementing one is allowed inside the code the
task already modifies. Cleanup beyond that radius still gets its own pull request. The
`experiments/` carve-out is untouched.

**Two writing rules adapted from MQT Core.** Documentation, Doxygen comments, and docstrings
describe the status quo rather than the previous behavior — a reader has no access to
"before", so "this fixes the way it was before" carries no information. `docs/changelog.rst`
is the stated exception, since naming the delta is its purpose. Separately, a description
now has to stay aligned with the implementation's actual scope, defaults, limitations, and
failure modes. The prose rules also pick up the ASD-STE100 principles and a terminology
precedent rule.

**Dependencies are fetched as release tarballs instead of git clones.** A clone stores the
upstream history in every build directory: `nlohmann_json` was 292 MB per build directory,
273 MB of it `.git`. Measured on `tests-slim`:

| | before | after |
| --- | --- | --- |
| `_deps` total | 504 MB | **262 MB** |
| `nlohmann_json` | 292 MB | **2.1 MB** |
| dependency `.git` | 322 MB | 32 MB |

Two constraints found while doing this, both recorded as comments in
`cmake/Dependencies.cmake`:

- `mockturtle` stays a clone. It carries `lib/parallel-hashmap` as a git submodule, and a
  GitHub source archive leaves submodule directories empty, so a tarball build fails on
  `#include <parallel_hashmap/phmap.h>`.
- No declaration uses `FIND_PACKAGE_ARGS`. `vendors/CMakeLists.txt` reads `<dep>_SOURCE_DIR`
  and the target names `FetchContent` creates, so a dependency satisfied by an installed
  package breaks the configure step — reproducible today on any machine with `tinyxml2`
  installed. Supporting both paths means reworking `vendors/CMakeLists.txt` first.

`.github/renovate.json5` is retargeted accordingly: five of the six custom managers keyed off
the `GIT_TAG` syntax this replaces, so without the update dependency automation would have
stopped silently. Each regex was verified against the reformatted file.

Finally, `AGENTS.md` now asks for one build preset per worktree and worktree teardown at task
end, since a build tree costs 1 to 4 GB against roughly 45 MB for the source checkout.

Fixes # (n/a)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. (n/a — no API change)
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Verified locally on this branch: `cmake --preset tests-slim` configures, builds 379 targets
with no failures, and `ctest` passes 118/118. `prek run` is clean on every changed file.

Drafted with AI assistance; the dependency change was verified by a clean configure, build,
and full test run, and the Renovate regexes were checked against the reformatted CMake file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build and Maintenance**
  * Dependencies are now downloaded from verified release archives where supported, improving build efficiency and reducing checkout size.
  * `mockturtle` continues to use a repository checkout where required for its submodule.
  * Dependency versions and download locations can be customized through build configuration.
  * The configured build directory is approximately 240 MB smaller.

* **Documentation**
  * Updated project guidance and changelog to reflect the revised dependency-fetching approach and reduced build footprint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->