### PR TITLE
📝 Add `UPGRADING.md` for breaking changes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -52,11 +52,14 @@ reviews:
         work happened all belong in the pull request or a code comment, not here.
     - path: "UPGRADING.md"
       instructions: >-
-        Migration notes for breaking changes, newest release first. Every entry is prose
-        with before-and-after code blocks. Flag an entry written as a list of symbol names,
-        and flag a before-and-after pair whose two blocks do not differ. An entry here and
-        a **Breaking:** bullet in docs/changelog.rst co-occur, so flag one that arrives
-        without the other.
+        Migration notes for breaking changes, newest release first. Every entry is prose,
+        carrying before-and-after code wherever the calling code changes. A removal with no
+        replacement, or a change that leaves the interface alone and only alters behavior,
+        takes the prose alone; do not ask for an invented pair. Flag an entry written as a
+        list of symbol names, and flag a before-and-after pair whose two blocks do not
+        differ. An entry here and a **Breaking:** bullet in docs/changelog.rst co-occur, so
+        flag one that arrives without the other. The file documents the release in
+        development; it does not back-fill the releases before it.
     - path: "docs/**"
       instructions: >-
         reStructuredText built by Sphinx, with Doxygen directives for the C++ API. A new

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -50,6 +50,13 @@ reviews:
         exceed this: per-file enumerations of a refactor, approaches that were tried and
         reverted, lists of individual linter findings, and narration of the order in which
         work happened all belong in the pull request or a code comment, not here.
+    - path: "UPGRADING.md"
+      instructions: >-
+        Migration notes for breaking changes, newest release first. Every entry is prose
+        with before-and-after code blocks. Flag an entry written as a list of symbol names,
+        and flag a before-and-after pair whose two blocks do not differ. An entry here and
+        a **Breaking:** bullet in docs/changelog.rst co-occur, so flag one that arrives
+        without the other.
     - path: "docs/**"
       instructions: >-
         reStructuredText built by Sphinx, with Doxygen directives for the C++ API. A new

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ This checklist serves as a reminder of a couple of things that ensure your pull 
 - [ ] The pull request only contains commits that are related to it.
 - [ ] I have added appropriate tests and documentation.
 - [ ] I have added a changelog entry.
+- [ ] I have added an `UPGRADING.md` entry for any breaking change.
 - [ ] I have created/adjusted the Python bindings for any new or updated functionality.
 - [ ] I have made sure that all CI jobs on GitHub pass.
 - [ ] The pull request introduces no new warnings and follows the project's style guidelines.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -113,3 +113,5 @@ template: |
   $CHANGES
 
   **Full [CHANGELOG](https://fiction.readthedocs.io/en/latest/changelog.html)**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+  **Upgrade guide**: https://github.com/$OWNER/$REPOSITORY/blob/v$RESOLVED_VERSION/UPGRADING.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,20 @@ enforces the following:
     Python).
   - Update `docs/changelog.rst`'s `Unreleased` section for any user-facing change; see
     `docs/AGENTS.md` for the entry style.
+  - Add an `UPGRADING.md` entry for a change that breaks working code: one that stops code
+    compiling or running against the previous release, or silently makes it do something
+    else. The cases are a renamed symbol, a removed symbol, a moved header, a changed
+    default, and a moved module. A new function or a new optional parameter is none of
+    them and goes in the changelog only.
+    - Such a change lands in **both** files, and the two entries co-occur: a
+      `**Breaking:**` bullet in `docs/changelog.rst` names the change, an `UPGRADING.md`
+      entry shows the migration. Neither belongs there without the other.
+    - Write the entry as prose with before-and-after code, never as a list of symbol
+      names. The reader arrives with code that stopped working and needs the replacement,
+      which is the one thing a symbol list withholds.
+    - Entries go under `## Unreleased` as `###` sections, ordered by how much code they
+      touch, most first. A release renames that heading to match the changelog's:
+      `## v0.7.0 - 2026-07-31`.
   - Satisfy every box in `.github/pull_request_template.md` before calling a PR done.
   - Use `const` correctness and braced initialization.
   - Keep plans, notes, analyses, and worktrees in `.ai/` (gitignored). Never write them to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,9 @@ enforces the following:
       entry shows the migration. Neither belongs there without the other.
     - Write the entry as prose with before-and-after code, never as a list of symbol
       names. The reader arrives with code that stopped working and needs the replacement,
-      which is the one thing a symbol list withholds.
+      which is the one thing a symbol list withholds. Where the calling code does not
+      change — a removal with no replacement, a behavior change behind an untouched
+      interface — the prose stands alone. Never invent a pair to satisfy the form.
     - Entries go under `## Unreleased` as `###` sections, ordered by how much code they
       touch, most first. A release renames that heading to match the changelog's:
       `## v0.7.0 - 2026-07-31`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -39,6 +39,24 @@ drop-in. It places and routes a network that already exists and takes
 The overload that accepted truth tables has no counterpart: synthesize a network from the
 specification first, then pass that network to `exact`.
 
+Before:
+
+```c++
+#include <fiction/algorithms/physical_design/one_pass_synthesis.hpp>
+
+fiction::one_pass_synthesis_params ps{};
+const auto lyt = fiction::one_pass_synthesis<Lyt>(ntk, ps);
+```
+
+After:
+
+```c++
+#include <fiction/algorithms/physical_design/exact.hpp>
+
+fiction::exact_physical_design_params ps{};
+const auto lyt = fiction::exact<Lyt>(ntk, ps);
+```
+
 `qca_energy_dissipation` and the `energy` command have no replacement.
 
 `range_t` and `fiction/utils/range.hpp` are gone. `coordinates()` and
@@ -126,10 +144,12 @@ After:
 inline constexpr auto mkd_doc_fiction_cartesian_layout_overridden = R"doc(...)doc";
 ```
 
-One substitution covers a fork that carries its own docstrings:
+One substitution covers a fork that carries its own docstrings. The word boundary is what
+keeps a name that merely contains the token, such as `foo__doc_bar`, out of the rewrite;
+`perl` rather than `sed` because GNU and BSD `sed` disagree on both `-i` and `\b`.
 
 ```bash
-sed -i 's/\b__doc_/mkd_doc_/g' <files>
+perl -pi -e 's/\b__doc_/mkd_doc_/g' <files>
 ```
 
 ### `generate_defective_surface.py` produces a different surface

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,143 @@
+# Upgrading
+
+How to migrate across a breaking change in _fiction_, newest release first. Each entry
+names what changed and shows the code that replaces what stopped working.
+
+The [changelog](https://fiction.readthedocs.io/en/latest/changelog.html) records every
+change in one or two sentences; this file covers the ones that need more. `AGENTS.md`
+states which changes need an entry here.
+
+## Unreleased
+
+### Removed algorithms, commands, and headers
+
+Mugen-based one-pass synthesis, jump-point search, and QCA energy dissipation are gone,
+together with the `onepass` and `energy` CLI commands and the `range_t` header.
+
+`a_star` replaces `jump_point_search`. It takes the same arguments and returns the same
+path type, so the call changes in name only.
+
+Before:
+
+```c++
+#include <fiction/algorithms/path_finding/jump_point_search.hpp>
+
+const auto path = fiction::jump_point_search<fiction::layout_coordinate_path<Lyt>>(lyt, {source, target});
+```
+
+After:
+
+```c++
+#include <fiction/algorithms/path_finding/a_star.hpp>
+
+const auto path = fiction::a_star<fiction::layout_coordinate_path<Lyt>>(lyt, {source, target});
+```
+
+`exact` replaces `one_pass_synthesis`, but it is a different algorithm rather than a
+drop-in. It places and routes a network that already exists and takes
+`exact_physical_design_params` where one-pass synthesis took `one_pass_synthesis_params`.
+The overload that accepted truth tables has no counterpart: synthesize a network from the
+specification first, then pass that network to `exact`.
+
+`qca_energy_dissipation` and the `energy` command have no replacement.
+
+`range_t` and `fiction/utils/range.hpp` are gone. `coordinates()` and
+`ground_coordinates()` on `cartesian_layout` and `hexagonal_layout` return a
+`std::ranges::subrange` instead, which iterates identically. Only code that included the
+header or named `range_t` as a type has to change.
+
+### `technology_mapping` maps with `mockturtle::emap`
+
+`technology_mapping` and the `map` command now call `mockturtle::emap` instead of
+`mockturtle::map`. The parameter and statistics members change type with it, so code that
+names either type no longer compiles.
+
+Before:
+
+```c++
+mockturtle::map_params mp{};
+mp.verbose = true;
+
+fiction::technology_mapping_params ps{};
+ps.mapper_params = mp;
+```
+
+After:
+
+```c++
+mockturtle::emap_params mp{};
+mp.verbose = true;
+
+fiction::technology_mapping_params ps{};
+ps.mapper_params = mp;
+```
+
+`technology_mapping_stats::mapper_stats` is a `mockturtle::emap_stats` for the same
+reason. A setting that exists only on `mockturtle::map_params` has no counterpart:
+`enable_logic_sharing` is the one the CLI exposed, and the `map --logic_sharing` flag is
+removed with it.
+
+### `determine_all_combinations_of_distributing_k_entities_on_n_positions` moved
+
+The function moved out of `fiction/utils/math_utils.hpp` into the new
+`fiction/utils/combination_utils.hpp` to keep the heavier includes off the path that
+`traits.hpp` pulls in. Its name and signature are unchanged, so only the include changes.
+
+Before:
+
+```c++
+#include <fiction/utils/math_utils.hpp>
+```
+
+After:
+
+```c++
+#include <fiction/utils/combination_utils.hpp>
+```
+
+`design_sidb_gates.hpp` and `displacement_robustness_domain.hpp` include the new header
+themselves, so code that reached the function through one of those keeps compiling. Only a
+direct include of `math_utils.hpp` breaks.
+
+### The `map` command reports a failed mapping
+
+The `map` command warns when the network it maps is already mapped, and reports a mapping
+error instead of storing the failed result. A script that mapped twice used to gain a store
+entry either way; it now prints `[w] ... is already mapped` on the second pass and, where
+the mapping fails, `[e] an error occurred in mockturtle's technology mapper` and no new
+entry. Check the store after `map` rather than assuming the entry is there.
+
+### Generated docstring symbols are named `mkd_doc_*`
+
+The docstring generator emits `mkd_doc_*` symbols instead of `__doc_*`, which the standard
+reserves. `DOC(...)` is unchanged, so binding code that reads docstrings through the macro
+needs no edit. A hand-written docstring that defines such a symbol directly has to be
+renamed.
+
+Before:
+
+```c++
+inline constexpr auto __doc_fiction_cartesian_layout_overridden = R"doc(...)doc";
+```
+
+After:
+
+```c++
+inline constexpr auto mkd_doc_fiction_cartesian_layout_overridden = R"doc(...)doc";
+```
+
+One substitution covers a fork that carries its own docstrings:
+
+```bash
+sed -i 's/\b__doc_/mkd_doc_/g' <files>
+```
+
+### `generate_defective_surface.py` produces a different surface
+
+The out-of-bounds guard in the defect placement was always false, so a defect whose
+footprint ran off the right or bottom edge was placed clipped instead of being rejected.
+The guard now rejects it, and the generated surface changes.
+
+Regenerate any surface produced by an earlier revision. A measurement taken on an older
+surface is not comparable to one taken on a surface generated now, because the two contain
+different defects.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -33,6 +33,10 @@ The `Writing` rules in the root `AGENTS.md` apply here in full. In addition:
 Every user-facing change adds a bullet to the `Unreleased` section under `Added`,
 `Changed`, `Fixed`, or `Removed`, matching the existing category order and bullet style.
 
+A breaking change needs a second entry in the root `UPGRADING.md`, which carries the
+migration this file has no room for. Mark the bullet here `**Breaking:**` so the two are
+findable together; the root `AGENTS.md` states which changes qualify.
+
 ### Length
 
 **One or two sentences per entry.** Aim for 90 characters and treat 350 as the ceiling —

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -176,10 +176,10 @@ Changed
 Removed
 #######
 - Algorithms:
-    - Removed Mugen support: the vendored Glucose SAT solver (``vendors/mugen/``), the ``onepass`` CLI
-      command, and ``one_pass_synthesis()``. Use ``exact_physical_design()`` instead
-    - Removed ``jump_point_search()``. Use ``a_star()`` instead
-    - Removed ``qca_energy_dissipation()`` and the ``energy`` CLI command
+    - **Breaking:** removed Mugen support: the vendored Glucose SAT solver (``vendors/mugen/``), the
+      ``onepass`` CLI command, and ``one_pass_synthesis()``. Use ``exact()`` instead
+    - **Breaking:** removed ``jump_point_search()``. Use ``a_star()`` instead
+    - **Breaking:** removed ``qca_energy_dissipation()`` and the ``energy`` CLI command
 - Build system:
     - Removed ``FICTION_ENABLE_UNITY_BUILD``, which set a non-propagating property on an
       ``INTERFACE`` target and therefore never did anything
@@ -189,9 +189,9 @@ Removed
     - Removed the 🐍 CI workflow; the wheel builds now cover the same ground. ``nox -s tests``
       remains the local entry point
 - Data structures:
-    - Removed ``range_t`` (``fiction/utils/range.hpp``); ``cartesian_layout``'s and ``hexagonal_layout``'s
-      ``coordinates()``/``ground_coordinates()`` now return a ``std::ranges::subrange`` instead, with no
-      change in usage
+    - **Breaking:** removed ``range_t`` (``fiction/utils/range.hpp``); ``cartesian_layout``'s and
+      ``hexagonal_layout``'s ``coordinates()``/``ground_coordinates()`` now return a
+      ``std::ranges::subrange`` instead, with no change in usage
 
 Fixed
 #####

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -184,7 +184,8 @@ Removed
     - Removed ``FICTION_ENABLE_UNITY_BUILD``, which set a non-propagating property on an
       ``INTERFACE`` target and therefore never did anything
 - CLI:
-    - Removed the ``--logic_sharing`` flag from ``map``, which ``mockturtle::emap`` does not support
+    - **Breaking:** removed the ``--logic_sharing`` flag from ``map``, which ``mockturtle::emap``
+      does not support
 - Continuous integration:
     - Removed the 🐍 CI workflow; the wheel builds now cover the same ground. ``nox -s tests``
       remains the local entry point

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_.
 
+`UPGRADING.md <https://github.com/cda-tum/fiction/blob/main/UPGRADING.md>`_ shows how to
+migrate the code that a breaking change below affects.
+
 Unreleased
 ----------
 
@@ -34,6 +37,8 @@ Added
     - The 🐍 Packaging jobs now run ``check-sdist --inject-junk``, which fails if the source
       distribution drops a tracked source or ships an untracked one
     - Added a 🐍 Lint job that runs the ``mypy`` hook, which pre-commit.ci no longer runs
+- Documentation:
+    - Added ``UPGRADING.md``, which explains how to migrate across each breaking change
 - Experiments:
     - Added ``operational_domain_3d_bestagon_grid_vs_sketch``, which compares grid search against the
       operational domain sketch over a three-dimensional parameter space


### PR DESCRIPTION
## Description

The project has no upgrade guide. `docs/changelog.rst` records _what_ changed and `docs/AGENTS.md` caps an entry at one or two sentences, so it cannot explain _how_ to migrate. #1096, #1097, #1102, and #1103 each move or rename large parts of the public surface, so the structure is worth landing before anything needs to be written into it.

`UPGRADING.md` at the repository root carries the migration: prose with before-and-after code, one `###` section per change, under `## Unreleased`, with release sections below it as they come.

The rule is stated once, in `AGENTS.md`: a change breaks working code when it stops compiling or running against the previous release, or silently makes it do something else — a renamed symbol, a removed symbol, a moved header, a changed default, a moved module. Those land in **both** files, and the two entries co-occur: a `**Breaking:**` changelog bullet names the change, an `UPGRADING.md` entry shows the migration. A new function or a new optional parameter is none of them and goes in the changelog only.

Around it:

- `docs/AGENTS.md` points at the rule from the changelog instructions, which is the file an agent opens when editing the changelog.
- `.coderabbit.yaml` gives CodeRabbit the same kind of style contract it already has for `docs/changelog.rst`.
- `.github/pull_request_template.md` gains a checkbox.
- `.github/release-drafter.yml` links the file at the release tag, next to the existing changelog link.
- `docs/changelog.rst` links it, so a reader on the rendered page has a route to the migration.

### Deferred to #1106

Step 4 of #1101 asks for the file to be surfaced in the documentation. A proper `{include}` page needs MyST: `docs/conf.py` carries no `myst_parser` in `extensions` and sets `source_suffix = ".rst"`, so a root Markdown file cannot be included today. That is #1106's job, and #1106 now carries a note that both this file and the future root `CHANGELOG.md` (#1126) need the page. The plain link from `docs/changelog.rst` is what is achievable now.

### Two deviations worth a look

1. **The `Unreleased` section is not empty.** #1101 says to land the file empty. Shipping a rule that says breaking changes go in both files, next to a file asserting that nothing qualifies, would have been false on arrival: the changelog's `Unreleased` section already carries five `**Breaking:**` entries and a set of removals, one of which — the `combination_utils.hpp` header move — is verbatim one of the rule's own named cases. The section back-fills those. v0.7.0 and earlier are deliberately not back-filled.
2. **The heading is `## Unreleased`, not `## [Unreleased]`.** #1101 item 1 spells it bracketed. Keep a Changelog's brackets are shortcut reference links and need a `[Unreleased]: .../compare/...` definition that this file does not have, so they would render as literal punctuation. Unbracketed also matches `docs/changelog.rst`. Say the word and I will bracket it.

Fixes #1101

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation. Documentation only; the change adds no code to test.
- [x] I have added a changelog entry.
- [x] I have added an `UPGRADING.md` entry for any breaking change. This pull request introduces none; it back-fills the ones already in `Unreleased`.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. No functionality changes.
- [ ] I have made sure that all CI jobs on GitHub pass. Unticked until the run finishes; I am watching it and will fix what fails.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

---

Drafted with AI assistance. Checked locally: `prek run -a` clean, and `uvx check-sdist --inject-junk` reports "SDist matches git" with the new root file shipping in the source distribution, so neither `sdist.exclude` nor `[tool.check-sdist] git-only` needs a change. The `docs/conf.py` `extensions` and `source_suffix` values quoted above were read from the working tree. Every before-and-after snippet was verified against the current headers or the pre-removal revisions in git: the `a_star` and `jump_point_search` signatures, `verbose` on both `mockturtle::map_params` and `emap_params`, `enable_logic_sharing` on `map_params` only, `math_utils.hpp` no longer reaching `combination_utils.hpp`, and the warning and error paths in `cli/cmd/logic/src/map.cpp`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an upgrade guide covering upcoming breaking changes and migration steps.
  * Documented API, algorithm, header, reporting, and boundary-handling changes with before-and-after guidance.
  * Added an upgrade guide link to release notes and changelog documentation.

* **Process Improvements**
  * Updated contribution and review guidance to require migration notes and clearly labeled breaking changes.
  * Added checklist requirements to help ensure breaking changes are consistently documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->