### PR TITLE
✅ Verify the declared dependency floors with a `minimums` session

### DIFF
--- a/.github/workflows/change-detection.yml
+++ b/.github/workflows/change-detection.yml
@@ -24,6 +24,9 @@ on:
       run-python-linter:
         description: Whether to type check the Python sources
         value: ${{ jobs.change-detection.outputs.run-python-linter || false }}
+      run-python-minimums:
+        description: Whether to test against the lowest declared dependency versions
+        value: ${{ jobs.change-detection.outputs.run-python-minimums || false }}
       run-packaging:
         description: Whether to build the source distribution and the wheels
         value: ${{ jobs.change-detection.outputs.run-packaging || false }}
@@ -56,6 +59,7 @@ jobs:
       run-cpp-linter: ${{ steps.cpp-linter-changes.outputs.run-cpp-linter || false }}
       run-codeql: ${{ steps.codeql-changes.outputs.run-codeql || false }}
       run-python-linter: ${{ steps.python-linter-changes.outputs.run-python-linter || false }}
+      run-python-minimums: ${{ steps.python-minimums-changes.outputs.run-python-minimums || false }}
       run-packaging: ${{ steps.packaging-changes.outputs.run-packaging || false }}
       run-docker: ${{ steps.docker-changes.outputs.run-docker || false }}
       run-workflows: ${{ steps.workflows-changes.outputs.run-workflows || false }}
@@ -178,6 +182,31 @@ jobs:
           || steps.changed-python-linter-files.outputs.all != ''
         id: python-linter-changes
         run: echo "run-python-linter=true" >> "${GITHUB_OUTPUT}"
+
+      # Deliberately narrow. The job checks the declared dependency floors, and those live in
+      # `pyproject.toml`, `uv.lock`, and the session itself. The wheel jobs already build the
+      # extension on Python 3.10, so a C++ change cannot break this job without breaking those
+      # too. The test suite is in the filter because a test that reaches for a newer pytest API
+      # is exactly the kind of floor violation this job exists to catch.
+      - name: Get the changed files relevant for the lowest-dependency test run
+        if: github.event_name == 'pull_request'
+        id: changed-python-minimums-files
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
+        with:
+          filter: |
+            pyproject.toml
+            uv.lock
+            noxfile.py
+            bindings/mnt/pyfiction/test/**
+            .github/workflows/ci.yml
+            .github/workflows/change-detection.yml
+            .github/workflows/python-minimums.yml
+      - name: Set a flag for running the lowest-dependency test run
+        if: >-
+          github.event_name != 'pull_request'
+          || steps.changed-python-minimums-files.outputs.all != ''
+        id: python-minimums-changes
+        run: echo "run-python-minimums=true" >> "${GITHUB_OUTPUT}"
 
       # `[tool.cibuildwheel] test-command` runs pytest against every wheel it builds, so
       # this is also what gates the Python test suite — there is no separate test job. The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,16 @@ jobs:
     if: fromJSON(needs.change-detection.outputs.run-python-linter)
     uses: ./.github/workflows/python-linter.yml
 
+  # Builds the extension from source outside the wheel jobs' `cibuildwheel` path, so it stays a
+  # single runner on a single interpreter. See `python-minimums.yml` for why.
+  python-minimums:
+    name: 🐍 Minimums
+    permissions:
+      contents: read # required to check out the repository
+    needs: change-detection
+    if: fromJSON(needs.change-detection.outputs.run-python-minimums)
+    uses: ./.github/workflows/python-minimums.yml
+
   packaging-sdist:
     name: 🐍 Packaging
     permissions:
@@ -210,6 +220,7 @@ jobs:
       - cpp-coverage
       - codeql
       - python-linter
+      - python-minimums
       - packaging-sdist
       - packaging-wheels
       - docker
@@ -231,6 +242,8 @@ jobs:
             && 'codeql,' || '' }}
             ${{ !fromJSON(needs.change-detection.outputs.run-python-linter)
             && 'python-linter,' || '' }}
+            ${{ !fromJSON(needs.change-detection.outputs.run-python-minimums)
+            && 'python-minimums,' || '' }}
             ${{ !fromJSON(needs.change-detection.outputs.run-packaging)
             && 'packaging-sdist,packaging-wheels,' || '' }}
             ${{ !fromJSON(needs.change-detection.outputs.run-docker)

--- a/.github/workflows/python-minimums.yml
+++ b/.github/workflows/python-minimums.yml
@@ -1,0 +1,72 @@
+name: 🐍 • Minimums
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-python-minimums
+  cancel-in-progress: true
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  Z3_VERSION: 4.13.4
+
+jobs:
+  minimums:
+    name: 🐍 Lowest dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read # required to check out the repository
+
+    # Every other entry point resolves each dependency to the newest compatible version, so a lower
+    # bound in `pyproject.toml` is only ever asserted -- locally, in `cibuildwheel`, and on Read the
+    # Docs alike. This job resolves each direct dependency to the oldest version its bound allows,
+    # on the oldest interpreter the project supports, and runs the test suite against that
+    # combination. A floor that is too low fails here instead of in a downstream install.
+    #
+    # One runner and one interpreter: the wheel jobs already cover every other combination, and this
+    # one builds the extension from source outside their ccache-warmed `cibuildwheel` path.
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # `vcs-versioning` derives the version from the tag history
+          persist-credentials: false
+
+      # The session pins Python 3.10, so the interpreter has to be on `PATH` before nox runs.
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+        with:
+          key: "ubuntu-24.04-minimums"
+          save: true
+          max-size: 10G
+
+      - name: Install Z3
+        uses: cda-tum/setup-z3@7bfe87519f27304460db44284cb8cc59f50f5fc9 # v1.7.2
+        with:
+          version: ${{ env.Z3_VERSION }}
+
+      - name: Setup mold
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "latest"
+          enable-cache: false
+
+      # `--error-on-missing-interpreters` is what makes the pin load-bearing: without it, a runner
+      # without Python 3.10 skips the session and the job reports success having tested nothing.
+      - name: Run the test suite against the lowest declared dependencies
+        run: uvx nox -s minimums --error-on-missing-interpreters

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ Use these commands to validate your work.
 
 - **Test (Full)**: `nox -s tests` (Runs pytest in isolated environments)
 - **Test (Quick)**: `pytest` (Use if only Python code changed to avoid C++ rebuilds)
+- **Test (Floors)**: `nox -s minimums` (Runs pytest on Python 3.10 against the lowest declared
+  dependency versions)
 - **Lint**: `nox -s lint` (Runs prek hooks including ruff and mypy)
 
 ### General

--- a/bindings/mnt/pyfiction/README.md
+++ b/bindings/mnt/pyfiction/README.md
@@ -105,6 +105,14 @@ A `nox` session is provided to conveniently run the Python tests.
 This installs all dependencies for running the tests in an isolated environment, builds the Python package, and then
 runs the tests.
 
+The `minimums` session runs the same tests against the lowest declared direct dependencies instead of the newest
+compatible ones, which exercises the lower bounds in `pyproject.toml`. It requires Python 3.10, the oldest version
+_fiction_ supports.
+
+```bash
+(venv) $ nox -s minimums
+```
+
 ## Usage
 
 The bindings are available as a Python module named `pyfiction` in the namespace `mnt`. To use the bindings, simply

--- a/bindings/mnt/pyfiction/README.md
+++ b/bindings/mnt/pyfiction/README.md
@@ -63,7 +63,7 @@ You can also run the checks manually:
 
 ### Install Z3
 
-Make sure to have the SMT Solver [`Z3 >= 4.8.0`](https://github.com/Z3Prover/z3) installed. This can be accomplished in
+Make sure to have the SMT Solver [`Z3 >= 4.8.5`](https://github.com/Z3Prover/z3) installed. This can be accomplished in
 a multitude of ways:
 
 - Under Ubuntu 20.04 and newer: `sudo apt-get install libz3-dev`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Added
     - The 🐍 Packaging jobs now run ``check-sdist --inject-junk``, which fails if the source
       distribution drops a tracked source or ships an untracked one
     - Added a 🐍 Lint job that runs the ``mypy`` hook, which pre-commit.ci no longer runs
+    - Added a 🐍 Minimums job that runs ``nox -s minimums``, so a lower bound that is too low fails
+      CI instead of a downstream install
 - Experiments:
     - Added ``operational_domain_3d_bestagon_grid_vs_sketch``, which compares grid search against the
       operational domain sketch over a three-dimensional parameter space

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,9 @@ Added
       ``displacement_robustness_domain_params``
     - Exposed ``mol_qca_technology``, ``mol_qca_layout``, ``write_mol_qca_layout_svg``, and
       ``apply_sim7_mol_library``
+- Tooling:
+    - Added the ``minimums`` nox session, which runs the Python test suite on Python 3.10 against
+      the lowest declared direct dependencies instead of the newest compatible ones
 
 Changed
 #######

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -152,6 +152,10 @@ Changed
       run, so its commit on a pull request head would carry no ``🚦 Check``
     - Publishing to PyPI runs in a ``pypi`` deployment environment, which is where a required
       reviewer or a wait timer on releases would go
+- Dependencies:
+    - **Breaking:** raised the declared ``z3-solver`` floor from 4.8.0 to 4.8.5, which is the
+      version ``find_package(Z3 4.8.5)`` has required all along. A pin between 4.8.0 and 4.8.4 no
+      longer resolves
 - Documentation:
     - The README's six per-workflow status badges are replaced by one ``CI`` and one ``CD`` badge,
       matching the two workflows that remain

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,7 +110,8 @@ def check_sdist(session: nox.Session) -> None:
     """Diff the built source distribution against the files git tracks.
 
     Not a prek hook: it builds an sdist, which needs a build environment that the pre-commit
-    sandbox does not have. CI runs it in the packaging workflow's sdist job.
+    sandbox does not have. The packaging workflow's sdist job runs `check-sdist` directly, so this
+    session is the local entry point.
     """
     session.install("check-sdist")
     session.run("check-sdist", "--inject-junk", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import contextlib
-import os
 import shutil
 import tempfile
 from typing import TYPE_CHECKING
@@ -26,13 +25,24 @@ nox.options.sessions = ["lint", "tests"]
 PYTHON_ALL_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 
-if os.environ.get("CI", None):
-    nox.options.error_on_missing_interpreters = True
-
-
 @contextlib.contextmanager
-def preserve_lockfile() -> Generator[None]:
-    """Preserve the lockfile by moving it to a temporary directory."""
+def preserve_lockfile(session: nox.Session) -> Generator[None]:
+    """Move `uv.lock` aside for the duration of the block and restore it afterwards.
+
+    A session that resolves differently would otherwise leave its own resolution in `uv.lock`.
+    While the block runs, the real lockfile is absent from the working tree and `uv` writes a
+    stand-in in its place. That stand-in is internally consistent, so `uv lock --check` and the
+    `uv-lock` hook accept it, and anything that reads or commits `uv.lock` in that window records
+    the stand-in instead of the real lockfile. Run one such session at a time per worktree, and do
+    not commit from a worktree while one runs.
+
+    Starting on a `uv.lock` that already differs from `HEAD` aborts the session, because restoring
+    would overwrite that difference.
+    """
+    pending = session.run("git", "diff", "--name-only", "--", "uv.lock", external=True, silent=True)
+    if pending and pending.strip():
+        session.error("`uv.lock` differs from HEAD. Commit or restore it before running this session")
+
     with tempfile.TemporaryDirectory() as temp_dir_name:
         shutil.move("uv.lock", f"{temp_dir_name}/uv.lock")
         try:
@@ -103,6 +113,27 @@ def _run_tests(
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
     _run_tests(session)
+
+
+@nox.session(python="3.10", reuse_venv=True)
+def minimums(session: nox.Session) -> None:
+    """Run the test suite against the lowest declared direct dependencies.
+
+    Every other entry point resolves each dependency to the newest compatible version, so a lower
+    bound in `pyproject.toml` is only ever asserted. This session resolves each direct dependency
+    to the oldest version its declared bound allows, so the test suite exercises the bounds
+    themselves.
+
+    The session pins Python 3.10, the `requires-python` floor, because the oldest interpreter
+    combined with the oldest dependencies is the one combination nothing else in the project
+    covers. CI passes `--error-on-missing-interpreters`, without which a runner that lacks Python
+    3.10 skips the session and reports success.
+
+    `preserve_lockfile` keeps the lockfile out of the resolution; read its caveat before running
+    this session next to anything else in the same worktree.
+    """
+    with preserve_lockfile(session):
+        _run_tests(session, install_args=["--resolution", "lowest-direct"])
 
 
 @nox.session(reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "z3-solver>=4.8.0"
+    "z3-solver>=4.8.5"
 ]
 
 [project.urls]
@@ -184,7 +184,7 @@ test-command = "pytest"
 
 [tool.cibuildwheel.linux]
 environment = { Z3_ROOT = "/opt/python/cp311-cp311/lib/python3.11/site-packages/z3" }
-before-all = "/opt/python/cp311-cp311/bin/pip install z3-solver>=4.8.0"
+before-all = "/opt/python/cp311-cp311/bin/pip install z3-solver>=4.8.5"
 repair-wheel-command = [
     "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp311-cp311/lib/python3.11/site-packages/z3/lib",
     "auditwheel repair -w {dest_dir} {wheel}",

--- a/uv.lock
+++ b/uv.lock
@@ -479,7 +479,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "z3-solver", specifier = ">=4.8.0" }]
+requires-dist = [{ name = "z3-solver", specifier = ">=4.8.5" }]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
## Description

Every lower bound in `pyproject.toml` was asserted and never exercised. `uv` resolves to the newest
compatible version everywhere — locally, in `cibuildwheel`, and on Read the Docs — so a floor that is
too low fails only for a downstream user who happens to pin an old version.

This adds a `minimums` nox session that resolves the other way, runs it in CI, and corrects the one
floor that turned out to be wrong.

Fixes #1135

### The session

`nox -s minimums` resolves every direct dependency to the oldest version its declared bound allows
(`--resolution lowest-direct`) and runs the same suite `nox -s tests` runs. It calls
`preserve_lockfile()`, which was defined in `noxfile.py` and never called; this is its caller.

**It pins Python 3.10**, the declared `requires-python` floor. Oldest interpreter with oldest
dependencies is the one combination nothing else in the project covers, and the wheel jobs already
cover everything else. Without a pin the session runs on whatever interpreter nox happens to start
under, which is a nondeterministic runtime for a deterministic floor check.

### What it actually resolves to

From the local 3.10 run (`Python 3.10.16`, `pytest-9.0.1`), against what `uv.lock` pins:

| Dependency          | `lowest-direct` | `uv.lock` | Distance |
| ------------------- | --------------- | --------- | -------- |
| `nanobind`          | 2.15.0          | 2.15.0    | none     |
| `scikit-build-core` | 1.0.3           | 1.0.3     | none     |
| `pytest-sugar`      | 1.1.1           | 1.1.1     | none     |
| `pytest-xdist`      | 3.8.0           | 3.8.0     | none     |
| `vcs-versioning`    | 2.3.0           | 2.3.1     | patch    |
| `pytest`            | 9.0.1           | 9.1.1     | minor    |
| `z3-solver`         | 4.8.5.0         | 5.1.0.0   | major    |

Four of seven direct dependencies do not move at all, because the `~=` and `==` pins already sit on
their floor. That is worth stating plainly: on the resolution table alone this session would be a
weak investment. Its value is the one floor that does travel.

### The concrete result: `z3-solver >=4.8.0` was wrong

`vendors/CMakeLists.txt:104` calls `find_package(Z3 4.8.5)`, and `cmake/FindZ3.cmake:58` enforces it
through `find_package_check_version`. A Z3 below that falls through to
`message(SEND_ERROR "Z3 solver could not be detected")` at `vendors/CMakeLists.txt:116`.
`pyproject.toml` declared `z3-solver>=4.8.0` in two places, so the published metadata permitted a
library the build rejects. Raised to `>=4.8.5` at `pyproject.toml:49` and `:187`.

**Why a build-time floor is expressed as a runtime dependency.** On the Linux wheel path the two are
the same package: `[tool.cibuildwheel.linux] before-all` pip-installs `z3-solver` and `environment`
points `Z3_ROOT` at that site-packages directory, which `FindZ3.cmake` searches *first*. On macOS and
Windows they are unrelated — `packaging-wheels.yml` supplies Z3 through `cda-tum/setup-z3`, and the
declared dependency plays no part in the build there.

4.8.5 is what `find_package` has required all along, so this states the bar honestly rather than
raising it. `--resolution lowest-direct` picked `z3-solver==4.8.0.0.post1` under the old floor, which
no ordinary resolution would produce. `bindings/mnt/pyfiction/README.md:66` also told contributors to
install `Z3 >= 4.8.0`, which would have failed the build; that is corrected in the same commit.

**Caveat, stated precisely:** the session is green on this floor *without exercising it*. The floor
governs the `libz3` shared library the extension links against, not the Python package, and nothing
in `pyfiction` imports the `z3` module — `bindings/mnt/__init__.py` and
`bindings/mnt/pyfiction/__init__.py` only read `Z3_ROOT` to register a Windows DLL search path.
`z3-solver==4.8.0.0.post1` could not be imported in any case: its `z3core.py` imports `pkg_resources`,
which is gone on Python 3.12+. The floor was found by reading the build, not by the session failing.

### The dead `CI` branch

```python
if os.environ.get("CI", None):
    nox.options.error_on_missing_interpreters = True
```

No workflow under `.github/workflows/` invoked `nox`, so this branch had no caller. It is deleted,
along with the then-unused `import os`.

Its purpose moves to the call site, where the caller is visible: the CI job runs
`nox -s minimums --error-on-missing-interpreters`. That matters more now that the session is pinned —
a runner without Python 3.10 would otherwise make nox *skip* the session and report success having
tested nothing.

### `preserve_lockfile()`

The helper moves `uv.lock` aside and restores it in a `finally`, so a failing session restores it too.
Two changes:

- **A guard.** It now refuses to start on a `uv.lock` that already differs from `HEAD`, because
  restoring afterwards would overwrite that difference.
- **A documented caveat.** While the block runs, the real lockfile is absent and `uv` leaves an
  internally consistent stand-in in its place — one that `uv lock --check` and the `uv-lock` prek hook
  both accept. Anything that reads or commits `uv.lock` in that window records the stand-in.

The distinction matters: the guard protects the *session* from a dirty lockfile, not a *bystander*
from the session. The hazard is not theoretical — it bit twice while this PR was being written, once
when a concurrent session was running during a commit, and once when a file snapshot captured the
stand-in instead of the real lockfile. Hence the rule in the docstring: one such session at a time per
worktree, and no commits from a worktree while one runs.

### Commits

| Commit     | Change                                                                    |
| ---------- | ------------------------------------------------------------------------- |
| `378ce9dd` | 📝 Correct where `check_sdist`'s docstring says CI runs the session        |
| `065c56da` | ✅ Add the `minimums` session, the `preserve_lockfile` guard, and its docs |
| `57db79f4` | 🔧 Raise the declared `z3-solver` floor to the version the build enforces  |
| `2f1d9e44` | 👷 Run the `minimums` session in CI                                       |

`378ce9dd` is a cleanup found on the way: the docstring claimed CI runs the session in the packaging
workflow's sdist job, but that job runs `uvx check-sdist --inject-junk` directly and never enters it.

### CI footprint

The job is one runner on one interpreter (`ubuntu-24.04`, Python 3.10), gated by a deliberately narrow
`change-detection` filter: `pyproject.toml`, `uv.lock`, `noxfile.py`, the Python test suite, and the
three workflow files. The wheel jobs already build the extension on Python 3.10, so a C++ change
cannot break this job without breaking those too; the test suite is in the filter because a test that
reaches for a newer pytest API is exactly the floor violation the job exists to catch.

**This PR itself touches `ci.yml` and `change-detection.yml`, so it runs the full fleet.**

### Verification

- `nox -s minimums` on a cold Python 3.10 environment: **331 passed in 25.41s**, session successful in
  6 minutes (of which ~5 is the from-source nanobind build).
- The new guard: dirtying `uv.lock` aborts the session before it touches anything —
  `` Session minimums aborted: `uv.lock` differs from HEAD. Commit or restore it before running this session. ``
- `uv.lock` byte-identical after every run, including a deliberately failed one.
- `prek run -a` clean.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation. (The session *is* the test; documented in
      `bindings/mnt/pyfiction/README.md` and the root `AGENTS.md`.)
- [x] I have added a changelog entry. (`Added` → `Tooling` and → `Continuous integration`; `Changed` →
      `Dependencies`, marked **Breaking** — a pin between 4.8.0 and 4.8.4 no longer resolves.)
- [x] I have created/adjusted the Python bindings for any new or updated functionality. (Not
      applicable — this PR adds no binding surface.)
- [ ] I have made sure that all CI jobs on GitHub pass. (Not yet run; the fleet has not started. I
      will watch it and fix what fails.)
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

---

Drafted with AI assistance. Verified locally: the cold Python 3.10 run of `nox -s minimums`, the
guard's abort path and the lockfile's restoration after a forced failure, the resolution table above
read from that run's `uv sync` output, and the `find_package(Z3 4.8.5)` and `find_package_check_version`
line references read in `vendors/CMakeLists.txt` and `cmake/FindZ3.cmake`.
