### PR TITLE
🔧 Maintenance round

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,7 @@ repos:
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.38.0
     hooks:
+      - id: check-codecov
       - id: check-github-workflows
       - id: check-readthedocs
       - id: check-renovate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project (https://github.com/lefticus/cpp_starter_project) and CMake Template
 # (https://github.com/cpp-best-practices/cmake_template)
 
-cmake_minimum_required(VERSION 3.23...4.2)
+cmake_minimum_required(VERSION 3.23...4.4)
 
 # Only set the CMAKE_CXX_STANDARD if it is not set by someone else
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,6 +53,8 @@ Changed
     - **Breaking:** generated docstring symbols are now named ``mkd_doc_*`` instead of the reserved
       ``__doc_*``. ``DOC(...)`` is unchanged, but hand-written docstrings that define such a symbol
       directly must be renamed
+    - ``mnt.pyfiction`` now advertises developers and information technology as intended audiences
+      and physics as a topic on PyPI
 - Algorithms:
     - ``technology_mapping`` and the ``map`` command now default to ``mockturtle::emap`` instead of
       ``mockturtle::map``
@@ -86,6 +88,9 @@ Changed
     - ``FICTION_ENABLE_PCH`` now covers the test suite as well as the CLI, and is on in the ``dev``
       and ``tests-slim`` presets
     - The CI presets no longer build the experiments; one dedicated 🐧 job compiles them instead
+    - ``vcs-versioning`` replaces ``setuptools-scm`` for deriving the version from git, which drops
+      ``setuptools`` from the build. Building from source now requires ``scikit-build-core`` 1.0
+    - The CMake policy range now ends at 4.4
 - Experiments:
     - Modernized ``generate_defective_surface.py`` now that ``experiments/AGENTS.md`` opens the
       directory to it. Apart from the out-of-bounds fix below, the surface it generates is unchanged
@@ -128,6 +133,7 @@ Changed
     - Halved the OS matrices; ``docs/getting_started.rst`` records the combinations we verify
     - The wheel builds now run the ``pyfiction`` test suite against the repaired wheel instead of
       only smoke-testing the import
+    - ``prek`` now validates ``.codecov.yml`` against its schema
 
 Removed
 #######

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,23 +22,26 @@ keywords = ["MNT", "fiction", "nanotechnology", "FCN", "QCA", "NML", "SiDB", "de
 license = { file = "LICENSE.txt" }
 
 classifiers = [
-    'Development Status :: 4 - Beta',
-    'Programming Language :: Python :: 3',
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    'Programming Language :: C++',
-    'Environment :: Console',
-    'License :: OSI Approved :: MIT License',
-    'Operating System :: Microsoft :: Windows',
-    'Operating System :: MacOS',
-    'Operating System :: POSIX :: Linux',
-    'Intended Audience :: Science/Research',
-    'Natural Language :: English',
-    'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Topic :: Scientific/Engineering :: Physics",
 ]
 
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "scikit-build-core>=0.10.1",
-    "setuptools-scm>=8.1",
+    "scikit-build-core~=1.0.3",
+    "vcs-versioning~=2.3.0",
     "nanobind~=2.13.0"
 ]
 build-backend = "scikit_build_core.build"
@@ -76,8 +76,6 @@ build.targets = ["pyfiction"]
 # Only install the Python package component
 install.components = ["fiction_Python"]
 
-metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-
 # The sdist has to build the extension, so it keeps `include/`, `bindings/`, `vendors/`, and
 # `cmake/`. Two rules keep it readable: name directories, never a source glob, and anchor every
 # pattern to the repository root. The published sdist shipped no C++ sources at all because
@@ -131,7 +129,11 @@ inherit.cmake.define = "append"
 cmake.define.DISABLE_GIL = "1"
 
 
-[tool.setuptools_scm]
+[[tool.dynamic-metadata]]
+provider = "vcs_versioning"
+
+
+[tool.vcs-versioning]
 
 
 [tool.check-sdist]
@@ -310,12 +312,11 @@ docstring-code-format = true
 
 [dependency-groups]
 build = [
-    "scikit-build-core>=0.11.0",
-    "setuptools-scm>=8.1",
+    "scikit-build-core~=1.0.3",
+    "vcs-versioning~=2.3.0",
     "nanobind~=2.13.0",
 ]
 docs = [
-    "setuptools-scm>=8.1",
     "sphinx==8.1.3; python_version < '3.11'",
     "sphinx==8.2.3; python_version >= '3.11'",
     "breathe==4.36.0",

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -377,7 +377,7 @@ dependencies = [
 build = [
     { name = "nanobind" },
     { name = "scikit-build-core" },
-    { name = "setuptools-scm" },
+    { name = "vcs-versioning" },
 ]
 dev = [
     { name = "nanobind" },
@@ -386,11 +386,10 @@ dev = [
     { name = "pytest-sugar" },
     { name = "pytest-xdist" },
     { name = "scikit-build-core" },
-    { name = "setuptools-scm" },
+    { name = "vcs-versioning" },
 ]
 docs = [
     { name = "breathe" },
-    { name = "setuptools-scm" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-rtd-theme" },
@@ -408,8 +407,8 @@ requires-dist = [{ name = "z3-solver", specifier = ">=4.8.0" }]
 [package.metadata.requires-dev]
 build = [
     { name = "nanobind", specifier = "~=2.13.0" },
-    { name = "scikit-build-core", specifier = ">=0.11.0" },
-    { name = "setuptools-scm", specifier = ">=8.1" },
+    { name = "scikit-build-core", specifier = "~=1.0.3" },
+    { name = "vcs-versioning", specifier = "~=2.3.0" },
 ]
 dev = [
     { name = "nanobind", specifier = "~=2.13.0" },
@@ -417,12 +416,11 @@ dev = [
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "scikit-build-core", specifier = ">=0.11.0" },
-    { name = "setuptools-scm", specifier = ">=8.1" },
+    { name = "scikit-build-core", specifier = "~=1.0.3" },
+    { name = "vcs-versioning", specifier = "~=2.3.0" },
 ]
 docs = [
     { name = "breathe", specifier = "==4.36.0" },
-    { name = "setuptools-scm", specifier = ">=8.1" },
     { name = "sphinx", marker = "python_full_version < '3.11'", specifier = "==8.1.3" },
     { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = "==8.2.3" },
     { name = "sphinx-rtd-theme", specifier = "==3.1.0" },
@@ -592,7 +590,7 @@ name = "roman-numerals-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "roman-numerals" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
 wheels = [
@@ -616,31 +614,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "84.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
-]
-
-[[package]]
-name = "setuptools-scm"
-version = "10.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "setuptools" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "vcs-versioning" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/b1/d0b97ffd2856a7d19c63024a89fb84813cb9d2ed7fa8fdbedf9e2f13a9ab/setuptools_scm-10.2.1.tar.gz", hash = "sha256:4fa7dd82cf8c800df59c9a288c90299b1657ff1ecfc3f5cc00287c5dbf5e27a9", size = 154237, upload-time = "2026-07-21T08:08:04.553Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/b4/02ac1d9833b882c87b3a4e82703e70eac4ab33d0d15fb123e60bb01f3bc1/setuptools_scm-10.2.1-py3-none-any.whl", hash = "sha256:b7c82f4102d389ee57dc66ccdb4f9b4bca3c40ba83b43f1f63d68ccd72db2580", size = 29078, upload-time = "2026-07-21T08:08:03.293Z" },
-]
-
-[[package]]
 name = "snowballstemmer"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -657,23 +630,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -688,23 +661,23 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals-py" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
@@ -891,16 +864,16 @@ wheels = [
 
 [[package]]
 name = "vcs-versioning"
-version = "2.2.4"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/92/14277e46f415b6a01b6e94960cd6bc3acdc366e990d43ad71d63fef83d1b/vcs_versioning-2.2.4.tar.gz", hash = "sha256:ed718fdee42170e128a8add6f23f53aa64dc7d9ab2de87d3083a691df881a809", size = 145243, upload-time = "2026-08-07T20:20:42.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/cb/6f5c4ed4da249ef5eea34ddfbb38174c5533ff3da8703b8252bf44b80396/vcs_versioning-2.3.1.tar.gz", hash = "sha256:806635bd0ea653c96af98a70624be758d408a989f2cd0b390e63474d99f96b63", size = 156292, upload-time = "2026-08-19T07:37:21.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/26/7d2b738d2b7e177e729932dbdf1ebfa57c98846777a87a864130cc1e196b/vcs_versioning-2.2.4-py3-none-any.whl", hash = "sha256:48ffea8a6a175c37a718c7ee2e5f508d0e500c2cf3371791f7948bccb2b44628", size = 109066, upload-time = "2026-08-07T20:20:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1e/94c0a4b8c8c639e91ff6bce375a2c92460a711b9e040b28674ed492d004d/vcs_versioning-2.3.1-py3-none-any.whl", hash = "sha256:a11299394e101569a62ab061375260d08bc56cd33d685b7067d85312368f4457", size = 114617, upload-time = "2026-08-19T07:37:19.553Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

A round of tooling maintenance. Five commits, each independent:

- **Validate the Codecov configuration in pre-commit.** `.codecov.yml` was the one configuration file no hook checked. A typo in it fails silently — Codecov falls back to its defaults and the coverage gate stops enforcing what the file says. `check-jsonschema` already ships `check-codecov`, and its file pattern matches the root `.codecov.yml`. The current file passes unchanged.
- **Broaden the trove classifiers.** `mnt.pyfiction` listed only `Science/Research` under intended audience and only EDA under topic, so it does not surface on PyPI for developers or for anyone browsing physics. Adds `Intended Audience :: Developers`, `Intended Audience :: Information Technology`, and `Topic :: Scientific/Engineering :: Physics`, sorts the list, and settles the mixed quoting on double quotes.
- **Indicate support for CMake 4.4.** The policy range ended at 4.2, so CMake 4.3 and 4.4 ran the project under policies from two releases back. Configuring the `dev` preset with CMake 4.4.2 produces no policy warnings.
- **Derive the version from `vcs-versioning`.** `setuptools-scm` split its version-inference core out into `vcs-versioning`, which carries no dependency on `setuptools` — one fewer package in every build of a project that does not use `setuptools`. `scikit-build-core` resolves the provider by entry-point name through the top-level `[[tool.dynamic-metadata]]` table, which needs 1.0, so the build requirement moves to `~=1.0.3`.
- **Record the maintenance round in the changelog.**

`Typing :: Typed` is deliberately not among the added classifiers: `pyfiction` ships no `.pyi` stubs and no `py.typed` marker, so the classifier would be a false claim. Tracked as #1131, a sub-issue of #1099.

### Verification

- `prek run -a` passes, including the new `check-codecov` hook.
- `nox -s check_sdist` reports `SDist matches git`. That is the check that matters here: #1093 set `build-backend = "none"`, so `check-sdist` accounts for every tracked file the source distribution drops, and the raised effective `minimum-version` would show up as a mismatch if it changed what gets packaged. `PKG-INFO` carries the git-derived version and the new classifiers.
- `cmake -S . --preset dev` configures cleanly under CMake 4.4.2.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
