### PR TITLE
♻️ Convert the unblocked `static_assert` type checks into `requires` clauses

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,6 +59,22 @@ jobs:
         with:
           python-version: "3.14.x"
 
+      # TEMPORARY: remove before merging. Checks whether Apple Clang has started shipping `<stop_token>` and
+      # `std::jthread`, which the note in `algorithms/simulation/sidb/operational_domain.hpp` says it has not.
+      # A green step means the flood fill's hand-rolled termination logic can move to `std::jthread`.
+      - name: Probe libc++ for std::jthread
+        continue-on-error: true
+        run: |
+          cat > probe.cpp <<'EOF'
+          #include <stop_token>
+          #include <thread>
+          #include <version>
+          static_assert(__cpp_lib_jthread >= 201911L, "std::jthread is not available");
+          int main() { std::jthread t{[](std::stop_token) {}}; }
+          EOF
+          clang++ --version
+          clang++ -std=c++20 probe.cpp -o probe && ./probe && echo "PROBE RESULT: jthread available"
+
       - name: Install building tools
         run: brew install autoconf
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,22 +59,6 @@ jobs:
         with:
           python-version: "3.14.x"
 
-      # TEMPORARY: remove before merging. Checks whether Apple Clang has started shipping `<stop_token>` and
-      # `std::jthread`, which the note in `algorithms/simulation/sidb/operational_domain.hpp` says it has not.
-      # A green step means the flood fill's hand-rolled termination logic can move to `std::jthread`.
-      - name: Probe libc++ for std::jthread
-        continue-on-error: true
-        run: |
-          cat > probe.cpp <<'EOF'
-          #include <stop_token>
-          #include <thread>
-          #include <version>
-          static_assert(__cpp_lib_jthread >= 201911L, "std::jthread is not available");
-          int main() { std::jthread t{[](std::stop_token) {}}; }
-          EOF
-          clang++ --version
-          clang++ -std=c++20 probe.cpp -o probe && ./probe && echo "PROBE RESULT: jthread available"
-
       - name: Install building tools
         run: brew install autoconf
 

--- a/bindings/mnt/pyfiction/README.md
+++ b/bindings/mnt/pyfiction/README.md
@@ -154,16 +154,27 @@ Action [pyfiction-docstring-generator](https://github.com/cda-tum/fiction/action
 which regenerates `pybind11_mkdoc_docstrings.hpp` and overrides the existing one every time changes to
 any `*.hpp` file are pushed to a branch.
 
-Alternatively, you can also run `pybind11_mkdoc` locally using the `pybind11_mkdoc` tool (not recommended):
+Alternatively, you can run `pybind11_mkdoc` locally (not recommended). It parses with libclang, so it needs the same
+include paths, defines, and language standard as the real build. Without them it parses this C++20 code base as C++11
+and silently drops the docstrings that follow anything it cannot parse, such as a `requires` clause.
+
+Install the tool and the libclang bindings, which must match the `libclang-18` shared library that does the parsing:
 
 ```bash
-pip install pybind11_mkdoc clang==14
+pip install "pybind11_mkdoc==3.0.0" "clang==18.1.8" nanobind
 ```
 
-To generate the docstrings call
+Configure a build to produce the compile database the flags are read from, then generate the docstrings from
+_fiction_'s base directory:
 
 ```bash
-python3 -m pybind11_mkdoc -o pybind11_mkdoc_docstrings.hpp -D FICTION_Z3_SOLVER `find ./include/fiction -name "*.hpp" -print`
+cmake --preset pyfiction
+python3 -m pybind11_mkdoc \
+  -o bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp \
+  -std=c++20 \
+  "-resource-dir=$(llvm-config-18 --libdir)/clang/18" \
+  $(python3 .github/scripts/mkdoc_compile_flags.py build-pyfiction) \
+  $(find include/fiction -name "*.hpp" -print)
 ```
 
-in _fiction_'s base directory.
+Expect zero parse errors. A drop in the number of generated symbols means the flags did not take effect.

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -4110,7 +4110,7 @@ static const char *mkd_doc_fiction_critical_temperature_domain_contour_tracing =
 R"doc(Computes the critical temperature domain of the given SiDB cell-level
 layout. The critical temperature domain consists of all parameter
 combinations for which the layout is logically operational, along with
-the critical temperature for each specific parameter point.nt.
+the critical temperature for each specific parameter point.
 
 This algorithm first uses random sampling to find a set of operational
 point within the parameter range. From there, it traverses outwards to

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -16742,7 +16742,14 @@ Args:
 
 )doc";
 
-static const char *mkd_doc_fiction_hexagonal_layout_hexagonal_layout_2 = R"doc()doc";
+static const char *mkd_doc_fiction_hexagonal_layout_hexagonal_layout_2 =
+R"doc(Constructor that takes ownership of an existing storage, so that the
+new layout shares the coordinates of the one the storage came from.
+
+Args:
+    s: Storage to adopt.
+
+)doc";
 
 static const char *mkd_doc_fiction_hexagonal_layout_hexagonal_layout_storage = R"doc()doc";
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -82,6 +82,12 @@ Changed
     - Modernized the entire code base for C++20, adopting ``std::ranges`` algorithms, concepts,
       defaulted comparison operators, and designated initializers throughout
     - Replaced unchecked ``operator[]`` with bounds-checked ``at()`` in the operational domain module
+    - The type checks on the path-finding, operational domain, and ``hexagonal_layout`` entry points
+      are now ``requires`` clauses. An unsatisfied one is reported as a failed constraint at the call
+      site instead of a ``static_assert`` message from inside the body
+    - ``hexagonal_layout`` now rejects an invalid ``HexagonalCoordinateSystem`` where the type is
+      named rather than where it is constructed
+    - ``exact`` no longer polls its worker futures every 10 ms while solving asynchronously
 - Continuous integration:
     - Updated the Ubuntu compiler matrix for C++20: dropped ``g++-10``, ``clang++-14``, and
       ``clang++-15``, and added ``clang++-19`` and ``clang++-20``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -88,6 +88,10 @@ Changed
     - ``hexagonal_layout`` now rejects an invalid ``HexagonalCoordinateSystem`` where the type is
       named rather than where it is constructed
     - ``exact`` no longer polls its worker futures every 10 ms while solving asynchronously
+    - Cleared the pre-existing Clang-Tidy findings in ``exact.hpp`` that touching the file surfaced:
+      pruned and completed its includes, replaced ``std::lock_guard`` with ``std::scoped_lock``,
+      unfolded four nested conditional operators into ``if``/``else``, and dropped an incorrect
+      ``noexcept`` from a lambda that can throw ``z3::exception``
 - Continuous integration:
     - Updated the Ubuntu compiler matrix for C++20: dropped ``g++-10``, ``clang++-14``, and
       ``clang++-15``, and added ``clang++-19`` and ``clang++-20``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -88,10 +88,9 @@ Changed
     - ``hexagonal_layout`` now rejects an invalid ``HexagonalCoordinateSystem`` where the type is
       named rather than where it is constructed
     - ``exact`` no longer polls its worker futures every 10 ms while solving asynchronously
-    - Cleared the pre-existing Clang-Tidy findings in ``exact.hpp`` that touching the file surfaced:
-      pruned and completed its includes, replaced ``std::lock_guard`` with ``std::scoped_lock``,
-      unfolded four nested conditional operators into ``if``/``else``, and dropped an incorrect
-      ``noexcept`` from a lambda that can throw ``z3::exception``
+    - ``exact`` now surfaces a failure in one of its asynchronous workers instead of reporting it
+      as "no layout found"
+    - Cleared the pre-existing Clang-Tidy findings in ``exact.hpp``
 - Continuous integration:
     - Updated the Ubuntu compiler matrix for C++20: dropped ``g++-10``, ``clang++-14``, and
       ``clang++-15``, and added ``clang++-19`` and ``clang++-20``

--- a/include/fiction/algorithms/path_finding/a_star.hpp
+++ b/include/fiction/algorithms/path_finding/a_star.hpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <limits>
@@ -395,13 +396,12 @@ class a_star_impl
  * @return The shortest loop-less path in `layout` from `objective.source` to `objective.target`.
  */
 template <typename Path, typename Lyt, typename Dist = uint64_t, typename Cost = uint8_t>
+    requires is_coordinate_layout_v<Lyt>
 [[nodiscard]] Path a_star(const Lyt& layout, const routing_objective<Lyt>& objective,
                           const distance_functor<Lyt, Dist>& dist_fn = manhattan_distance_functor<Lyt, uint64_t>(),
                           const cost_functor<Lyt, Cost>&     cost_fn = unit_cost_functor<Lyt, uint8_t>(),
                           const a_star_params&               params  = {}) noexcept
 {
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-
     return detail::a_star_impl<Path, Lyt, Dist, Cost>{layout, objective, dist_fn, cost_fn, params}.run();
 }
 /**
@@ -421,14 +421,10 @@ template <typename Path, typename Lyt, typename Dist = uint64_t, typename Cost =
  * @return Minimum path length between `source` and `target` in `layout`.
  */
 template <typename Lyt, typename Dist = uint64_t>
+    requires is_coordinate_layout_v<Lyt> && (std::integral<Dist> || std::floating_point<Dist>)
 [[nodiscard]] Dist a_star_distance(const Lyt& layout, const coordinate<Lyt>& source,
                                    const coordinate<Lyt>& target) noexcept
 {
-    // do not convert these `static_assert` type checks into a `requires` clause; see the note on `manhattan_distance`
-    // in `distance.hpp` for why the pyfiction docstring generator forbids it
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_arithmetic_v<Dist>, "Dist is not an arithmetic type");
-
     const auto path_length = a_star<layout_coordinate_path<Lyt>>(layout, {source, target}).size();
 
     if (path_length == 0ul)

--- a/include/fiction/algorithms/path_finding/cost.hpp
+++ b/include/fiction/algorithms/path_finding/cost.hpp
@@ -7,10 +7,10 @@
 
 #include "fiction/traits.hpp"
 
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <random>
-#include <type_traits>
 
 namespace fiction
 {
@@ -25,14 +25,10 @@ namespace fiction
  * @return Unit cost between `source` and `target`, i.e., 1.
  */
 template <typename Lyt, typename Cost = uint8_t>
+    requires is_coordinate_layout_v<Lyt> && std::integral<Cost>
 [[nodiscard]] constexpr Cost unit_cost([[maybe_unused]] const coordinate<Lyt>& source,
                                        [[maybe_unused]] const coordinate<Lyt>& target) noexcept
 {
-    // do not convert the `static_assert` type checks of this file's free functions into `requires` clauses; see the
-    // note on `manhattan_distance` in `distance.hpp` for why the pyfiction docstring generator forbids it
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_integral_v<Cost>, "Cost is not an integral type");
-
     return static_cast<Cost>(1);
 }
 /**
@@ -45,12 +41,10 @@ template <typename Lyt, typename Cost = uint8_t>
  * @return Random cost between `source` and `target`, i.e., a random number between 0 and 1.
  */
 template <typename Lyt, typename Cost = double>
+    requires is_coordinate_layout_v<Lyt> && std::floating_point<Cost>
 [[nodiscard]] Cost random_cost([[maybe_unused]] const coordinate<Lyt>& source,
                                [[maybe_unused]] const coordinate<Lyt>& target) noexcept
 {
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_floating_point_v<Cost>, "Cost is not a floating-point type");
-
     static std::default_random_engine           engine{std::random_device{}()};
     static std::uniform_real_distribution<Cost> distr{0, 1};
 

--- a/include/fiction/algorithms/path_finding/distance.hpp
+++ b/include/fiction/algorithms/path_finding/distance.hpp
@@ -9,10 +9,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <limits>
-#include <type_traits>
 
 namespace fiction
 {
@@ -30,20 +30,10 @@ namespace fiction
  * @return Manhattan distance between `source` and `target`.
  */
 template <typename Lyt, typename Dist = uint64_t>
+    requires is_coordinate_layout_v<Lyt> && std::integral<Dist>
 [[nodiscard]] constexpr Dist manhattan_distance([[maybe_unused]] const Lyt& lyt, const coordinate<Lyt>& source,
                                                 const coordinate<Lyt>& target) noexcept
 {
-    // do not convert the `static_assert` type checks of this file's free functions into `requires` clauses with
-    // `std::integral`/`std::floating_point`. The pyfiction docstring generator
-    // (.github/workflows/pyfiction-docstring-generator.yml) runs pybind11_mkdoc with neither `-I include` nor an
-    // `-std` flag, so it parses these headers as C++11 with unresolved project includes. A `requires` clause is a
-    // syntax error there, and it aborts the enclosing declaration list, dropping the Doxygen comments of everything
-    // declared after it. Passing `-std=c++20` alone makes this worse, not better: it cut the generated docstrings
-    // from 3292 to 1769 on CI. Fixing the include path is the prerequisite for revisiting it; tracked in
-    // https://github.com/cda-tum/fiction/issues/1062. The same applies to `cost.hpp` and `a_star.hpp`
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_integral_v<Dist>, "Dist is not an integral type");
-
     return static_cast<Dist>(std::abs(static_cast<int64_t>(source.x) - static_cast<int64_t>(target.x)) +
                              std::abs(static_cast<int64_t>(source.y) - static_cast<int64_t>(target.y)));
 }
@@ -60,12 +50,10 @@ template <typename Lyt, typename Dist = uint64_t>
  * @return Euclidean distance between `source` and `target`.
  */
 template <typename Lyt, typename Dist = double>
+    requires is_coordinate_layout_v<Lyt> && std::floating_point<Dist>
 [[nodiscard]] constexpr Dist euclidean_distance([[maybe_unused]] const Lyt& lyt, const coordinate<Lyt>& source,
                                                 const coordinate<Lyt>& target) noexcept
 {
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_floating_point_v<Dist>, "Dist is not a floating-point type");
-
     const auto x = static_cast<double>(source.x) - static_cast<double>(target.x);
     const auto y = static_cast<double>(source.y) - static_cast<double>(target.y);
 
@@ -87,12 +75,10 @@ template <typename Lyt, typename Dist = double>
  * @return Squared euclidean distance between `source` and `target`.
  */
 template <typename Lyt, typename Dist = uint64_t>
+    requires is_coordinate_layout_v<Lyt> && std::integral<Dist>
 [[nodiscard]] constexpr Dist squared_euclidean_distance([[maybe_unused]] const Lyt& lyt, const coordinate<Lyt>& source,
                                                         const coordinate<Lyt>& target) noexcept
 {
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_integral_v<Dist>, "Dist is not an integral type");
-
     const auto x = static_cast<double>(source.x) - static_cast<double>(target.x);
     const auto y = static_cast<double>(source.y) - static_cast<double>(target.y);
 
@@ -117,12 +103,10 @@ template <typename Lyt, typename Dist = uint64_t>
  * @return 2DDWave distance between `source` and `target`.
  */
 template <typename Lyt, typename Dist = uint64_t>
+    requires is_coordinate_layout_v<Lyt> && std::integral<Dist>
 [[nodiscard]] constexpr Dist twoddwave_distance([[maybe_unused]] const Lyt& lyt, const coordinate<Lyt>& source,
                                                 const coordinate<Lyt>& target) noexcept
 {
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_integral_v<Dist>, "Dist is not an integral type");
-
     return source.x <= target.x && source.y <= target.y ? manhattan_distance<Lyt, Dist>(lyt, source, target) :
                                                           static_cast<Dist>(std::numeric_limits<uint32_t>::max());
 }
@@ -142,12 +126,10 @@ template <typename Lyt, typename Dist = uint64_t>
  * @return Chebyshev distance between `source` and `target`.
  */
 template <typename Lyt, typename Dist = uint64_t>
+    requires is_coordinate_layout_v<Lyt> && std::integral<Dist>
 [[nodiscard]] constexpr Dist chebyshev_distance([[maybe_unused]] const Lyt& lyt, const coordinate<Lyt>& source,
                                                 const coordinate<Lyt>& target) noexcept
 {
-    static_assert(is_coordinate_layout_v<Lyt>, "Lyt is not a coordinate layout");
-    static_assert(std::is_integral_v<Dist>, "Dist is not an integral type");
-
     return static_cast<Dist>(std::max(std::abs(static_cast<int64_t>(source.x) - static_cast<int64_t>(target.x)),
                                       std::abs(static_cast<int64_t>(source.y) - static_cast<int64_t>(target.y))));
 }

--- a/include/fiction/algorithms/physical_design/exact.hpp
+++ b/include/fiction/algorithms/physical_design/exact.hpp
@@ -2996,26 +2996,20 @@ class exact_impl
                 fut[i] = std::async(std::launch::async, &exact_impl::explore_asynchronously, this, i, ti_list);
             }
 
-            // wait for all tasks to finish running (can be made much prettier in C++20...)
-            for (auto still_running = true; still_running;)
+            // wait for every task to finish running. This is the join that makes the unguarded `result_aspect_ratio`
+            // read below safe: a running task may still write it under `rar_mutex`
+            for (auto& f : fut)
             {
-                still_running = false;
-                for (auto i = 0u; i < ps.num_threads; ++i)
-                {
-                    using namespace std::chrono_literals;
-                    if (fut[i].wait_for(10ms) == std::future_status::timeout)
-                    {
-                        still_running = true;
-                    }
+                f.wait();
+
 #if (PROGRESS_BARS)
-                    else if (!post_toggle)
-                    {
-                        thread_bar.done();
-                        post_bar(true);
-                        post_toggle = true;
-                    }
-#endif
+                if (!post_toggle)
+                {
+                    thread_bar.done();
+                    post_bar(true);
+                    post_toggle = true;
                 }
+#endif
             }
 
             if (result_aspect_ratio)

--- a/include/fiction/algorithms/physical_design/exact.hpp
+++ b/include/fiction/algorithms/physical_design/exact.hpp
@@ -10,6 +10,7 @@
 #include "fiction/algorithms/iter/aspect_ratio_iterator.hpp"
 #include "fiction/algorithms/network_transformation/fanout_substitution.hpp"
 #include "fiction/layouts/clocking_scheme.hpp"
+#include "fiction/networks/technology_network.hpp"
 #include "fiction/technology/cell_ports.hpp"
 #include "fiction/technology/sidb_surface_analysis.hpp"
 #include "fiction/traits.hpp"
@@ -20,23 +21,22 @@
 #include "fiction/utils/truth_table_utils.hpp"
 
 #include <fmt/format.h>
-#include <kitty/dynamic_truth_table.hpp>
 #include <kitty/operations.hpp>
 #include <mockturtle/traits.hpp>
 #include <mockturtle/utils/node_map.hpp>
 #include <mockturtle/utils/stopwatch.hpp>
-#include <mockturtle/views/color_view.hpp>
 #include <mockturtle/views/depth_view.hpp>
 #include <mockturtle/views/fanout_view.hpp>
+#include <mockturtle/views/names_view.hpp>
 #include <mockturtle/views/topo_view.hpp>
 #if (PROGRESS_BARS)
 #include <mockturtle/utils/progress_bar.hpp>
 #endif
 
 #include <z3++.h>
+#include <z3_api.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
@@ -49,9 +49,9 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace fiction
@@ -178,9 +178,9 @@ template <typename Lyt>
 class exact_impl
 {
   public:
-    exact_impl(mockturtle::names_view<technology_network>& src, const exact_physical_design_params& p,
+    exact_impl(mockturtle::names_view<technology_network>& src, exact_physical_design_params p,
                exact_physical_design_stats& st, const surface_black_list<Lyt, port_direction>& sbl = {}) :
-            ps{p},
+            ps{std::move(p)},
             pst{st},
             scheme{*get_clocking_scheme<Lyt>(ps.scheme)},
             black_list{sbl}
@@ -271,12 +271,12 @@ class exact_impl
          * @param lyt The empty gate-level layout that is going to contain the created layout.
          * @param ps The parameters to respect in the SMT instance generation process.
          */
-        smt_handler(ctx_ptr ctxp, Lyt& lyt, const topology_ntk_t& ntk, const exact_physical_design_params& ps,
+        smt_handler(ctx_ptr ctxp, Lyt& lyt, const topology_ntk_t& ntk, exact_physical_design_params ps,
                     const surface_black_list<Lyt, port_direction>& sbl) noexcept :
                 ctx{std::move(ctxp)},
                 layout{lyt},
                 network{ntk},
-                params{ps},
+                params{std::move(ps)},
                 black_list{sbl},
                 node2pos{ntk},
                 depth_ntk{ntk},
@@ -694,7 +694,7 @@ class exact_impl
         template <typename Fn>
         void apply_to_added_tiles(Fn&& fn)
         {
-            std::for_each(check_point->added_tiles.cbegin(), check_point->added_tiles.cend(), fn);
+            std::for_each(check_point->added_tiles.cbegin(), check_point->added_tiles.cend(), std::forward<Fn>(fn));
         }
         /**
          * Applies a given function to all updated tiles in the current solver check point.
@@ -705,7 +705,7 @@ class exact_impl
         template <typename Fn>
         void apply_to_updated_tiles(Fn&& fn)
         {
-            std::for_each(check_point->updated_tiles.cbegin(), check_point->updated_tiles.cend(), fn);
+            std::for_each(check_point->updated_tiles.cbegin(), check_point->updated_tiles.cend(), std::forward<Fn>(fn));
         }
         /**
          * Applies a given function to all added and updated tiles in the current solver check point.
@@ -717,7 +717,7 @@ class exact_impl
         void apply_to_added_and_updated_tiles(Fn&& fn)
         {
             apply_to_added_tiles(fn);
-            apply_to_updated_tiles(fn);
+            apply_to_updated_tiles(std::forward<Fn>(fn));
         }
         /**
          * Determines the number of child nodes to some given node n in the stored logic network, not counting constants
@@ -959,7 +959,7 @@ class exact_impl
                     // an artificial latch variable counts as an extra 1 clock cycle (n clock phases)
                     if (has_synchronization_elements_v<Lyt> && params.synchronization_elements && !params.desynchronize)
                     {
-                        ve.push_back(z3::ite(get_te(t, e), get_tse(t) * num_phases + one, zero));
+                        ve.push_back(z3::ite(get_te(t, e), (get_tse(t) * num_phases) + one, zero));
                     }
                     else
                     {
@@ -2077,16 +2077,34 @@ class exact_impl
                 network.foreach_pi(
                     [this, &assign_north, &assign_west, &assign_border](const auto& pi)
                     {
-                        layout.is_clocking_scheme(clock_name::COLUMNAR) ? assign_west(pi) :
-                        layout.is_clocking_scheme(clock_name::ROW)      ? assign_north(pi) :
-                                                                          assign_border(pi);
+                        if (layout.is_clocking_scheme(clock_name::COLUMNAR))
+                        {
+                            assign_west(pi);
+                        }
+                        else if (layout.is_clocking_scheme(clock_name::ROW))
+                        {
+                            assign_north(pi);
+                        }
+                        else
+                        {
+                            assign_border(pi);
+                        }
                     });
                 network.foreach_po(
                     [this, &assign_east, &assign_south, &assign_border](const auto& po)
                     {
-                        layout.is_clocking_scheme(clock_name::COLUMNAR) ? assign_east(network.get_node(po)) :
-                        layout.is_clocking_scheme(clock_name::ROW)      ? assign_south(network.get_node(po)) :
-                                                                          assign_border(network.get_node(po));
+                        if (layout.is_clocking_scheme(clock_name::COLUMNAR))
+                        {
+                            assign_east(network.get_node(po));
+                        }
+                        else if (layout.is_clocking_scheme(clock_name::ROW))
+                        {
+                            assign_south(network.get_node(po));
+                        }
+                        else
+                        {
+                            assign_border(network.get_node(po));
+                        }
                     });
             }
             else
@@ -2099,10 +2117,18 @@ class exact_impl
                                                {
                                                    if (!skip_const_or_io_node(fon))
                                                    {
-                                                       layout.is_clocking_scheme(clock_name::COLUMNAR) ?
-                                                           assign_west(fon) :
-                                                       layout.is_clocking_scheme(clock_name::ROW) ? assign_north(fon) :
-                                                                                                    assign_border(fon);
+                                                       if (layout.is_clocking_scheme(clock_name::COLUMNAR))
+                                                       {
+                                                           assign_west(fon);
+                                                       }
+                                                       else if (layout.is_clocking_scheme(clock_name::ROW))
+                                                       {
+                                                           assign_north(fon);
+                                                       }
+                                                       else
+                                                       {
+                                                           assign_border(fon);
+                                                       }
                                                    }
                                                });
                     });
@@ -2110,17 +2136,26 @@ class exact_impl
                 network.foreach_po(
                     [this, &assign_east, &assign_south, &assign_border](const auto& po)
                     {
-                        network.foreach_fanin(
-                            po,
-                            [this, &assign_east, &assign_south, &assign_border](const auto& fi)
-                            {
-                                if (const auto fin = network.get_node(fi); !skip_const_or_io_node(fin))
-                                {
-                                    layout.is_clocking_scheme(clock_name::COLUMNAR) ? assign_east(fin) :
-                                    layout.is_clocking_scheme(clock_name::ROW)      ? assign_south(fin) :
-                                                                                      assign_border(fin);
-                                }
-                            });
+                        network.foreach_fanin(po,
+                                              [this, &assign_east, &assign_south, &assign_border](const auto& fi)
+                                              {
+                                                  if (const auto fin = network.get_node(fi);
+                                                      !skip_const_or_io_node(fin))
+                                                  {
+                                                      if (layout.is_clocking_scheme(clock_name::COLUMNAR))
+                                                      {
+                                                          assign_east(fin);
+                                                      }
+                                                      else if (layout.is_clocking_scheme(clock_name::ROW))
+                                                      {
+                                                          assign_south(fin);
+                                                      }
+                                                      else
+                                                      {
+                                                          assign_border(fin);
+                                                      }
+                                                  }
+                                              });
                     });
             }
         }
@@ -2367,7 +2402,8 @@ class exact_impl
          */
         void black_list_gates()  // TODO take advantage of incremental solving
         {
-            const auto gather_black_list_expr = [this](const auto& port, const auto& t) noexcept
+            // not `noexcept`: building the `z3::expr_vector` and every `z3` call below can throw `z3::exception`
+            const auto gather_black_list_expr = [this](const auto& port, const auto& t)
             {
                 z3::expr_vector iop{*ctx};
 
@@ -2816,7 +2852,7 @@ class exact_impl
         const auto time_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(time).count();
         const auto time_left = (ps.timeout - time_elapsed > 0 ? static_cast<unsigned>(ps.timeout - time_elapsed) : 0u);
 
-        if (!time_left)
+        if (time_left == 0u)
         {
             throw z3::exception("timeout");
         }
@@ -2866,7 +2902,7 @@ class exact_impl
 
             // mutually exclusive access to the aspect ratio iterator
             {
-                std::lock_guard<std::mutex> guard(ari_mutex);
+                const std::scoped_lock guard{ari_mutex};
 
                 ++ari;
                 ar = *ari;  // operations ++ and * are split to prevent a vector copy construction
@@ -2887,7 +2923,7 @@ class exact_impl
 
             // mutually exclusive access to the result aspect ratio
             {
-                std::lock_guard<std::mutex> guard(rar_mutex);
+                const std::scoped_lock guard{rar_mutex};
 
                 // a result is available already
                 if (result_aspect_ratio)
@@ -2912,7 +2948,7 @@ class exact_impl
                 {
                     // mutually exclusive access to the result_aspect_ratio
                     {
-                        std::lock_guard<std::mutex> guard(rar_mutex);
+                        const std::scoped_lock guard{rar_mutex};
 
                         // update the result_aspect_ratio if there is none
                         if (!result_aspect_ratio)
@@ -3062,6 +3098,9 @@ class exact_impl
         {
 
 #if (PROGRESS_BARS)
+            // `progress_bar::operator()` is non-const, so `bar` cannot be declared `const`; clang-tidy does not
+            // recognize the variadic call below as a mutating use
+            // NOLINTNEXTLINE(misc-const-correctness)
             mockturtle::progress_bar bar("[i] examining layout aspect ratios: {:>2} × {:<2}");
 #endif
 
@@ -3178,7 +3217,7 @@ std::optional<Lyt> exact(const Ntk& ntk, const exact_physical_design_params& ps 
         throw unsupported_clocking_scheme_exception();
     }
     // check for input degree
-    else if (has_high_degree_fanin_nodes(ntk, clocking_scheme->max_in_degree))
+    if (has_high_degree_fanin_nodes(ntk, clocking_scheme->max_in_degree))
     {
         throw high_degree_fanin_exception();
     }
@@ -3189,7 +3228,7 @@ std::optional<Lyt> exact(const Ntk& ntk, const exact_physical_design_params& ps 
         {
             std::cout << "[w] Lyt does not implement the foreach_adjacent_opposite_tiles function; straight inverters "
                          "cannot be guaranteed"
-                      << std::endl;
+                      << '\n';
         }
     }
     if constexpr (!fiction::has_synchronization_elements_v<Lyt>)

--- a/include/fiction/algorithms/physical_design/exact.hpp
+++ b/include/fiction/algorithms/physical_design/exact.hpp
@@ -3048,20 +3048,23 @@ class exact_impl
 #endif
             }
 
-            if (result_aspect_ratio)
+            // extract the layout from the futures. Every future is consumed, even when no result was found:
+            // `wait` above does not propagate a stored exception, so skipping `get` would discard a genuine worker
+            // failure and misreport it as "no layout found". `explore_asynchronously` handles `z3::exception`
+            // itself, so anything surfacing here is a real error and belongs to the caller
+            for (auto& f : fut)
             {
-                const auto result_ar_val = *result_aspect_ratio;
-                // extract the layout from the futures
-                for (auto& f : fut)
+                const auto l = f.get();
+
+                if (!result_aspect_ratio || !l.has_value())
                 {
-                    if (auto l = f.get(); l.has_value())
-                    {
-                        // in case multiple returned, get the actual winner
-                        if ((*l).x() == result_ar_val.x && (*l).y() == result_ar_val.y)
-                        {
-                            layout = *l;
-                        }
-                    }
+                    continue;
+                }
+
+                // in case multiple returned, get the actual winner
+                if (l->x() == result_aspect_ratio->x && l->y() == result_aspect_ratio->y)
+                {
+                    layout = *l;
                 }
             }
         }

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -643,10 +643,12 @@ class operational_domain_impl
 
         // this termination logic is hand-rolled rather than built on `std::jthread` with
         // `std::stop_source`/`std::stop_token` and the C++20 `std::condition_variable_any::wait` stop-token overload.
-        // Apple's libc++ does not ship `<stop_token>`: P0660R10 is absent from
-        // https://developer.apple.com/xcode/cpp/, so the macOS CI job cannot compile it. Upstream libc++ un-gated it
-        // from `-fexperimental-library` in LLVM 20. A single portable implementation was preferred over a
-        // feature-detected second copy. Revisit once Apple Clang ships the feature
+        // Apple's libc++ ships the `<stop_token>` and `<__thread/jthread.h>` headers but keeps their contents behind
+        // `-fexperimental-library`, so including them defines no `__cpp_lib_jthread` and declares neither
+        // `std::jthread` nor `std::stop_token`. Verified on the macOS CI runner on 2026-08-17: Apple clang 17.0.0
+        // (Xcode 16.4, macos-15) fails the probe with "use of undeclared identifier '__cpp_lib_jthread'". Upstream
+        // libc++ un-gated the feature in LLVM 20, which Apple Clang has not picked up yet. A single portable
+        // implementation was preferred over a feature-detected second copy. Revisit once Apple Clang un-gates it
         std::mutex              queue_mutex{};
         std::condition_variable queue_cv{};
 

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -2334,7 +2334,7 @@ critical_temperature_domain_flood_fill(const Lyt& lyt, const std::vector<TT>& sp
 /**
  * Computes the critical temperature domain of the given SiDB cell-level layout. The critical temperature domain
  * consists of all parameter combinations for which the layout is logically operational, along with the critical
- * temperature for each specific parameter point.nt.
+ * temperature for each specific parameter point.
  *
  * This algorithm first uses random sampling to find a set of operational point within the parameter range. From there,
  * it traverses outwards to find the edge of the operational area and performs Moore neighborhood contour tracing to

--- a/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
+++ b/include/fiction/algorithms/simulation/sidb/operational_domain.hpp
@@ -643,9 +643,10 @@ class operational_domain_impl
 
         // this termination logic is hand-rolled rather than built on `std::jthread` with
         // `std::stop_source`/`std::stop_token` and the C++20 `std::condition_variable_any::wait` stop-token overload.
-        // Apple's libc++ still gates `<stop_token>` and `std::jthread` behind `-fexperimental-library`, so both macOS
-        // CI jobs fail to compile them. A single portable implementation was preferred over a feature-detected second
-        // copy. Revisit once the macOS runners ship a libc++ that enables them by default
+        // Apple's libc++ does not ship `<stop_token>`: P0660R10 is absent from
+        // https://developer.apple.com/xcode/cpp/, so the macOS CI job cannot compile it. Upstream libc++ un-gated it
+        // from `-fexperimental-library` in LLVM 20. A single portable implementation was preferred over a
+        // feature-detected second copy. Revisit once Apple Clang ships the feature
         std::mutex              queue_mutex{};
         std::condition_variable queue_cv{};
 
@@ -1855,19 +1856,11 @@ class operational_domain_impl
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] operational_domain operational_domain_grid_search(const Lyt& lyt, const std::vector<TT>& spec,
                                                                 const operational_domain_params& params = {},
                                                                 operational_domain_stats*        stats  = nullptr)
 {
-    // do not convert the `static_assert` type checks in this file's public entry points into `requires` clauses: the
-    // pyfiction docstring generator parses this header as C++11 (see the note on `manhattan_distance` in
-    // `algorithms/path_finding/distance.hpp`), where the clause is a syntax error that drops the Doxygen comments of
-    // the declarations that follow. `kitty` also provides no `is_truth_table_v` alias that would simplify the third
-    // check
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     // this may throw an `std::invalid_argument` exception
     detail::validate_sweep_parameters(params);
 
@@ -1906,15 +1899,12 @@ template <typename Lyt, typename TT>
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] operational_domain operational_domain_random_sampling(const Lyt& lyt, const std::vector<TT>& spec,
                                                                     const std::size_t                samples,
                                                                     const operational_domain_params& params = {},
                                                                     operational_domain_stats*        stats  = nullptr)
 {
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     // this may throw an `std::invalid_argument` exception
     detail::validate_sweep_parameters(params);
 
@@ -1963,14 +1953,11 @@ template <typename Lyt, typename TT>
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] operational_domain
 operational_domain_flood_fill(const Lyt& lyt, const std::vector<TT>& spec, const std::size_t samples,
                               const operational_domain_params& params = {}, operational_domain_stats* stats = nullptr)
 {
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     if (params.sweep_dimensions.size() != 2 && params.sweep_dimensions.size() != 3)
     {
         throw std::invalid_argument("Flood fill is only applicable to 2 or 3 dimensions");
@@ -2023,15 +2010,12 @@ operational_domain_flood_fill(const Lyt& lyt, const std::vector<TT>& spec, const
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] operational_domain operational_domain_contour_tracing(const Lyt& lyt, const std::vector<TT>& spec,
                                                                     const std::size_t                samples,
                                                                     const operational_domain_params& params = {},
                                                                     operational_domain_stats*        stats  = nullptr)
 {
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     if (params.sweep_dimensions.size() != 2)
     {
         throw std::invalid_argument("Contour tracing is only applicable to exactly 2 dimensions");
@@ -2074,15 +2058,12 @@ template <typename Lyt, typename TT>
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] critical_temperature_domain
 critical_temperature_domain_grid_search(const Lyt& lyt, const std::vector<TT>& spec,
                                         const operational_domain_params& params = {},
                                         operational_domain_stats*        stats  = nullptr)
 {
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     // this may throw an `std::invalid_argument` exception
     detail::validate_sweep_parameters(params);
 
@@ -2120,15 +2101,12 @@ critical_temperature_domain_grid_search(const Lyt& lyt, const std::vector<TT>& s
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] critical_temperature_domain
 critical_temperature_domain_random_sampling(const Lyt& lyt, const std::vector<TT>& spec, const std::size_t samples,
                                             const operational_domain_params& params = {},
                                             operational_domain_stats*        stats  = nullptr)
 {
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     // this may throw an `std::invalid_argument` exception
     detail::validate_sweep_parameters(params);
 
@@ -2172,15 +2150,12 @@ critical_temperature_domain_random_sampling(const Lyt& lyt, const std::vector<TT
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] critical_temperature_domain
 critical_temperature_domain_flood_fill(const Lyt& lyt, const std::vector<TT>& spec, const std::size_t samples,
                                        const operational_domain_params& params = {},
                                        operational_domain_stats*        stats  = nullptr)
 {
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     if (params.sweep_dimensions.size() != 2 && params.sweep_dimensions.size() != 3)
     {
         throw std::invalid_argument("Flood fill is only applicable to 2 or 3 dimensions");
@@ -2232,15 +2207,12 @@ critical_temperature_domain_flood_fill(const Lyt& lyt, const std::vector<TT>& sp
  * @throws std::invalid_argument if the given sweep parameters are invalid.
  */
 template <typename Lyt, typename TT>
+    requires is_cell_level_layout_v<Lyt> && has_sidb_technology_v<Lyt> && kitty::is_truth_table<TT>::value
 [[nodiscard]] critical_temperature_domain
 critical_temperature_domain_contour_tracing(const Lyt& lyt, const std::vector<TT>& spec, const std::size_t samples,
                                             const operational_domain_params& params = {},
                                             operational_domain_stats*        stats  = nullptr)
 {
-    static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
-    static_assert(has_sidb_technology_v<Lyt>, "Lyt is not an SiDB layout");
-    static_assert(kitty::is_truth_table<TT>::value, "TT is not a truth table");
-
     if (params.sweep_dimensions.size() != 2)
     {
         throw std::invalid_argument("Contour tracing is only applicable to exactly 2 dimensions");

--- a/include/fiction/layouts/hexagonal_layout.hpp
+++ b/include/fiction/layouts/hexagonal_layout.hpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -149,6 +150,10 @@ struct even_column_hex : flat_top_hex
  */
 template <typename OffsetCoordinateType = offset::ucoord_t, typename HexagonalCoordinateSystem = even_row_hex,
           typename CubeCoordinateType = cube::coord_t>
+    requires std::same_as<HexagonalCoordinateSystem, odd_row_hex> ||
+             std::same_as<HexagonalCoordinateSystem, even_row_hex> ||
+             std::same_as<HexagonalCoordinateSystem, odd_column_hex> ||
+             std::same_as<HexagonalCoordinateSystem, even_column_hex>
 class hexagonal_layout
 {
   public:
@@ -182,30 +187,14 @@ class hexagonal_layout
      *
      * @param ar Highest possible position in the layout.
      */
-    explicit hexagonal_layout(const aspect_ratio& ar = {}) : strg{std::make_shared<hexagonal_layout_storage>(ar)}
-    {
-        // do not convert this `static_assert` disjunction, or its twin in the constructor below, into a `requires`
-        // clause: the pyfiction docstring generator parses this header as C++11 (see the note on
-        // `manhattan_distance` in `algorithms/path_finding/distance.hpp`), where the clause is a syntax error that
-        // drops the Doxygen comments of the ~60 member functions declared after these constructors, breaking the
-        // fully bound `hexagonal_layout` bindings' ReadTheDocs build
-        static_assert(std::is_same_v<HexagonalCoordinateSystem, odd_row_hex> ||
-                          std::is_same_v<HexagonalCoordinateSystem, even_row_hex> ||
-                          std::is_same_v<HexagonalCoordinateSystem, odd_column_hex> ||
-                          std::is_same_v<HexagonalCoordinateSystem, even_column_hex>,
-                      "HexagonalCoordinateSystem has to be one of the following: odd_row_hex, even_row_hex, "
-                      "odd_column_hex, even_column_hex");
-    }
-
-    explicit hexagonal_layout(std::shared_ptr<hexagonal_layout_storage> s) : strg{std::move(s)}
-    {
-        static_assert(std::is_same_v<HexagonalCoordinateSystem, odd_row_hex> ||
-                          std::is_same_v<HexagonalCoordinateSystem, even_row_hex> ||
-                          std::is_same_v<HexagonalCoordinateSystem, odd_column_hex> ||
-                          std::is_same_v<HexagonalCoordinateSystem, even_column_hex>,
-                      "HexagonalCoordinateSystem has to be one of the following: odd_row_hex, even_row_hex, "
-                      "odd_column_hex, even_column_hex");
-    }
+    explicit hexagonal_layout(const aspect_ratio& ar = {}) : strg{std::make_shared<hexagonal_layout_storage>(ar)} {}
+    /**
+     * Constructor that takes ownership of an existing storage, so that the new layout shares the coordinates of the
+     * one the storage came from.
+     *
+     * @param s Storage to adopt.
+     */
+    explicit hexagonal_layout(std::shared_ptr<hexagonal_layout_storage> s) : strg{std::move(s)} {}
     /**
      * Clones the layout returning a deep copy.
      *


### PR DESCRIPTION
## Description

Now that [#1077](https://github.com/cda-tum/fiction/pull/1077) taught the docstring generator to parse the code base correctly (closing [#1062](https://github.com/cda-tum/fiction/issues/1062)), the `static_assert` type checks that were deliberately kept in place can finally become `requires` clauses.

Several headers carried comments saying, in effect, *do not convert these `static_assert`s into `requires` clauses* — pybind11_mkdoc ran with neither `-I include` nor `-std`, parsed the headers as C++11, and treated a `requires` clause as a syntax error that aborted the enclosing declaration list and silently dropped the Doxygen comments of everything declared after it. With the generator now receiving the real compile flags, that constraint is gone.

### Constraints converted

- **Path finding** — `manhattan_distance`, `euclidean_distance`, `squared_euclidean_distance`, `twoddwave_distance`, `chebyshev_distance`, `unit_cost`, `random_cost`, `a_star`, and `a_star_distance`. `std::is_arithmetic_v`/`std::is_integral_v`/`std::is_floating_point_v` become `std::integral` and `std::floating_point`.
- **Operational domain** — all eight public entry points (`operational_domain_*` and `critical_temperature_domain_*` in grid-search, random-sampling, flood-fill, and contour-tracing flavors).
- **`hexagonal_layout`** — the `HexagonalCoordinateSystem` disjunction moves from two duplicated constructor-body `static_assert`s to a single `requires` clause on the class template. An invalid coordinate system is now rejected where the type is *named*, not where it is *constructed*, and the second constructor gains the Doxygen comment it never had.

The user-visible effect is that an unsatisfied constraint is reported as a failed constraint at the call site instead of a `static_assert` message from somewhere inside the function body.

### Drive-by fixes

- **`exact`'s asynchronous mode** no longer burns a thread polling `wait_for(10ms)` in a loop over its worker futures; it just `wait()`s on each in turn. The comment now records that this join is what makes the subsequent unguarded `result_aspect_ratio` read safe.
- **The `<stop_token>` note** in `operational_domain.hpp` is expanded with the concrete compiler the limitation was observed on, and with the fact that upstream libc++ un-gated the feature in LLVM 20 while Apple Clang has not picked it up. (An earlier revision of this branch rewrote the note to claim the header is absent entirely; the CI probe disproved that — see below — and the gating explanation is restored.)
- **The local docstring generation instructions** in `bindings/mnt/pyfiction/README.md` were still telling readers to run `pybind11_mkdoc` with `clang==14` and no include path or `-std` — exactly the invocation that caused #1062. They now pin the tool and libclang versions, configure a build for the compile database, and pass the flags through `.github/scripts/mkdoc_compile_flags.py`.

## macOS `std::jthread` probe: result

The temporary probe step has **run, reported, and been removed** (`de3c31f4`).

**Result: `std::jthread` is not available.** On `macos-15` / arm64, Apple clang 17.0.0 (Xcode 16.4):

```
probe.cpp:4:15: error: use of undeclared identifier '__cpp_lib_jthread'
probe.cpp:5:19: error: no type named 'jthread' in namespace 'std'; did you mean 'thread'?
probe.cpp:5:37: error: no type named 'stop_token' in namespace 'std'
```

So the flood fill's hand-rolled termination logic stays exactly as it is, and no `std::jthread` migration follows from this PR.

The probe also **falsified the reworded note it was meant to confirm**, which is now fixed in the same commit. `#include <stop_token>` did *not* fail as a missing header — the compiler got as far as instantiating `__thread/jthread.h` from the SDK — so this branch's claim that Apple's libc++ "does not ship `<stop_token>`" was wrong. The headers are present and their contents are gated behind `-fexperimental-library`, which is what the note said *before* this branch reworded it. The original explanation is restored, now with the compiler and date the finding was observed on.

## Verification

The six touched headers were compiled standalone via the `libfiction_verify_interface_header_sets` targets with the project's own flags — no errors, no new warnings.

Fixes # (issue) — none; unblocked by #1077 / #1062.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation. <sub>No new tests: the conversions are behavior-preserving on valid instantiations, and the existing suites already cover them. Documentation updated where it was wrong.</sub>
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. <sub>No API surface changed.</sub>
- [x] I have made sure that all CI jobs on GitHub pass. <sub>24 checks green, plus the `docs/readthedocs.org:fiction`, `pre-commit.ci`, and `CodeRabbit` statuses. `codecov/patch` is red for the reasons set out in the comments below; it is not a required check. CodeQL and the PyPI publish are skipped by their path filters.</sub>
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved compile-time validation for path-finding, distance, cost, operational-domain, and hexagonal-layout APIs.
  - Invalid configurations are now rejected earlier with clearer compiler diagnostics.
  - Improved reliability and synchronization for exact physical-design execution.

- **Bug Fixes**
  - Fixed timeout handling, locking, and asynchronous result processing.
  - Resolved code-quality warnings and corrected exception behavior.

- **Documentation**
  - Updated binding-generation instructions, build requirements, compiler settings, and expected validation results.
  - Added changelog entries describing API validation and reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
