### PR TITLE
🔧 Give the prek hooks explicit priorities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,38 +19,71 @@ ci:
 
 exclude: "^vendors/|^benchmarks/|bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp"
 
+# `prek` runs hooks that share a `priority` concurrently and ascends from there; an unset
+# `priority` falls back to file order, which is fully serial. The tiers below are therefore
+# a correctness constraint, not a preference:
+#
+#   0     read-only checks and validators, plus `uv-lock`, which writes only `uv.lock`
+#   1-5   the hooks that rewrite every text file, one tier each. `end-of-file-fixer`,
+#         `mixed-line-ending`, `trailing-whitespace`, `fix-ligatures`, and `fix-smartquotes`
+#         all take `types: [text]`, so any two of them sharing a tier would read-modify-write
+#         the same file at the same time and lose one of the two edits
+#   6     the language formatters. These share a tier because their file types are disjoint
+#   7-9   the hooks that must observe the formatters' result
+#
+# Do not collapse tiers 1-5 to win back the wall clock; those hooks are cheap, and the
+# concurrency that matters is already in tiers 0 and 6. `require_serial` is not a substitute:
+# it only prevents concurrent batches of the same hook.
+
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        priority: 0
       - id: check-case-conflict
+        priority: 0
       - id: check-vcs-permalinks
+        priority: 0
       - id: check-merge-conflict
+        priority: 0
       - id: check-symlinks
+        priority: 0
       - id: check-json
+        priority: 0
       - id: check-toml
+        priority: 0
       - id: check-yaml
+        priority: 0
       - id: debug-statements
+        priority: 0
       - id: end-of-file-fixer
+        priority: 1
       - id: mixed-line-ending
+        priority: 2
       - id: trailing-whitespace
+        priority: 3
 
   # Handle unwanted unicode characters
   - repo: https://github.com/sirosen/texthooks
     rev: 0.7.1
     hooks:
       - id: fix-ligatures
+        priority: 4
       - id: fix-smartquotes
+        priority: 5
 
   # Check for common RST mistakes
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
       - id: rst-backticks
+        priority: 0
       - id: rst-directive-colons
+        priority: 0
       - id: rst-inline-touching-normal
+        priority: 0
 
   # CMake format and lint the CMakeLists.txt files
   - repo: https://github.com/cheshirekow/cmake-format-precommit
@@ -60,6 +93,7 @@ repos:
         additional_dependencies: [pyyaml]
         types: [file]
         files: (\.cmake|CMakeLists.txt)(.in)?$
+        priority: 6
 
   # clang-format the C++ part of the code base
   - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -68,18 +102,21 @@ repos:
       - id: clang-format
         types_or: [c++, c]
         args: ["-style=file"]
+        priority: 6
 
   # Ensure uv lock file is up-to-date
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.12.5
     hooks:
       - id: uv-lock
+        priority: 0
 
   # Python linting using ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.3
     hooks:
       - id: ruff-format
+        priority: 6
       - id: ruff-check
         require_serial: true
         # ruff lints `pyproject.toml`, where the rule selectors live, and skips every other TOML
@@ -87,6 +124,7 @@ repos:
         # while ruff falls back to parsing it as Python
         types_or: [python, pyi, jupyter, toml]
         exclude: ^uv\.lock$
+        priority: 8
 
   # Check static types with mypy
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -104,6 +142,7 @@ repos:
           # `experiments/` plots with `matplotlib` and holds its surfaces in `numpy` arrays
           - matplotlib
           - numpy
+        priority: 9
 
   # Format configuration files with prettier
   - repo: https://github.com/rbubley/mirrors-prettier
@@ -111,22 +150,28 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
+        priority: 6
 
   # Check JSON schemata
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.38.0
     hooks:
       - id: check-codecov
+        priority: 0
       - id: check-github-workflows
+        priority: 0
       - id: check-readthedocs
+        priority: 0
       - id: check-renovate
         additional_dependencies: ["json5"]
+        priority: 0
 
   # Check the pyproject.toml file
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
     rev: 2026.08.15
     hooks:
       - id: validate-pyproject
+        priority: 0
 
   # Clean jupyter notebooks
   - repo: https://github.com/srstevenson/nb-clean
@@ -138,3 +183,4 @@ repos:
           - --preserve-cell-metadata
           - raw_mimetype
           - --
+        priority: 7

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -142,6 +142,9 @@ Changed
     - The wheel builds now run the ``pyfiction`` test suite against the repaired wheel instead of
       only smoke-testing the import
     - ``prek`` now validates ``.codecov.yml`` against its schema
+    - The ``prek`` hooks now carry explicit priorities, which run the read-only checks
+      concurrently and cut a warm ``prek run -a`` by about 18%. Hooks that rewrite the same file
+      keep exclusive priorities, since ``prek`` runs hooks that share one concurrently
     - The docstring generator runs on ``main`` only. It pushes with a token that starts no workflow
       run, so its commit on a pull request head would carry no ``🚦 Check``
     - Publishing to PyPI runs in a ``pypi`` deployment environment, which is where a required


### PR DESCRIPTION
## Description

`prek` schedules hooks by `priority`: lower numbers run first, and hooks sharing a number run concurrently. An unset `priority` falls back to file order, which is fully serial. Every hook in `.pre-commit-config.yaml` left the field unset, so the per-hook times summed to roughly the wall clock, and `validate-pyproject`, the longest single hook at over six seconds, started wherever it happened to fall in file order.

The hooks now carry explicit tiers:

| Priority | Hooks |
| --- | --- |
| `0` | read-only checks and validators — `check-*`, `debug-statements`, the `rst-*` pygrep checks, `validate-pyproject`, plus `uv-lock`, which writes only `uv.lock` |
| `1`–`5` | the hooks that rewrite every text file, one tier each — `end-of-file-fixer`, `mixed-line-ending`, `trailing-whitespace`, `fix-ligatures`, `fix-smartquotes` |
| `6` | the language formatters, whose file types are disjoint — `cmake-format`, `clang-format`, `ruff-format`, `prettier` |
| `7`–`9` | the hooks that must observe the formatters' result — `nb-clean`, `ruff-check`, `mypy` |

Tiers `1`–`5` are a correctness constraint, not a preference. Those five hooks all take `types: [text]`, so any two of them sharing a tier would read-modify-write the same file at the same time and lose one of the two edits. `require_serial` does not help: it only prevents concurrent batches of the *same* hook. The config carries this as a comment so the tiers do not get collapsed later.

### Measurement

Six interleaved rounds on one machine, hook environments warmed first, config swap verified before every run:

| | median | min | max |
| --- | --- | --- | --- |
| no priorities | 11.08 s | 10.69 s | 11.31 s |
| with priorities | **9.13 s** | 8.58 s | 9.65 s |

About 18% off the median. All six pairs favor the change, and the slowest run with priorities (9.65 s) still beats the fastest without (10.69 s), so the two distributions do not overlap.

A first, non-interleaved attempt suggested a far larger gain. It was wrong: run-to-run spread on an unchanged config reached 11.0–16.2 s, which swamps the effect. Only the paired measurement above is trustworthy.

### Correctness

Reordering hooks risks letting a checker read a file before a formatter has finished rewriting it, which shows up on a second pass and nowhere else. `prek run -a` runs twice in a row with every hook passing and `git status` clean after both.

`priority` is a `prek` field. Plain `pre-commit` ignores it rather than rejecting it — `aigverse` carries these keys across the same hook set and its pre-commit.ci checks pass.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
