### PR TITLE
📝 Fold cleanup into the pull request that finds it, and open `experiments/` to modernization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,15 +9,16 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
 - Prefer the smallest change that fully solves the task, then improve what you found on
   the way there. Dependency bumps are the one thing that still belongs in its own pull
   request; Renovate opens those itself.
-- Do not add an abstraction, a template parameter, or a configuration option until a
+- Never add an abstraction, a template parameter, or a configuration option until a
   second concrete caller needs it. _fiction_ is header-only and template-heavy, so every
   added template parameter costs compile time and instantiation surface in every
   translation unit that includes the header.
 - Prefer an existing facility from the STL, `mockturtle`, or `kitty` over a new
   implementation. If you add a helper that duplicates one of them, say in the pull request
   description why the existing one does not fit.
-- Test the documented contract, not provisional implementation choices. A test that pins
-  down an internal detail blocks the next refactor without protecting a user.
+- Test the documented contract. Never pin down a provisional implementation choice: a
+  test that asserts on an internal detail blocks the next refactor without protecting a
+  user.
 - **Work in your own git worktree, always.** Create it with
   `git worktree add .ai/worktrees/<task> -b <branch>` and work there, never directly in the
   primary checkout. Two agents that share a working directory overwrite each other's
@@ -54,12 +55,12 @@ code comments, and error messages.
 - Cut every word that does not change the meaning. Prefer the short word.
 - Use active voice and name the actor: "`hexagonalization` now rejects empty layouts", not
   "empty layouts are now rejected".
-- No metaphors, no figures of speech, no filler openers ("Note that", "It is worth
+- Never use a metaphor, a figure of speech, or a filler opener ("Note that", "It is worth
   mentioning that", "Basically").
 - Keep sentences short and direct, and give each sentence one idea. Prefer an explicit noun
   to a pronoun whose referent the reader has to reconstruct — "the layout", not "it".
-- Use the established domain term, and use one term per concept. Do not paraphrase `SiDB`,
-  `defect`, `gate library`, or `operational domain` into everyday words, and do not switch
+- Use the established domain term, and use one term per concept. Never paraphrase `SiDB`,
+  `defect`, `gate library`, or `operational domain` into everyday words, and never switch
   between synonyms for variety. Take terminology from the repository's own usage and from
   established precedent in field-coupled nanocomputing, logic synthesis, and design
   automation. Where those communities use different words for one concept, explain the
@@ -68,7 +69,7 @@ code comments, and error messages.
   precision, keep the precise term.
 - Preserve the capitalization of project names: _fiction_, `pyfiction`, `nanobind`,
   `mockturtle`, `kitty`, `alice`, `Catch2`, `CMake`, `GitHub`, `SiDB`, `QCA`, `iNML`.
-- Write for the final design, not for the history of how you got there. Do not narrate
+- Write for the final design, not for the history of how you got there. Never narrate
   review rounds, prompts, former names, or the order in which you did the work. Where a
   rejected alternative is worth recording because a reader would otherwise retry it, put
   it in a code comment at the site or in the pull request — not in the changelog.
@@ -81,12 +82,12 @@ never describe what it used to do. A reader has no access to the earlier state, 
 sentence that compares against it carries no information and goes stale the moment someone
 reads it cold.
 
-Do not write "this fixes the way it was before", "unlike the previous implementation",
+Never write "this fixes the way it was before", "unlike the previous implementation",
 "now correctly handles", "changed to return", or "no longer crashes". Describe the behavior
 that exists: "returns `std::nullopt` when the layout is empty".
 
 The same holds for the reason a thing is the way it is. Record it as a present-tense
-constraint at the site, not as a story about a past attempt — "`std::unordered_map`
+constraint at the site, not as an account of a past attempt — "`std::unordered_map`
 is not usable here because the iteration order feeds the gate ordering", not "switched away
 from `std::unordered_map` because it broke the gate ordering".
 
@@ -162,7 +163,7 @@ current code before acting:
 `clang-tidy` findings from the `Clang-Tidy Review` workflow are binding: fix them, or
 suppress the specific check with a `// NOLINT(check-name)` comment stating the reason.
 CodeRabbit findings are suggestions; disagreeing with a stated reason is a normal outcome,
-and LLM reviewers skew conservative. Reply to comments, do not resolve them — resolution
+and LLM reviewers skew conservative. Reply to comments; never resolve them — resolution
 belongs to the reviewer. Full workflow: `docs/contributing.rst`, "Code Review".
 
 ## Git and GitHub
@@ -205,10 +206,9 @@ imitate.
   - Describe the status quo, never the previous behavior, and keep the description true to
     what the code does — see "Documentation describes the status quo" and "Descriptions
     match the implementation" under `Writing`.
-  - The current codebase uses `// Created by ...` comments. A migration to using `@file`
-    and `@author` tags per file (with full name and GitHub handle) is planned. After
-    migration, the new convention will be enforced and `// Created by ...` comments should
-    no longer be used.
+  - The codebase still carries `// Created by ...` comments. A migration to per-file
+    `@file` and `@author` tags, with full name and GitHub handle, is planned; once it
+    lands, that convention is enforced and `// Created by ...` is gone.
 
 ### Python
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
 
 ## Working Principles
 
-- Prefer the smallest change that fully solves the task. Cleanup, reformatting, and dependency
-  bumps in code the task does not otherwise touch belong in their own pull request.
+- Prefer the smallest change that fully solves the task, then improve what you found on
+  the way there. Dependency bumps are the one thing that still belongs in its own pull
+  request; Renovate opens those itself.
 - Do not add an abstraction, a template parameter, or a configuration option until a
   second concrete caller needs it. _fiction_ is header-only and template-heavy, so every
   added template parameter costs compile time and instantiation surface in every
@@ -37,9 +38,11 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
   while working, including in existing code.** Say what you would do and why. This is part
   of the task, not a distraction from it: a feature request or a bug fix is the moment
   someone reads the surrounding code closely, and staying quiet wastes that reading.
-- Implement such a change in the same pull request when it falls inside the code the task
-  already modifies. Beyond that radius, name it in the pull request description and open a
-  separate pull request; do not expand the diff to reach it.
+- Implement it in the same pull request, as its own commit, so a reviewer reads it apart
+  from the feature. There is no radius: a fix or a cleanup you found while working ships
+  with the work that found it, not in a follow-up pull request that nobody opens.
+- A redesign is the exception, because it costs more to review than to write. Say what you
+  would change and why, and act once the maintainer agrees.
 - Prioritize the architecture and maintainability of the project as a whole.
 
 ## Writing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,13 +115,13 @@ Each subtree below adds rules to this file and never contradicts it. Read the on
 matches what you touch. **If your tool does not load nested instruction files
 automatically, open the file yourself** — several do not.
 
-| Touching                  | Read                               | Why it matters                                                     |
-| ------------------------- | ---------------------------------- | ------------------------------------------------------------------ |
-| `bindings/mnt/pyfiction/` | `bindings/mnt/pyfiction/AGENTS.md` | nanobind wiring; five steps, no compiler reminder                  |
-| `test/`                   | `test/AGENTS.md`                   | test file base names must be globally unique                       |
-| `docs/`                   | `docs/AGENTS.md`                   | a page missing from a `toctree` builds silently and is unreachable |
-| `cli/`                    | `cli/AGENTS.md`                    | the one subtree with manual source lists, in two places            |
-| `experiments/`            | `experiments/AGENTS.md`            | published-paper reproductions; do not refactor them                |
+| Touching                  | Read                               | Why it matters                                                      |
+| ------------------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| `bindings/mnt/pyfiction/` | `bindings/mnt/pyfiction/AGENTS.md` | nanobind wiring; five steps, no compiler reminder                   |
+| `test/`                   | `test/AGENTS.md`                   | test file base names must be globally unique                        |
+| `docs/`                   | `docs/AGENTS.md`                   | a page missing from a `toctree` builds silently and is unreachable  |
+| `cli/`                    | `cli/AGENTS.md`                    | the one subtree with manual source lists, in two places             |
+| `experiments/`            | `experiments/AGENTS.md`            | published-paper reproductions; the code may change, the results not |
 
 Everything else: `include/fiction/` is the header-only C++20 library; `vendors/` holds
 third-party sources and is never modified; `benchmarks/` is input data. Build presets live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,8 +163,10 @@ current code before acting:
 `clang-tidy` findings from the `Clang-Tidy Review` workflow are binding: fix them, or
 suppress the specific check with a `// NOLINT(check-name)` comment stating the reason.
 CodeRabbit findings are suggestions; disagreeing with a stated reason is a normal outcome,
-and LLM reviewers skew conservative. Reply to comments; never resolve them — resolution
-belongs to the reviewer. Full workflow: `docs/contributing.rst`, "Code Review".
+and LLM reviewers skew conservative. CodeRabbit skips drafts, and marking a draft ready
+does not trigger a pass — ask for one with a `@coderabbitai review` comment. Reply to
+comments; never resolve them — resolution belongs to the reviewer. Full workflow:
+`docs/contributing.rst`, "Code Review".
 
 ## Git and GitHub
 
@@ -187,7 +189,17 @@ imitate.
   first; if you cannot explain it, do not submit it.
 - Never push, open or merge a pull request, post a comment, open an issue, or otherwise
   change remote state unless the maintainer authorized that specific action. Authorization
-  for one task does not carry over to the next.
+  for one task does not carry over to the next. It does carry within one pull request:
+  permission to open it covers pushing fixes to it until it is green and replying to its
+  review comments.
+- Opening a pull request does not finish the task. Watch it: poll `gh pr checks <PR>`, fix
+  what fails, push, and poll again. The matrix spans Linux, macOS, and Windows in Debug
+  and Release, plus the Python bindings, and takes hours — check back periodically rather
+  than blocking on `--watch`. Reviews arrive on their own schedule; answer them as they
+  land, as described under "Code Review".
+- Report success only once every required check is green and every review comment has an
+  answer. Report a check you cannot make pass just as promptly, naming the job and quoting
+  the failing lines. Never leave a red pull request unmentioned.
 
 ## Code Style
 

--- a/experiments/AGENTS.md
+++ b/experiments/AGENTS.md
@@ -1,16 +1,30 @@
 # AGENTS.md — experiments
 
 These programs reproduce the results of published papers. They are build artifacts of the
-scientific record, not library code.
+scientific record, so their results are fixed even though their code is not.
 
-- **Do not modernize, refactor, generalize, or reformat an existing experiment.** The
-  ongoing C++20 modernization campaign in `include/fiction/` stops at this directory.
-  Change an experiment only to fix a compilation break or a genuine correctness bug, and
-  say so in the changelog entry.
+- The C++20 modernization campaign in `include/fiction/` covers this directory too.
+  Modernize, refactor, and reformat an experiment as you would library code.
+- **Never change what an experiment computes.** An experiment that reproduces a published
+  result keeps producing that result: same parameters, same inputs, same output columns.
+- Record a change to an experiment under `Experiments` in `docs/changelog.rst`.
 - `experiments/CMakeLists.txt` globs `*.cpp` and derives the executable name from the file
   base name, so base names must be unique across the whole directory. Do not edit that
   file to register a new experiment.
-- Experiments are not built or run in CI. They take minutes to hours. Do not add one to a
-  CI workflow.
+- The `🐧 experiments` job in `.github/workflows/ubuntu.yml` builds every experiment on
+  every pull request that touches a `*.cpp`, `*.hpp`, `*.cmake`, or `CMakeLists.txt`, and
+  that job is what catches a refactor which breaks the build. It compiles with g++-14 in
+  Debug on Ubuntu and is the only place experiments are built, so a break specific to
+  another compiler or platform still ships unnoticed. Iterate locally rather than waiting
+  on it: `cmake -S . --preset dev-full` enables the experiments, then
+  `cmake --build --preset dev-full --target <base name>`.
+- CI never runs an experiment — a run takes minutes to hours — so nothing checks that a
+  result stayed the same. That check is yours. Never add an experiment to another
+  workflow: the test matrix sets `FICTION_EXPERIMENTS: OFF` on purpose, because building
+  them in every matrix entry cost time and caught nothing the one job does not.
+- The `Clang-Tidy Review` workflow lints a changed experiment as well: it configures with
+  `ci-tidy`, which sets `FICTION_EXPERIMENTS: ON`, and `experiments/` is not in its ignore
+  list. `cpp-linter` reports the whole file, not just your diff, so editing a
+  long-untouched experiment surfaces its entire backlog at once.
 - `*.json` and `*.csv` are gitignored: those are experiment outputs. Do not force-add
   result files.


### PR DESCRIPTION
## Description

Four changes to the agent instructions, one per commit.

**Cleanup folds into the pull request that finds it.** Improving code was allowed only inside the radius the task already modified; anything beyond went to a follow-up pull request, which meant it went nowhere. The agent that notices a problem is reading that code precisely because the task brought it there. An improvement now ships with the work that found it, as its own commit so a reviewer can read the two apart. Dependency bumps stay out, since Renovate opens those itself, and a redesign is still proposed before it is written.

**"Never" now marks the prohibitions that admit no exception.** The file mixed "Do not" and "Never" for rules of the same strength, so neither word carried information. "Never" applies to premature abstraction, tests that pin provisional implementation choices, figures of speech and filler openers, invented synonyms, narrating how the work happened, documenting former behavior, and resolving a reviewer's comment. The soft rules keep "prefer", which is what makes the distinction readable.

**Opening a pull request no longer ends the task.** Nothing said what to do afterwards, so "done" got reported while jobs were still running or already red. An agent now polls `gh pr checks` until every required job passes, and reports success only once CI is green and every review comment has an answer. A check it cannot fix is reported just as promptly, naming the job and quoting the failing lines. Watching implies pushing, so the authorization rule states the one case where permission carries: opening a pull request covers pushing fixes to that same pull request and replying to its review comments. Every other remote action still needs its own authorization.

**The modernization campaign reaches `experiments/`.** That file forbade modernizing, refactoring, generalizing, or reformatting an experiment and declared the C++20 campaign stopped at the directory. The reason given does not hold: what has to stay fixed is the result an experiment reproduces, not the code that computes it. Experiments are now refactored like library code under one prohibition — never change what an experiment computes: same parameters, same inputs, same output columns.

That last change leans on what CI covers, so the file now records it. The `🐧 experiments` job builds every experiment on any pull request touching C++ or CMake sources, so a refactor that breaks the build is caught — but only there, with g++-14 in Debug on Ubuntu, so a break specific to another compiler or platform is not. CI never runs an experiment, so no job checks that a result stayed the same. `Clang-Tidy Review` lints a changed experiment, and `cpp-linter` reports whole files, so editing a long-untouched experiment surfaces its entire backlog at once.

No changelog entry: `AGENTS.md`-only changes have not carried one (#1070, and the `AGENTS.md` half of #1080).

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] ~~I have added a changelog entry.~~ Not applicable; see above.
- [x] ~~I have created/adjusted the Python bindings for any new or updated functionality.~~ Not applicable.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

---

Drafted with AI assistance. The CI claims about `experiments/` were verified against `.github/workflows/ubuntu.yml`, `clang-tidy-review.yml`, and `CMakePresets.json` on `main`; `prek run -a` passes locally.
