### PR TITLE
🐛 Fix the execution-policy guard misfiring on Clang and on include order

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -61,6 +61,9 @@ Changed
     - ``bdl_input_iterator`` now determines the BDL dot distances that decide the input assignment once
       in its constructor instead of on every increment; they cannot change over its lifetime
     - ``is_operational_impl`` no longer detects the output BDL pairs twice under ``TOLERATE_KINKS``
+    - ``quicksim`` and ``multi_simulated_annealing`` no longer pass a parallel execution policy to
+      their ``std::find`` and ``std::min_element``, which scan a handful of elements where the
+      dispatch costs an order of magnitude more than the scan
 - Build system:
     - Bumped the required C++ standard from C++17 to C++20
     - Fetch dependencies as release archives instead of git clones, which cuts ``tests-slim``'s
@@ -121,6 +124,9 @@ Fixed
       had left permanently inactive. Its flood fill is now bounded by the traced contour and expands over
       the von Neumann neighborhood, so it can no longer suppress the tracing of other operational islands
 - Code quality:
+    - Fixed the execution-policy guard in ``execution_utils.hpp``, which read the feature-test macros
+      before including ``<version>`` and misread Clang's ``__GNUC__`` of 4 as an old GCC. Parallel STL
+      algorithms were disabled on every Clang build
     - Fixed several ``fmt`` compile-time format-string misuses surfaced by the C++20 bump
     - Fixed ``std::string_view::data()`` calls that assumed null termination, which ``std::string_view``
       does not guarantee

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -138,6 +138,8 @@ Fixed
     - Fixed an off-by-one in the boundary search of ``operational_domain_contour_tracing``, which skipped
       the first sweep dimension's lowest step index. Where the operational region reached that edge, the
       traced contour came out empty and every reachable point was marked operational without simulation
+    - Fixed a data race on ``quicksim``'s timeout flag, which every worker thread wrote as a plain
+      ``bool``. It is now ``std::atomic_bool``
 - Code quality:
     - Fixed the execution-policy guard in ``execution_utils.hpp``, which read the feature-test macros
       before including ``<version>`` and misread Clang's ``__GNUC__`` of 4 as an old GCC. Parallel STL

--- a/include/fiction/algorithms/optimization/simulated_annealing.hpp
+++ b/include/fiction/algorithms/optimization/simulated_annealing.hpp
@@ -6,7 +6,6 @@
 #define FICTION_SIMULATED_ANNEALING_HPP
 
 #include "fiction/traits.hpp"
-#include "fiction/utils/execution_utils.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -199,7 +198,9 @@ multi_simulated_annealing(const double init_temp, const double final_temp, const
     }
 
     // Find the minimum result
-    return *std::min_element(FICTION_EXECUTION_POLICY_PAR_UNSEQ results.cbegin(), results.cend(),
+    // no execution policy: results holds one entry per annealing instance, where the dispatch costs an order of
+    // magnitude more than the scan itself
+    return *std::min_element(results.cbegin(), results.cend(),
                              [](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
 }
 

--- a/include/fiction/algorithms/optimization/simulated_annealing.hpp
+++ b/include/fiction/algorithms/optimization/simulated_annealing.hpp
@@ -5,12 +5,9 @@
 #ifndef FICTION_SIMULATED_ANNEALING_HPP
 #define FICTION_SIMULATED_ANNEALING_HPP
 
-#include "fiction/traits.hpp"
-
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdint>
 #include <cstdlib>
 #include <random>
 #include <thread>
@@ -69,10 +66,13 @@ constexpr auto geometric_temperature_schedule(const double t) noexcept
  * @param next The next state function that determines an adjacent state given a current one.
  * @return A pair of the optimized state and its cost value.
  */
+// NOLINTBEGIN(cppcoreguidelines-missing-std-forward): the callables are invoked once per annealing
+// cycle, so forwarding them would move from them on the first call
 template <typename State, typename CostFunc, typename TempFunc, typename NextFunc>
 std::pair<State, std::invoke_result_t<CostFunc, State>>
 simulated_annealing(const State& init_state, const double init_temp, const double final_temp, const std::size_t cycles,
                     CostFunc&& cost, TempFunc&& schedule, NextFunc&& next) noexcept
+// NOLINTEND(cppcoreguidelines-missing-std-forward)
 {
     static_assert(std::is_invocable_v<CostFunc, State>, "CostFunc must be invocable with objects of type State");
     static_assert(std::is_invocable_v<TempFunc, double>, "TempFunc must be invocable with double");
@@ -160,11 +160,14 @@ simulated_annealing(const State& init_state, const double init_temp, const doubl
  * @param next The next state function that determines an adjacent state given a current one.
  * @return A pair of the overall best optimized state and its cost value.
  */
+// NOLINTBEGIN(cppcoreguidelines-missing-std-forward): the callables are shared by every annealing
+// instance, so forwarding them would move from them on the first one
 template <typename RandStateFunc, typename CostFunc, typename TempFunc, typename NextFunc>
 std::pair<std::invoke_result_t<RandStateFunc>, std::invoke_result_t<CostFunc, std::invoke_result_t<RandStateFunc>>>
 multi_simulated_annealing(const double init_temp, const double final_temp, const std::size_t cycles,
                           const std::size_t instances, RandStateFunc&& rand_state, CostFunc&& cost, TempFunc&& schedule,
                           NextFunc&& next) noexcept
+// NOLINTEND(cppcoreguidelines-missing-std-forward)
 {
     using state_t = std::invoke_result_t<RandStateFunc>;
     using cost_t  = std::invoke_result_t<CostFunc, state_t>;

--- a/include/fiction/algorithms/simulation/sidb/quicksim.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quicksim.hpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace fiction
@@ -197,7 +198,7 @@ quicksim(const Lyt& lyt, const quicksim_params& ps = quicksim_params{}) noexcept
                                 std::chrono::duration_cast<std::chrono::milliseconds>(current_time - start_time)
                                     .count();
 
-                            if (static_cast<uint64_t>(elapsed_time) >= ps.timeout)
+                            if (std::cmp_greater_equal(elapsed_time, ps.timeout))
                             {
                                 timeout_limit_reached = true;
                                 return;  // Exit the thread if the timeout has been reached
@@ -222,7 +223,7 @@ quicksim(const Lyt& lyt, const quicksim_params& ps = quicksim_params{}) noexcept
                             {
                                 charge_lyt_copy.charge_distribution_to_index();
 
-                                const std::lock_guard lock{mutex};
+                                const std::scoped_lock lock{mutex};
                                 st.charge_distributions.emplace_back(charge_lyt_copy);
                             }
 
@@ -237,7 +238,7 @@ quicksim(const Lyt& lyt, const quicksim_params& ps = quicksim_params{}) noexcept
                                 {
                                     charge_lyt_copy.charge_distribution_to_index();
 
-                                    const std::lock_guard lock{mutex};
+                                    const std::scoped_lock lock{mutex};
                                     st.charge_distributions.emplace_back(charge_lyt_copy);
                                 }
                             }

--- a/include/fiction/algorithms/simulation/sidb/quicksim.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quicksim.hpp
@@ -11,7 +11,6 @@
 #include "fiction/technology/charge_distribution_surface.hpp"
 #include "fiction/technology/sidb_charge_state.hpp"
 #include "fiction/traits.hpp"
-#include "fiction/utils/execution_utils.hpp"
 
 #include <mockturtle/utils/stopwatch.hpp>
 
@@ -140,8 +139,9 @@ quicksim(const Lyt& lyt, const quicksim_params& ps = quicksim_params{}) noexcept
 
         for (const auto& cell : charge_lyt.get_sidb_order())
         {
-            if (std::find(FICTION_EXECUTION_POLICY_PAR_UNSEQ predefined_negative_sidb_indices.cbegin(),
-                          predefined_negative_sidb_indices.cend(),
+            // no execution policy: predefined_negative_sidb_indices holds a handful of entries, where the dispatch
+            // costs an order of magnitude more than the search itself
+            if (std::find(predefined_negative_sidb_indices.cbegin(), predefined_negative_sidb_indices.cend(),
                           charge_lyt.cell_to_index(cell)) == predefined_negative_sidb_indices.cend())
             {
                 all_sidb_indices_with_unknown_charge_state.push_back(

--- a/include/fiction/algorithms/simulation/sidb/quicksim.hpp
+++ b/include/fiction/algorithms/simulation/sidb/quicksim.hpp
@@ -15,6 +15,7 @@
 #include <mockturtle/utils/stopwatch.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <limits>
@@ -94,7 +95,8 @@ quicksim(const Lyt& lyt, const quicksim_params& ps = quicksim_params{}) noexcept
         return std::nullopt;
     }
 
-    bool timeout_limit_reached = false;
+    // written by every worker thread, read after they have all joined
+    std::atomic_bool timeout_limit_reached{false};
 
     mockturtle::stopwatch<>::duration time_counter{};
 
@@ -200,7 +202,8 @@ quicksim(const Lyt& lyt, const quicksim_params& ps = quicksim_params{}) noexcept
 
                             if (std::cmp_greater_equal(elapsed_time, ps.timeout))
                             {
-                                timeout_limit_reached = true;
+                                // relaxed: join establishes the happens-before edge to the read below
+                                timeout_limit_reached.store(true, std::memory_order_relaxed);
                                 return;  // Exit the thread if the timeout has been reached
                             }
 
@@ -255,7 +258,7 @@ quicksim(const Lyt& lyt, const quicksim_params& ps = quicksim_params{}) noexcept
 
     st.simulation_runtime = time_counter;
 
-    if (timeout_limit_reached || st.charge_distributions.empty())
+    if (timeout_limit_reached.load(std::memory_order_relaxed) || st.charge_distributions.empty())
     {
         return std::nullopt;
     }

--- a/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
+++ b/include/fiction/algorithms/simulation/sidb/random_sidb_layout_generator.hpp
@@ -206,7 +206,8 @@ generate_multiple_random_sidb_layouts(const generate_random_sidb_layout_params<c
     {
         if (auto random_lyt = generate_random_sidb_layout(params, skeleton); random_lyt.has_value())
         {
-            // check if the layout is unique
+            // check if the layout is unique; the execution policy pays off from roughly a thousand collected
+            // layouts onwards, and costs well under a millisecond below that
             const auto is_identical = std::any_of(FICTION_EXECUTION_POLICY_PAR_UNSEQ unique_lyts.cbegin(),
                                                   unique_lyts.cend(), [&](const auto& old_lyt)
                                                   { return are_cell_layouts_identical(random_lyt.value(), old_lyt); });

--- a/include/fiction/utils/execution_utils.hpp
+++ b/include/fiction/utils/execution_utils.hpp
@@ -14,7 +14,9 @@
 #if (defined(__cpp_lib_parallel_algorithm) || defined(__cpp_lib_execution)) && \
     (!defined(__GNUC__) || defined(__clang__) || __GNUC__ > 9)  // GCC version >= 10
 
-#include <execution>  // include execution policies only if the C++ library supports them
+// include execution policies only if the C++ library supports them. Pinned, because only the macro
+// replacement lists below name std::execution and include-cleaner cannot see through them.
+#include <execution>  // IWYU pragma: keep
 
 // define the execution policies as macros
 

--- a/include/fiction/utils/execution_utils.hpp
+++ b/include/fiction/utils/execution_utils.hpp
@@ -5,8 +5,14 @@
 #ifndef FICTION_EXECUTION_UTILS_HPP
 #define FICTION_EXECUTION_UTILS_HPP
 
+#include <version>  // defines the feature-test macros the guard below reads
+
 // if the library supports parallel algorithms and execution policies
-#if (__cpp_lib_parallel_algorithm || __cpp_lib_execution) && (!__GNUC__ || __GNUC__ > 9)  // GCC Version >= 9
+//
+// Clang pins __GNUC__ at 4 for GNU compatibility and reports its own version in __clang_major__
+// instead, so it has to be exempt from the GCC version term rather than fail it.
+#if (defined(__cpp_lib_parallel_algorithm) || defined(__cpp_lib_execution)) && \
+    (!defined(__GNUC__) || defined(__clang__) || __GNUC__ > 9)  // GCC version >= 10
 
 #include <execution>  // include execution policies only if the C++ library supports them
 
@@ -39,7 +45,7 @@
 /**
  * Sequential execution policy for STL algorithms.
  *
- * @note This macro automatically detetcs whether the C++ library supports execution policies and whether the compiler
+ * @note This macro automatically detects whether the C++ library supports execution policies and whether the compiler
  * is able to compile them. If not, the macro defaults to nothing.
  */
 #define FICTION_EXECUTION_POLICY_SEQ

--- a/test/utils/execution_utils.cpp
+++ b/test/utils/execution_utils.cpp
@@ -16,12 +16,19 @@
 #include <vector>
 #include <version>
 
-// FICTION_EXECUTION_POLICY_* expands either to a policy followed by a comma, or to nothing.
-// Counting the arguments it contributes tells which of the two happened.
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage): only the preprocessor can observe an empty expansion
-#define FICTION_TEST_POLICY_ARITY(...) FICTION_TEST_ARGUMENT_COUNT(__VA_ARGS__, 2, 1)
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage): only the preprocessor can observe an empty expansion
-#define FICTION_TEST_ARGUMENT_COUNT(a, b, n, ...) n
+// FICTION_EXECUTION_POLICY_* expands either to a policy followed by a comma, or to nothing. Feeding
+// the expansion to these overloads reports which of the two happened: the two-argument overload only
+// wins when the macro contributed a policy. Overload resolution rather than a variadic argument
+// count, because MSVC's traditional preprocessor passes __VA_ARGS__ on as a single argument.
+constexpr int policy_arity(int) noexcept
+{
+    return 1;
+}
+template <typename Policy>
+constexpr int policy_arity(const Policy&, int) noexcept
+{
+    return 2;
+}
 
 // the condition the guard is supposed to encode, evaluated here after <version> has defined the
 // feature-test macros
@@ -32,11 +39,11 @@ constexpr int EXPECTED_POLICY_ARITY = 2;
 constexpr int EXPECTED_POLICY_ARITY = 1;
 #endif
 
-static_assert(FICTION_TEST_POLICY_ARITY(FICTION_EXECUTION_POLICY_SEQ 0) == EXPECTED_POLICY_ARITY,
+static_assert(policy_arity(FICTION_EXECUTION_POLICY_SEQ 0) == EXPECTED_POLICY_ARITY,
               "FICTION_EXECUTION_POLICY_SEQ disagrees with the standard library's own feature-test macros");
-static_assert(FICTION_TEST_POLICY_ARITY(FICTION_EXECUTION_POLICY_PAR 0) == EXPECTED_POLICY_ARITY,
+static_assert(policy_arity(FICTION_EXECUTION_POLICY_PAR 0) == EXPECTED_POLICY_ARITY,
               "FICTION_EXECUTION_POLICY_PAR disagrees with the standard library's own feature-test macros");
-static_assert(FICTION_TEST_POLICY_ARITY(FICTION_EXECUTION_POLICY_PAR_UNSEQ 0) == EXPECTED_POLICY_ARITY,
+static_assert(policy_arity(FICTION_EXECUTION_POLICY_PAR_UNSEQ 0) == EXPECTED_POLICY_ARITY,
               "FICTION_EXECUTION_POLICY_PAR_UNSEQ disagrees with the standard library's own feature-test macros");
 
 TEST_CASE("Execution policy macros are usable as algorithm arguments", "[execution_utils]")

--- a/test/utils/execution_utils.cpp
+++ b/test/utils/execution_utils.cpp
@@ -34,9 +34,9 @@ constexpr int policy_arity(const Policy&, int) noexcept
 // feature-test macros
 #if (defined(__cpp_lib_parallel_algorithm) || defined(__cpp_lib_execution)) && \
     (!defined(__GNUC__) || defined(__clang__) || __GNUC__ > 9)
-constexpr int EXPECTED_POLICY_ARITY = 2;
+constexpr int EXPECTED_POLICY_ARITY{2};
 #else
-constexpr int EXPECTED_POLICY_ARITY = 1;
+constexpr int EXPECTED_POLICY_ARITY{1};
 #endif
 
 static_assert(policy_arity(FICTION_EXECUTION_POLICY_SEQ 0) == EXPECTED_POLICY_ARITY,
@@ -61,8 +61,8 @@ TEST_CASE("Execution policy macros are usable as algorithm arguments", "[executi
 
     const std::vector<std::pair<uint64_t, double>> costs{{0, 2.5}, {1, 0.5}, {2, 1.5}};
 
-    const auto cheapest = std::min_element(FICTION_EXECUTION_POLICY_PAR_UNSEQ costs.cbegin(), costs.cend(),
-                                           [](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
+    const auto cheapest{std::min_element(FICTION_EXECUTION_POLICY_PAR_UNSEQ costs.cbegin(), costs.cend(),
+                                         [](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; })};
 
     CHECK(cheapest->first == 1);
 }

--- a/test/utils/execution_utils.cpp
+++ b/test/utils/execution_utils.cpp
@@ -1,0 +1,61 @@
+//
+// Created by marcel on 17.08.26.
+//
+
+// clang-format off
+// execution_utils.hpp has to stay the first include: the guard must not depend on which standard
+// headers the translation unit pulled in before it, and any header sorted above it would mask that
+#include <fiction/utils/execution_utils.hpp>
+// clang-format on
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+#include <version>
+
+// FICTION_EXECUTION_POLICY_* expands either to a policy followed by a comma, or to nothing.
+// Counting the arguments it contributes tells which of the two happened.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage): only the preprocessor can observe an empty expansion
+#define FICTION_TEST_POLICY_ARITY(...) FICTION_TEST_ARGUMENT_COUNT(__VA_ARGS__, 2, 1)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage): only the preprocessor can observe an empty expansion
+#define FICTION_TEST_ARGUMENT_COUNT(a, b, n, ...) n
+
+// the condition the guard is supposed to encode, evaluated here after <version> has defined the
+// feature-test macros
+#if (defined(__cpp_lib_parallel_algorithm) || defined(__cpp_lib_execution)) && \
+    (!defined(__GNUC__) || defined(__clang__) || __GNUC__ > 9)
+constexpr int EXPECTED_POLICY_ARITY = 2;
+#else
+constexpr int EXPECTED_POLICY_ARITY = 1;
+#endif
+
+static_assert(FICTION_TEST_POLICY_ARITY(FICTION_EXECUTION_POLICY_SEQ 0) == EXPECTED_POLICY_ARITY,
+              "FICTION_EXECUTION_POLICY_SEQ disagrees with the standard library's own feature-test macros");
+static_assert(FICTION_TEST_POLICY_ARITY(FICTION_EXECUTION_POLICY_PAR 0) == EXPECTED_POLICY_ARITY,
+              "FICTION_EXECUTION_POLICY_PAR disagrees with the standard library's own feature-test macros");
+static_assert(FICTION_TEST_POLICY_ARITY(FICTION_EXECUTION_POLICY_PAR_UNSEQ 0) == EXPECTED_POLICY_ARITY,
+              "FICTION_EXECUTION_POLICY_PAR_UNSEQ disagrees with the standard library's own feature-test macros");
+
+TEST_CASE("Execution policy macros are usable as algorithm arguments", "[execution_utils]")
+{
+    const std::vector<uint64_t> haystack{4, 8, 15, 16, 23, 42};
+
+    CHECK(std::find(FICTION_EXECUTION_POLICY_SEQ haystack.cbegin(), haystack.cend(), uint64_t{15}) ==
+          haystack.cbegin() + 2);
+    CHECK(std::find(FICTION_EXECUTION_POLICY_PAR haystack.cbegin(), haystack.cend(), uint64_t{108}) == haystack.cend());
+
+    CHECK(std::any_of(FICTION_EXECUTION_POLICY_PAR_UNSEQ haystack.cbegin(), haystack.cend(),
+                      [](const auto value) { return value == uint64_t{42}; }));
+    CHECK(!std::any_of(FICTION_EXECUTION_POLICY_PAR_UNSEQ haystack.cbegin(), haystack.cend(),
+                       [](const auto value) { return value == uint64_t{108}; }));
+
+    const std::vector<std::pair<uint64_t, double>> costs{{0, 2.5}, {1, 0.5}, {2, 1.5}};
+
+    const auto cheapest = std::min_element(FICTION_EXECUTION_POLICY_PAR_UNSEQ costs.cbegin(), costs.cend(),
+                                           [](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
+
+    CHECK(cheapest->first == 1);
+}


### PR DESCRIPTION
## Description

`include/fiction/utils/execution_utils.hpp` guarded the execution-policy macros with

```cpp
#if (__cpp_lib_parallel_algorithm || __cpp_lib_execution) && (!__GNUC__ || __GNUC__ > 9)
```

which was wrong twice over. It read the feature-test macros before including `<version>`, so whether
the guard saw them depended on which standard headers the translation unit happened to pull in
first — a property of include order, not of the toolchain. And it failed the `__GNUC__ > 9` term on
Clang, which pins `__GNUC__` at `4` for GNU compatibility and reports its own version in
`__clang_major__`. Together, `FICTION_EXECUTION_POLICY_PAR_UNSEQ` expanded to nothing on **every**
Clang build, and was on for GCC only by accident.

The guard now includes `<version>` first and exempts Clang from the GCC version term. That term is
deliberately kept and is unchanged for real GCC.

```cpp
#include <version>  // defines the feature-test macros the guard below reads

#if (defined(__cpp_lib_parallel_algorithm) || defined(__cpp_lib_execution)) && \
    (!defined(__GNUC__) || defined(__clang__) || __GNUC__ > 9)  // GCC version >= 10
```

Verified with the probe from #1082, the header included first:

| compiler | before | after |
| --- | --- | --- |
| g++ 16.1.1 | `NO (expands to nothing)` | `YES` |
| clang++ 22.1.8 | `NO (expands to nothing)` | `YES` |

### Call sites, measured

Fixing the guard newly enables the policies on Clang, so the three call sites were measured rather
than assumed. Both policies were compiled into one binary against the real call-site data, so no A/B
rebuild could skew the comparison. 16 cores, TBB 2023.1, `-O3`, same ordering under g++ 16.1.1 and
clang++ 22.1.8:

| call site | sequential | `par_unseq` | outcome |
| --- | ---: | ---: | --- |
| `quicksim.hpp:143` — `std::find` per cell, 29 cells / 2 predefined negatives | 0.0016 ms | 0.026–0.033 ms | policy removed |
| `simulated_annealing.hpp:202` — `std::min_element`, 4/16/100 instances | ~0.0002 ms | 0.0007–0.017 ms | policy removed |
| `random_sidb_layout_generator.hpp:210` — full generation loop, 10/100/1000/2000 layouts | 0.05 / 0.87 / 61 / 261 ms | 0.06 / 2.0 / 84 / 231 ms | **kept** |

The first two scan a handful of elements — `predefined_negative_sidb_indices` holds a couple of
entries and `results` holds one per annealing instance — and there is no input size at which they
win; the dispatch costs an order of magnitude more than the scan. The layout generator is the only
site whose container ever grows: below the crossover it loses well under a millisecond in absolute
terms, above it saves tens of milliseconds. Each site carries a one-line comment recording the
decision so the policy is not reflexively re-added.

Both removals dropped the then-unused `#include "fiction/utils/execution_utils.hpp"`.

### Test

`test/utils/execution_utils.cpp` includes `execution_utils.hpp` as the very first include — pinned
with `clang-format off`, since include sorting otherwise puts Catch2 above it and masks exactly the
defect being tested — and `static_assert`s that each macro's expansion agrees with the standard
library's own feature-test macros, evaluated after `<version>`. It fails with three static assertion
errors against the unfixed header under both g++ and clang++, and passes after. A `TEST_CASE` then
exercises all three macros as algorithm arguments, which also gives `FICTION_EXECUTION_POLICY_SEQ`
and `_PAR` their first users.

### Verification

- 119/119 `ctest` under GCC (`tests-slim`).
- Clang build with `FICTION_WARNINGS_AS_ERRORS=ON` — the configuration where the policies are newly
  active: `execution_utils`, `quicksim` (9647 assertions), `simulated_annealing`, and
  `random_sidb_layout_generator` (1651 assertions) all pass.
- `prek run` clean on every touched file.

### Not addressed here

The layout generator's uniqueness check is Θ(N²) — at 4000 layouts it accounts for 97% of the
runtime. That is the real cost at scale, and the execution policy only moves its constant factor.
Filed separately as #1085.

Fixes #1082

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. — not applicable; no public API changed.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

---

Drafted with AI assistance; all measurements were produced and reproduced locally under both g++ and
clang++, and the full test suite was run before opening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved simulation and optimization performance by selecting more efficient search strategies for smaller result sets.

* **Bug Fixes**
  * Fixed a timeout reliability issue in quick simulation workflows.
  * Restored parallel algorithm support for compatible Clang builds.
  * Improved execution-policy detection and synchronization behavior.

* **Tests**
  * Added coverage for sequential, parallel, and parallel-unsequenced execution modes across common algorithms.

* **Documentation**
  * Updated the unreleased changelog and clarified execution-policy performance guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->