### PR TITLE
👷 Add a weekly canary against the pinned `mockturtle` branch

### DIFF
--- a/.github/mockturtle-canary-issue.md
+++ b/.github/mockturtle-canary-issue.md
@@ -1,0 +1,20 @@
+The weekly canary in `.github/workflows/mockturtle-canary.yml` builds and tests _fiction_
+against the current head of the `mnt` branch of
+[`marcelwa/mockturtle`](https://github.com/marcelwa/mockturtle) instead of the commit
+`cmake/Dependencies.cmake` pins. That run failed.
+
+- Failing run: {{ RUN_URL }}
+- Branch under test: <https://github.com/marcelwa/mockturtle/tree/mnt>
+
+Three things produce this, in falling order of likelihood:
+
+1. The branch moved in a way _fiction_ does not follow.
+2. The branch itself is broken.
+3. Neither: the run hit an infrastructure flake, such as the apt mirror hang the workflow
+   bounds with a timeout. Read the run before acting on this issue.
+
+For the first two, Renovate's next bump of the pin carries the same failure, so fixing it
+here is what unblocks that pull request.
+
+Close this issue once the canary is green again. While it stays open, further failures
+rewrite this body instead of filing another issue.

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -11,6 +11,13 @@ on:
         description: The C++ compiler package and binary name, e.g. `g++-13`
         required: true
         type: string
+      mockturtle-ref:
+        description: >-
+          A `marcelwa/mockturtle` ref to build against instead of the revision
+          `cmake/Dependencies.cmake` pins. Empty keeps the pin.
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: >-
@@ -28,13 +35,21 @@ env:
   Z3_VERSION: 4.13.4
   CMAKE_BUILD_PARALLEL_LEVEL: 4
   CTEST_PARALLEL_LEVEL: 4
-  # Z3 has no ARM build in `cda-tum/setup-z3`
-  EXTRA_CMAKE_ARGS: ${{ inputs.runs-on == 'ubuntu-24.04-arm' && '-DFICTION_Z3=OFF' || '' }}
+  # First argument: Z3 has no ARM build in `cda-tum/setup-z3`. Second: FetchContent adopts the
+  # tree at `FETCHCONTENT_SOURCE_DIR_MOCKTURTLE` and skips its own clone, which is how the
+  # weekly canary reaches a branch head without editing the pin in `cmake/Dependencies.cmake`.
+  EXTRA_CMAKE_ARGS: >-
+    ${{ inputs.runs-on == 'ubuntu-24.04-arm' && '-DFICTION_Z3=OFF' || '' }}
+    ${{ inputs.mockturtle-ref != ''
+    && format('-DFETCHCONTENT_SOURCE_DIR_MOCKTURTLE={0}/mockturtle', github.workspace) || '' }}
 
 jobs:
   build_and_test:
     name: 🐧 ${{ inputs.runs-on }} ${{ inputs.compiler }}
     runs-on: ${{ inputs.runs-on }}
+    # Roughly three times the slowest observed run, and far below the six-hour default. The
+    # weekly canary is the one caller nobody watches, so a hung step has to end on its own.
+    timeout-minutes: 150
     permissions:
       contents: read # required to check out the repository
 
@@ -59,12 +74,28 @@ jobs:
         with:
           persist-credentials: false
 
+      # Has to follow the step above: that one cleans the workspace and would delete this
+      # checkout. `submodules` is what makes the tree usable — mockturtle carries
+      # `lib/parallel-hashmap` as one, and `#include <parallel_hashmap/phmap.h>` needs it.
+      - name: Clone the mockturtle revision to build against
+        if: inputs.mockturtle-ref != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: marcelwa/mockturtle
+          ref: ${{ inputs.mockturtle-ref }}
+          path: mockturtle
+          submodules: recursive
+          persist-credentials: false
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.compiler }}"
           variant: ccache
-          save: true
+          # A canary run restores this cache, where most objects stay valid, and never writes
+          # back to it. It shares the key with the mainline matrix and runs on `main`, so its
+          # objects would land in the default-branch scope every pull request restores from.
+          save: ${{ inputs.mockturtle-ref == '' }}
           max-size: 10G
 
       - name: Setup mold
@@ -90,6 +121,19 @@ jobs:
           cmake -S . --preset ci-debug
           -DCMAKE_CXX_COMPILER="$COMPILER"
           $EXTRA_CMAKE_ARGS
+
+      # A canary that quietly fell back to the pinned revision would pass forever while testing
+      # nothing. FetchContent writes `_deps/mockturtle-src` only when it clones, so the absence
+      # of that directory is what proves the override took.
+      - name: Verify the build adopted the mockturtle checkout
+        if: inputs.mockturtle-ref != ''
+        run: |
+          if [ -e build-ci-debug/_deps/mockturtle-src ]; then
+            echo "::error::FetchContent cloned mockturtle; FETCHCONTENT_SOURCE_DIR_MOCKTURTLE did not apply"
+            exit 1
+          fi
+          echo "built against $(git -C mockturtle rev-parse HEAD)"
+          echo "pinned        $(grep -oE 'GIT_TAG [0-9a-f]{40}' cmake/Dependencies.cmake | cut -d' ' -f2)"
 
       - name: Build (Debug)
         run: cmake --build --preset ci-debug

--- a/.github/workflows/mockturtle-canary.yml
+++ b/.github/workflows/mockturtle-canary.yml
@@ -1,0 +1,94 @@
+name: mockturtle Canary
+
+# `cmake/Dependencies.cmake` pins mockturtle to a commit on the `mnt` branch of a fork, and
+# Renovate bumps that pin. Between bumps nobody learns whether *fiction* still builds against
+# the branch, so drift surfaces at the next bump as one large failure with an unclear cause.
+# This run builds and tests against the branch head every week and files a single tracking
+# issue when that breaks.
+#
+# Deliberately not a job in `ci.yml`: the run reports on an external branch and must never
+# gate a contributor's pull request. The cron slot avoids `codeql-weekly.yml`'s.
+#
+# Coverage is one compiler on one operating system, so a break that only shows on Clang,
+# arm64, macOS, Windows, or the Python bindings still gets through. The Renovate bump this
+# de-risks runs the full fleet; the canary buys early warning, not proof.
+
+on:
+  schedule:
+    - cron: "40 4 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Named apart from `ci.yml`'s `🐧 Test` on purpose. A scheduled run attaches its check runs
+  # to `main`'s head commit, so a shared name would put a red and a green check with the same
+  # context on the same commit.
+  canary:
+    name: 🐤 Canary
+    permissions:
+      contents: read # required to check out the repository
+    uses: ./.github/workflows/cpp-tests-ubuntu.yml
+    with:
+      runs-on: ubuntu-24.04
+      compiler: g++-13
+      mockturtle-ref: mnt
+
+  report:
+    name: 🐤 Report
+    needs: canary
+    # The branch guard keeps a `workflow_dispatch` from a topic branch from filing a real,
+    # labelled, assigned public issue while someone is testing this workflow.
+    if: failure() && github.ref == 'refs/heads/main'
+    # `ubuntu-24.04`, not `ubuntu-slim`: the step below shells out to `gh`, `jq`, and `sed`.
+    # The slim image carries all three today, but nothing promises it always will, and this is
+    # the one job whose failure means nobody hears that the canary broke.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read # required to read the issue body out of the repository
+      issues: write # required to open or update the tracking issue
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # One standing issue, never one per run. Listing the open issues and comparing titles
+      # exactly beats `--search`, whose index lags behind issue creation and tokenizes the
+      # emoji. `gh issue edit --body-file` rewrites only the body, so the run link refreshes
+      # while the title, labels, and assignee stay put. Closing the issue is the reset signal:
+      # the next failure finds no open match and opens a fresh one.
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_TITLE: "🐛 fiction does not build against the head of the mockturtle mnt branch"
+          ISSUE_LABELS: dependencies
+          ISSUE_ASSIGNEES: marcelwa
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          sed "s|{{ RUN_URL }}|${RUN_URL}|" \
+            .github/mockturtle-canary-issue.md > "${RUNNER_TEMP}/issue-body.md"
+
+          number=$(gh issue list --state open --limit 200 --json number,title \
+            --jq '[.[] | select(.title == env.ISSUE_TITLE) | .number] | first // empty')
+
+          if [ -n "${number}" ]; then
+            gh issue edit "${number}" --body-file "${RUNNER_TEMP}/issue-body.md"
+            echo "Refreshed the standing tracking issue #${number}"
+          else
+            gh issue create --title "${ISSUE_TITLE}" \
+              --body-file "${RUNNER_TEMP}/issue-body.md" \
+              --label "${ISSUE_LABELS}" --assignee "${ISSUE_ASSIGNEES}"
+          fi

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -83,7 +83,6 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "MOCKTURTLE_EXAMPLES": "OFF",
         "FICTION_PROGRESS_BARS": "OFF",
         "FICTION_CLI": "OFF",
         "FICTION_TEST": "OFF",
@@ -117,8 +116,7 @@
         "FICTION_Z3": "ON",
         "FICTION_ALGLIB": "ON",
         "FICTION_PROGRESS_BARS": "ON",
-        "FICTION_WARNINGS_AS_ERRORS": "OFF",
-        "MOCKTURTLE_EXAMPLES": "OFF"
+        "FICTION_WARNINGS_AS_ERRORS": "OFF"
       }
     },
     {
@@ -150,7 +148,6 @@
         "FICTION_ALGLIB": "ON",
         "FICTION_PROGRESS_BARS": "OFF",
         "FICTION_WARNINGS_AS_ERRORS": "OFF",
-        "MOCKTURTLE_EXAMPLES": "OFF",
         "FICTION_ENABLE_PCH": "ON"
       }
     },
@@ -198,8 +195,7 @@
         "FICTION_PROGRESS_BARS": "ON",
         "FICTION_Z3": "ON",
         "FICTION_ALGLIB": "ON",
-        "FICTION_PYTHON_BINDINGS": "ON",
-        "MOCKTURTLE_EXAMPLES": "OFF"
+        "FICTION_PYTHON_BINDINGS": "ON"
       }
     }
   ],

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -146,13 +146,13 @@ FetchContent_MakeAvailable(alice)
 # submodule directories empty, so a tarball build fails on `#include
 # <parallel_hashmap/phmap.h>`. Do not convert this to a `URL` without first
 # arranging for that header to resolve.
-set(MOCKTURTLE_EXAMPLES
+set(MOCKTURTLE_BUILD_EXAMPLES
     OFF
     CACHE BOOL "" FORCE)
-set(MOCKTURTLE_EXPERIMENTS
+set(MOCKTURTLE_BUILD_EXPERIMENTS
     OFF
     CACHE BOOL "" FORCE)
-set(MOCKTURTLE_TEST
+set(MOCKTURTLE_BUILD_TESTS
     OFF
     CACHE BOOL "" FORCE)
 FetchContent_Declare(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -214,6 +214,8 @@ Fixed
       ``uv build --sdist`` would otherwise ship into the source distribution
     - Fixed the source distribution shipping none of the C++ sources it needs to build, which made
       ``pip install mnt.pyfiction`` fail wherever no matching wheel exists
+    - Fixed the misspelled ``mockturtle`` build options, which left its 13 example executables in
+      every build graph because ``MOCKTURTLE_BUILD_EXAMPLES`` defaults to ``ON``
 - Code quality:
     - Fixed the execution-policy guard in ``execution_utils.hpp``, which read the feature-test macros
       before including ``<version>`` and misread Clang's ``__GNUC__`` of 4 as an old GCC. Parallel STL

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Added
     - The 🐍 Packaging jobs now run ``check-sdist --inject-junk``, which fails if the source
       distribution drops a tracked source or ships an untracked one
     - Added a 🐍 Lint job that runs the ``mypy`` hook, which pre-commit.ci no longer runs
+    - Added a weekly canary that builds and tests against the head of the ``mnt`` branch of the
+      ``marcelwa/mockturtle`` fork, and opens or updates one tracking issue when that breaks
 - Experiments:
     - Added ``operational_domain_3d_bestagon_grid_vs_sketch``, which compares grid search against the
       operational domain sketch over a three-dimensional parameter space

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ sdist.exclude = [
 ]
 
 [tool.scikit-build.cmake.define]
-MOCKTURTLE_EXAMPLES = "OFF"
 FICTION_PROGRESS_BARS = "OFF"
 FICTION_CLI = "OFF"
 FICTION_TEST = "OFF"


### PR DESCRIPTION
## Description

`cmake/Dependencies.cmake` pins `mockturtle` to a commit on the `mnt` branch of the
`marcelwa/mockturtle` fork. It is the only dependency fetched as a git clone rather than a
hashed tarball, and the one _fiction_ depends on most deeply. Between Renovate's bumps of
that pin, nothing tells us whether _fiction_ still builds against the branch, so drift
surfaces at the next bump as one large failure with an unclear cause, at the moment someone
was trying to do something else.

`mockturtle-canary.yml` builds and tests against the branch head every Monday at 04:40 UTC
and opens or updates a single tracking issue when that fails.

Closes #1124.

### How it reaches the branch head

Through `-DFETCHCONTENT_SOURCE_DIR_MOCKTURTLE`, pointed at a checkout the job makes itself.
CMake skips the download and update steps entirely for a dependency whose source directory
is named that way, so the pin in `cmake/Dependencies.cmake` and the Renovate custom manager
that matches its literal `GIT_REPOSITORY … GIT_TAG <sha>` shape both stay exactly as they
are. Nothing about the pinned build path changes.

### Why `cpp-tests-ubuntu.yml` is touched

So the canary drives the existing build recipe rather than copying it. The new
`mockturtle-ref` input places the checkout and composes the override into `EXTRA_CMAKE_ARGS`
beside the existing arm64 `-DFICTION_Z3=OFF`; empty (the default, and what every `ci.yml`
caller passes) leaves every existing job byte-identical.

One input rather than a generic `extra-cmake-args`, because a caller job that `uses:` a
reusable workflow never gets a runner: it cannot place the source tree on the machine that
configures CMake, and the absolute path is only knowable inside the called job. One input
owning both halves is the single source of truth.

Three guards come with it:

- **ccache** — a canary run restores the shared cache, where most objects stay valid, and
  never saves to it. It shares a key with the mainline matrix and runs on `main`, so its
  objects would otherwise land in the default-branch scope that every pull request restores
  from.
- **A canary that silently tested the pin** would pass forever while testing nothing. A step
  fails the run if FetchContent cloned `mockturtle` anyway.
- **`timeout-minutes: 150`** on `build_and_test`, which it never had. Roughly three times the
  slowest observed run and far below the six-hour default. The canary is the one caller
  nobody watches.

### Reporting

A `gh` run step: list the open issues, match the title exactly, then rewrite that issue's body
or create a new one. Listing beats `--search`, whose index lags behind issue creation.
`gh issue edit --body-file` touches only the body, so the run link refreshes while the title,
labels, and assignee stay put. Closing the issue is the reset signal — the next failure finds
no open match and opens a fresh one. No third-party action is involved.

That job takes a full `ubuntu-24.04` runner rather than `ubuntu-slim`. The slim image carries
`gh`, `jq`, and `sed` today, but nothing promises it always will, and this is the one job
whose failure means nobody hears that the canary broke. Ten seconds of a standard runner once
a week buys that assumption away. `ci.yml`'s change-detection and guard jobs stay on
`ubuntu-slim`; they run plain shell and the assumption does not apply to them.

`issues: write` is new to this repository. It is scoped to the one job that needs it; the
workflow keeps `permissions: {}` at the top level like every other workflow here. A
`github.ref == 'refs/heads/main'` guard keeps a `workflow_dispatch` from a topic branch from
filing a real, labelled, assigned public issue.

### Second commit: the misspelled `mockturtle` build options

Found while reading `cmake/Dependencies.cmake` for the pin. It set `MOCKTURTLE_EXAMPLES`,
`MOCKTURTLE_EXPERIMENTS`, and `MOCKTURTLE_TEST`; `mockturtle` declares none of those. Its
options are `MOCKTURTLE_BUILD_EXAMPLES`, `MOCKTURTLE_BUILD_EXPERIMENTS`, and
`MOCKTURTLE_BUILD_TESTS`. Two of the real ones default to `OFF`, which hid the misspelling —
but `MOCKTURTLE_BUILD_EXAMPLES` defaults to `ON`, so every configure carried `mockturtle`'s
13 example executables in the build graph. The same dead name was repeated in four
`CMakePresets.json` presets and in `pyproject.toml`; those five are deleted rather than
renamed, because the `FORCE` in `Dependencies.cmake` already wins and a stale copy earns a
`CMake Warning (unused-cli)` on every configure.

## Verification

- The override mechanism was verified against this `Dependencies.cmake`, not assumed: with
  `FETCHCONTENT_SOURCE_DIR_MOCKTURTLE` set, `_deps/mockturtle-src` is never created, the
  checkout's `include/` lands on the test compile lines, and a real test translation unit
  compiles and its binary passes.
- Both branches of the new assertion step were exercised: it passes with the override in
  effect and fails with the `::error::` annotation when a clone is present.
- `prek run -a` is clean.
- `zizmor --persona=pedantic` over `.github/workflows/` reports nothing new; the only finding
  in the tree is the pre-existing `stale-action-refs` on `advanced-security/filter-sarif` in
  `codeql.yml`.
- Configuring `ci-debug` reports no unused variable, no longer configures
  `_deps/mockturtle-build/examples`, and `test_graph_coloring` builds and passes.

### How to verify the reporting path after merge

The workflow cannot be dispatched before it exists on the default branch, so this is a
post-merge step:

1. On a branch off `main`, point `mockturtle-ref` at a ref that does not exist. That fails
   the checkout in seconds and costs no build.
2. `gh workflow run mockturtle-canary.yml --ref <branch>` and confirm `🐤 Report` **skips** —
   the branch guard doing its job.
3. Land that temporarily broken revision on `main`, dispatch again, and confirm the tracking
   issue appears with the run link, the `dependencies` label, and the assignee.
4. Dispatch a second time without changing anything. Confirm the issue count does not change
   and the body now carries the **new** run URL.
5. Close the issue, dispatch a third time, and confirm a fresh issue is filed.
6. Restore `mockturtle-ref: mnt` and dispatch once to confirm green.

## Known limits

- **One compiler on one operating system.** A break that only shows on Clang, arm64, macOS,
  Windows, or the Python bindings still gets through. The Renovate bump this de-risks runs
  the full fleet; the canary buys early warning, not proof. Widening it to a matrix is a
  one-line change if the weekly cost is judged worth it.
- **Infrastructure flakes file the issue too.** A hung apt mirror looks the same as a real
  break. The standing issue caps the damage at one ticket and names the flake as a possible
  cause, but the run still has to be read before acting.
- **The issue is closed by hand.** That keeps "handled" an explicit human judgement rather
  than something the workflow decides.
- **This pull request runs the full C++ fleet**, because `cpp-tests-ubuntu.yml` sits in the
  `run-cpp-tests`, `run-cpp-linter`, `run-codeql`, and `run-packaging` change-detection
  filters. The shared recipe was preferred over a duplicated one.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation. No unit tests apply to a workflow;
      the mechanism is verified as described above and both branches of the new assertion
      step were exercised. Both workflows and the issue body carry the reasoning inline.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality. Not
      applicable; no library surface changes.
- [ ] I have made sure that all CI jobs on GitHub pass. To be confirmed once the run completes.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
      The second commit removes a `CMake Warning (unused-cli)` that the first would otherwise
      have introduced.

---

Drafted with AI assistance. The `FETCHCONTENT_SOURCE_DIR_MOCKTURTLE` behavior, the removal of
the `unused-cli` warning, and both branches of the new assertion step were reproduced locally
against this tree, and the `gh`/`jq` behavior was exercised against this repository's live
issue list; the reporting path itself is verified post-merge as described above.
