### PR TITLE
🔧 Enforce a per-file copyright header on the Python sources

### DIFF
--- a/.github/scripts/mkdoc_compile_flags.py
+++ b/.github/scripts/mkdoc_compile_flags.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Emit the include and define flags that ``pybind11_mkdoc`` needs to parse *fiction*.
 
 ``pybind11_mkdoc`` invokes libclang directly, so it needs the same include paths and

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ docs/html/
 # Experiment files
 *.json
 !CMakePresets.json
+!.license-tools-config.json
 *.csv
 
 # Coverage files

--- a/.license-tools-config.json
+++ b/.license-tools-config.json
@@ -1,0 +1,22 @@
+{
+  "author": {
+    "name": "Marcel Walter\nCopyright (c) 2023 - present Chair for Design Automation, Technical University of Munich",
+    "years": [2018, 2023]
+  },
+  "force_author": true,
+  "force_license": true,
+  "license": "MIT",
+  "title": false,
+  "style_override_for_suffix": {
+    ".pyi": "DOCSTRING_STYLE"
+  },
+  "include": ["**/*.py", "**/*.pyi"],
+  "exclude": [
+    "^vendors/",
+    "^benchmarks/",
+    "(^|/)\\.(ai|git|mypy_cache|nox|pytest_cache|ruff_cache|tox|venv[^/]*)/",
+    "(^|/)(build|cmake-build)[^/]*/",
+    "(^|/)(dist|venv|_deps|__pycache__)/",
+    "\\.egg-info/"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,9 @@ ci:
   # 🐍 Lint workflow runs it instead
   skip: [mypy]
 
+# The fourth copy of this list. The others are `path_filters:` in `.coderabbit.yaml`,
+# `ignore:` in `.github/workflows/cpp-linter.yml`, and `exclude` in
+# `.license-tools-config.json`, which is JSON and cannot say so itself. Keep them in sync
 exclude: "^vendors/|^benchmarks/|bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp"
 
 # `prek` runs hooks that share a `priority` concurrently and ascends from there; an unset
@@ -34,6 +37,12 @@ exclude: "^vendors/|^benchmarks/|bindings/mnt/pyfiction/include/pyfiction/pybind
 # Do not collapse tiers 1-5 to win back the wall clock; those hooks are cheap, and the
 # concurrency that matters is already in tiers 0 and 6. `require_serial` is not a substitute:
 # it only prevents concurrent batches of the same hook.
+#
+# `license-tools` rewrites a file whole, header and body alike, so it cannot share a tier with
+# another hook that writes Python, and tiers 1 to 6 and tier 8 all do. It sits at 7 rather
+# than 9 so that `ruff-check` at 8 lints the header in the same pass. Its `types_or` is what
+# makes it disjoint from `nb-clean`, which also sits at 7 and takes `types: [text]`, so both
+# would otherwise receive the same notebooks.
 
 repos:
   # Standard hooks
@@ -125,6 +134,20 @@ repos:
         types_or: [python, pyi, jupyter, toml]
         exclude: ^uv\.lock$
         priority: 8
+
+  # Add and update the Python copyright headers. `types_or` repeats what `include` in
+  # `.license-tools-config.json` already says, on purpose: the config scopes a bare `lictool`
+  # run, this line scopes the hook. The config carries the second copyright holder as free
+  # text in `author.name` after a newline, so the `- present` in it is literal and is never
+  # parsed back as a year. That survives a round trip only because `force_author: true`
+  # discards the author the tool mis-parses out of the line; turning that off emits a
+  # garbage name
+  - repo: https://github.com/emzeat/mz-lictools
+    rev: v2.9.0
+    hooks:
+      - id: license-tools
+        types_or: [python, pyi]
+        priority: 7
 
   # Check static types with mypy
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/bindings/mnt/__init__.py
+++ b/bindings/mnt/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Namespace package for the MNT tools.
 
 Windows resolves the DLLs a native extension links against through an explicit search path, so

--- a/bindings/mnt/pyfiction/__init__.py
+++ b/bindings/mnt/pyfiction/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """MNT fiction framework.
 
 This file is part of the MNT fiction framework released under the MIT license.

--- a/bindings/mnt/pyfiction/test/__init__.py
+++ b/bindings/mnt/pyfiction/test/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Test package for the ``pyfiction`` bindings.
 
 Windows resolves the DLLs a native extension links against through an explicit search path,

--- a/bindings/mnt/pyfiction/test/algorithms/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/iter/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/iter/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/iter/test_bdl_input_iterator.py
+++ b/bindings/mnt/pyfiction/test/algorithms/iter/test_bdl_input_iterator.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/network_transformation/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/network_transformation/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/network_transformation/test_fanout_substitution.py
+++ b/bindings/mnt/pyfiction/test/algorithms/network_transformation/test_fanout_substitution.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/network_transformation/test_network_balancing.py
+++ b/bindings/mnt/pyfiction/test/algorithms/network_transformation/test_network_balancing.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import is_balanced, network_balancing, network_balancing_params

--- a/bindings/mnt/pyfiction/test/algorithms/network_transformation/test_technology_mapping.py
+++ b/bindings/mnt/pyfiction/test/algorithms/network_transformation/test_technology_mapping.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/path_finding/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/path_finding/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/path_finding/test_a_star.py
+++ b/bindings/mnt/pyfiction/test/algorithms/path_finding/test_a_star.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/path_finding/test_distance.py
+++ b/bindings/mnt/pyfiction/test/algorithms/path_finding/test_distance.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/path_finding/test_enumerate_all_paths.py
+++ b/bindings/mnt/pyfiction/test/algorithms/path_finding/test_enumerate_all_paths.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/path_finding/test_k_shortest_paths.py
+++ b/bindings/mnt/pyfiction/test/algorithms/path_finding/test_k_shortest_paths.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_apply_gate_library.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_apply_gate_library.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_color_routing.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_color_routing.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_design_sidb_gates.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_design_sidb_gates.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_exact.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_exact.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_graph_oriented_layout_design.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_graph_oriented_layout_design.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_hexagonalization.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_hexagonalization.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_orthogonal.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_orthogonal.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_post_layout_optimization.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_post_layout_optimization.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/physical_design/test_wiring_reduction.py
+++ b/bindings/mnt/pyfiction/test/algorithms/physical_design/test_wiring_reduction.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_calculate_energy_and_state_type.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_calculate_energy_and_state_type.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_can_positive_charges_occur.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_can_positive_charges_occur.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_check_simulation_result_for_equivalence.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_check_simulation_result_for_equivalence.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_clustercomplete.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_clustercomplete.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_critical_temperature.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_critical_temperature.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_detect_bdl_pairs.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_detect_bdl_pairs.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_detect_bdl_wires.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_detect_bdl_wires.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_displacement_robustness_domain.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_displacement_robustness_domain.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_energy_distribution.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_energy_distribution.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_exhaustive_ground_state_simulation.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_exhaustive_ground_state_simulation.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_groundstate_from_simulation_results.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_groundstate_from_simulation_results.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_is_ground_state.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_is_ground_state.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_is_operational.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_is_operational.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_minimum_energy.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_minimum_energy.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain_ratio.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_operational_domain_ratio.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_physical_population_stability.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_physical_population_stability.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_physically_valid_parameters.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_physically_valid_parameters.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_quickexact.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_quickexact.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_quicksim.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_quicksim.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_random_sidb_layout_generator.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_random_sidb_layout_generator.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_sidb_simulation_engine.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_sidb_simulation_engine.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_sidb_simulation_parameters.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_sidb_simulation_parameters.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import sidb_simulation_parameters

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_sidb_simulation_result.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_sidb_simulation_result.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_time_to_solution.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/sidb/test_time_to_solution.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import math

--- a/bindings/mnt/pyfiction/test/algorithms/simulation/test_logic_simulation.py
+++ b/bindings/mnt/pyfiction/test/algorithms/simulation/test_logic_simulation.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import exact_cartesian, exact_params, read_technology_network, simulate

--- a/bindings/mnt/pyfiction/test/algorithms/verification/__init__.py
+++ b/bindings/mnt/pyfiction/test/algorithms/verification/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/algorithms/verification/test_design_rule_violations.py
+++ b/bindings/mnt/pyfiction/test/algorithms/verification/test_design_rule_violations.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import cartesian_gate_layout, color_routing, gate_level_drvs

--- a/bindings/mnt/pyfiction/test/algorithms/verification/test_equivalence_checking.py
+++ b/bindings/mnt/pyfiction/test/algorithms/verification/test_equivalence_checking.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import eq_type, equivalence_checking, equivalence_checking_stats, read_technology_network

--- a/bindings/mnt/pyfiction/test/conftest.py
+++ b/bindings/mnt/pyfiction/test/conftest.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Fixtures shared across the pyfiction test suite."""
 
 from __future__ import annotations

--- a/bindings/mnt/pyfiction/test/inout/__init__.py
+++ b/bindings/mnt/pyfiction/test/inout/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/inout/test_read_write_fgl_layout.py
+++ b/bindings/mnt/pyfiction/test/inout/test_read_write_fgl_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/inout/test_read_write_sqd_layout.py
+++ b/bindings/mnt/pyfiction/test/inout/test_read_write_sqd_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import read_sqd_layout_100, read_sqd_layout_111

--- a/bindings/mnt/pyfiction/test/inout/test_write_operational_domain.py
+++ b/bindings/mnt/pyfiction/test/inout/test_write_operational_domain.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/inout/test_write_qll_layout.py
+++ b/bindings/mnt/pyfiction/test/inout/test_write_qll_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import tempfile

--- a/bindings/mnt/pyfiction/test/inout/test_write_svg_layout.py
+++ b/bindings/mnt/pyfiction/test/inout/test_write_svg_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/layouts/__init__.py
+++ b/bindings/mnt/pyfiction/test/layouts/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/layouts/test_bounding_box.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_bounding_box.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/layouts/test_cartesian_layout.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_cartesian_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import cartesian_layout

--- a/bindings/mnt/pyfiction/test/layouts/test_cell_level_layout.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_cell_level_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import inml_technology, qca_layout, qca_technology, sidb_technology

--- a/bindings/mnt/pyfiction/test/layouts/test_clocked_layout.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_clocked_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/layouts/test_coordinates.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_coordinates.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import operator

--- a/bindings/mnt/pyfiction/test/layouts/test_gate_level_layout.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_gate_level_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/layouts/test_hexagonal_layout.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_hexagonal_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import hexagonal_layout

--- a/bindings/mnt/pyfiction/test/layouts/test_obstruction_layout.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_obstruction_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/layouts/test_shifted_cartesian_layout.py
+++ b/bindings/mnt/pyfiction/test/layouts/test_shifted_cartesian_layout.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import shifted_cartesian_layout

--- a/bindings/mnt/pyfiction/test/networks/__init__.py
+++ b/bindings/mnt/pyfiction/test/networks/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/networks/test_logic_network.py
+++ b/bindings/mnt/pyfiction/test/networks/test_logic_network.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/bindings/mnt/pyfiction/test/technology/__init__.py
+++ b/bindings/mnt/pyfiction/test/technology/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/technology/test_area.py
+++ b/bindings/mnt/pyfiction/test/technology/test_area.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/technology/test_charge_distribution_surface.py
+++ b/bindings/mnt/pyfiction/test/technology/test_charge_distribution_surface.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import (

--- a/bindings/mnt/pyfiction/test/technology/test_sidb_lattice.py
+++ b/bindings/mnt/pyfiction/test/technology/test_sidb_lattice.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/technology/test_sidb_nm_distance.py
+++ b/bindings/mnt/pyfiction/test/technology/test_sidb_nm_distance.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 import pytest

--- a/bindings/mnt/pyfiction/test/technology/test_sidb_nm_position.py
+++ b/bindings/mnt/pyfiction/test/technology/test_sidb_nm_position.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import sidb_100_lattice, sidb_111_lattice, sidb_layout, sidb_nm_position

--- a/bindings/mnt/pyfiction/test/utils/__init__.py
+++ b/bindings/mnt/pyfiction/test/utils/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License

--- a/bindings/mnt/pyfiction/test/utils/test_routing_utils.py
+++ b/bindings/mnt/pyfiction/test/utils/test_routing_utils.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 from __future__ import annotations
 
 from mnt.pyfiction import a_star, cartesian_gate_layout, route_path

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,9 @@ Added
       ``displacement_robustness_domain_params``
     - Exposed ``mol_qca_technology``, ``mol_qca_layout``, ``write_mol_qca_layout_svg``, and
       ``apply_sim7_mol_library``
+- Tooling:
+    - Added the ``license-tools`` prek hook, which puts an MIT copyright header on every Python
+      file and rewrites any that departs from the canonical text
 
 Changed
 #######
@@ -113,7 +116,8 @@ Changed
     - Every Python file now carries ``from __future__ import annotations``, which ruff's
       ``future-annotations`` setting had assumed of all of them and only six of them had
     - Retired ruff's TODO ignore list. Every entry that remains states a decision in a comment,
-      including ``CPY001``, which stays off pending #1091
+      including ``CPY001``, which stays off because the ``license-tools`` hook enforces the
+      headers instead
     - ``mypy`` now checks every Python file the repository owns, where it previously checked only
       the bindings and ``noxfile.py``
 - Continuous integration:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Sphinx configuration for the fiction documentation.
 
 Only the values that differ from Sphinx's defaults are set here. The full list of options is

--- a/experiments/defect_aware_physical_design/generate_defective_surface.py
+++ b/experiments/defect_aware_physical_design/generate_defective_surface.py
@@ -7,6 +7,7 @@
 #
 # Licensed under the MIT License
 
+# Keep the blank line above: `license-tools` reads an unbroken run of `#` lines as its own header and deletes it
 # /// script
 # requires-python = ">=3.10"
 # dependencies = ["matplotlib", "numpy"]

--- a/experiments/defect_aware_physical_design/generate_defective_surface.py
+++ b/experiments/defect_aware_physical_design/generate_defective_surface.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env -S uv run --script --quiet
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 # /// script
 # requires-python = ">=3.10"
 # dependencies = ["matplotlib", "numpy"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,7 @@
 #
 # Licensed under the MIT License
 
+# Keep the blank line above: `license-tools` reads an unbroken run of `#` lines as its own header and deletes it
 # /// script
 # dependencies = ["nox"]
 # ///

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env -S uv run --script --quiet
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 # /// script
 # dependencies = ["nox"]
 # ///

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,10 @@ ignore = [
     "single-line-implicit-string-concatenation", # conflicts with the formatter
     "missing-trailing-comma", # conflicts with the formatter
     "PLR09", # too many <...>
-    "missing-copyright-notice", # the project uses no per-file copyright headers; see #1091
+    # the `license-tools` prek hook writes the per-file copyright headers and rewrites any
+    # that departs from the canonical text. Ruff only reports what that hook already fixes,
+    # and it matches against a preview default regex that can diverge from the emitted header
+    "missing-copyright-notice",
     # `TD002`/`TD003`/`TD004` stay on and demand that a TODO name an author, link an issue, and
     # end in a colon. `FIX002` fires on every TODO regardless of form, so the two cannot both hold
     "line-contains-todo",

--- a/scripts/update_dependency_hashes.py
+++ b/scripts/update_dependency_hashes.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+# Copyright (c) 2018 - 2023 Marcel Walter
+# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
 """Recompute the ``URL_HASH`` values in ``cmake/Dependencies.cmake``.
 
 Renovate bumps the ``*_VERSION`` and ``ALICE_REV`` variables in that file but


### PR DESCRIPTION
## Description

#1091 asked whether the project adopts per-file copyright headers. It does, for the Python
tier first. The `license-tools` hook from `emzeat/mz-lictools` writes the header and rewrites
any that departs from the canonical text, the same mechanism `mqt-core` uses.

Every one of the 88 tracked Python files now opens with:

```
# Copyright (c) 2018 - 2023 Marcel Walter
# Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
# All rights reserved.
#
# SPDX-License-Identifier: MIT
#
# Licensed under the MIT License
```

Both holders and both year ranges come from `LICENSE.txt` verbatim. The tool maintains only
the first line; the second rides along as free text in `author.name`, which is what lets it
say `present` instead of a year that needs an annual 88-file rewrite. That round-trips only
because `force_author: true` discards the author the tool mis-parses back out of that line,
and `.pre-commit-config.yaml` records the caveat next to the hook.

Three commits:

| Commit | What |
| --- | --- |
| 🔧 Enforce a per-file copyright header on the Python sources | the hook, `.license-tools-config.json`, the `.gitignore` re-include, the `CPY001` comment, the changelog |
| 📝 Add the copyright header to every Python file | the unedited output of `prek run license-tools --all-files`, 88 files, 691 insertions, zero deletions |
| 📝 Mark the blank line below the copyright header as load-bearing | one comment each in the two `uv run --script` files |

### Scope: Python only

`.license-tools-config.json` sets `"include": ["**/*.py", "**/*.pyi"]`, and the hook carries a
matching `types_or`. The 500 tracked `.hpp`/`.cpp` files outside `vendors/` are **#1139**, for
two reasons that make them a separate decision: `cpp-linter` analyses whole changed files, so a
header on all of them would report the repository's entire Clang-Tidy backlog on one pull
request; and `AGENTS.md` already plans a `// Created by ...` to `@file`/`@author` migration that
edits the same lines, so the two rewrites should touch each file once, together.

### Decisions worth a reviewer's attention

- **`CPY001` stays ignored.** It does pass zero-configuration against the emitted header — I
  checked — but it only reports what the hook already fixes, and it matches on ruff's *preview*
  default `copyright-notice-regex`, which a version bump can move out from under us. The ignore
  comment now names the hook as the enforcer instead of pointing at this issue.
- **No `ci: skip:` entry.** `license-tools` runs on pre-commit.ci: `language: python` with a
  ~1 MB environment, no network at run time, and no `git` at run time either, since `GitRepo` is
  constructed only when `author.from_git` is set and this config omits it.
- **`priority: 7`.** The hook rewrites a file whole, so it cannot share a tier with another hook
  that writes Python, and tiers 1–6 and 8 all do. 7 puts the header in front of `ruff-check` at 8
  in the same pass; `types_or` is what keeps it off the notebooks `nb-clean` takes in that tier.
- **`style_override_for_suffix` for `.pyi` is load-bearing, not decoration.** The tool maps no
  comment style to `.pyi`, so without it the first stub the repository gains fails the hook
  outright, with no header written and no re-run that recovers.
- **`.gitignore`.** `*.json` is ignored for experiment output, so the new config is re-included
  the way `CMakePresets.json` already is.

### CI footprint

`change-detection.yml` filters `experiments/**` into the C++ test and `cpp-linter` jobs and
`bindings/**` into `cpp-linter`, so the header on `generate_defective_surface.py` and the binding
tests runs the full matrix, not just the Python tier.

### Verification

- `prek run -a` clean; `prek run license-tools --all-files` a no-op on the second and third run.
- Deleted a header by hand: the hook fails and restores it byte-identically.
- Dropped a scratch `.pyi` in: fails without the style override, passes and gets the header with it.
- `uvx check-sdist --inject-junk` reports "SDist matches git", so no `sdist.exclude` or
  `[tool.check-sdist] git-only` entry is needed for the new config.
- `ruff check --select CPY001` passes on all 88 files, and fires again when a header is removed.
- All 88 files compile, and `import mnt.pyfiction` still works.
- `uv run --script` still parses both PEP 723 blocks with the new comment above them.

Fixes #1091.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation. There is no new code to test; the hook
      verifies itself, and `prek run -a` runs it. The rationale that outlives this pull request
      lives in `.pre-commit-config.yaml` and `pyproject.toml` next to what it explains.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. No
      binding surface changes; the binding sources only gain a comment header.
- [ ] I have made sure that all CI jobs on GitHub pass. Pending the first run on this branch.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

---

Drafted with AI assistance. The header text was checked against `LICENSE.txt` line by line; the
88-file diff is the tool's own output, re-run to convergence; the `.pyi`, `CPY001`, `check-sdist`,
PEP 723, and pre-commit.ci claims above were each reproduced locally, the last by installing the
hook with `pip` on Python 3.11, 3.13, and 3.14.
