### PR TITLE
👷 Bring back the per-platform CI badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,101 @@ jobs:
     if: fromJSON(needs.change-detection.outputs.run-workflows)
     uses: ./.github/workflows/zizmor.yml
 
+  # The next five jobs exist so the README can show one badge per platform again. Each
+  # collapses a group into a single check run with a fixed name, which is what
+  # `img.shields.io/github/check-runs/…?nameFilter=` needs: it matches the check run's name
+  # exactly, and the jobs above carry their matrix entry in theirs
+  # (`🐧 Test (ubuntu-24.04, g++-13) / 🐧 ubuntu-24.04 g++-13`), leaving nothing fixed to
+  # point at. They are `🚦 Check` in miniature and follow it for the same reasons: without
+  # `if: always()` a failed dependency skips the job, and a group that change detection
+  # skips has to conclude here anyway — a check run that never appears reads as a grey
+  # "no check runs" on the badge, not as success.
+  #
+  # None of them belong in `required-checks-pass`. They restate jobs the guard already
+  # covers, and branch protection has exactly one required context by design.
+  cpp-tests-ubuntu-badge:
+    name: 🐧 Ubuntu
+    if: always()
+    needs:
+      - change-detection
+      - cpp-tests-ubuntu
+    runs-on: ubuntu-slim
+    steps:
+      - name: Decide whether the Ubuntu tests succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          allowed-skips: >-
+            ${{ !fromJSON(needs.change-detection.outputs.run-cpp-tests)
+            && 'cpp-tests-ubuntu' || '' }}
+          jobs: ${{ toJSON(needs) }}
+
+  cpp-tests-macos-badge:
+    name: 🍎 macOS
+    if: always()
+    needs:
+      - change-detection
+      - cpp-tests-macos
+    runs-on: ubuntu-slim
+    steps:
+      - name: Decide whether the macOS tests succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          allowed-skips: >-
+            ${{ !fromJSON(needs.change-detection.outputs.run-cpp-tests)
+            && 'cpp-tests-macos' || '' }}
+          jobs: ${{ toJSON(needs) }}
+
+  cpp-tests-windows-badge:
+    name: 🪟 Windows
+    if: always()
+    needs:
+      - change-detection
+      - cpp-tests-windows
+    runs-on: ubuntu-slim
+    steps:
+      - name: Decide whether the Windows tests succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          allowed-skips: >-
+            ${{ !fromJSON(needs.change-detection.outputs.run-cpp-tests)
+            && 'cpp-tests-windows' || '' }}
+          jobs: ${{ toJSON(needs) }}
+
+  # `🐳 Docker` produces a single check run today, so its name could be filtered directly.
+  # It gets a badge job anyway: that name embeds the called workflow's job name, and a
+  # change-detection skip would leave the badge grey.
+  docker-badge:
+    name: 🐳 Docker Image
+    if: always()
+    needs:
+      - change-detection
+      - docker
+    runs-on: ubuntu-slim
+    steps:
+      - name: Decide whether the Docker image build succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          allowed-skips: >-
+            ${{ !fromJSON(needs.change-detection.outputs.run-docker)
+            && 'docker' || '' }}
+          jobs: ${{ toJSON(needs) }}
+
+  codeql-badge:
+    name: 📝 CodeQL Analysis
+    if: always()
+    needs:
+      - change-detection
+      - codeql
+    runs-on: ubuntu-slim
+    steps:
+      - name: Decide whether the CodeQL analysis succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          allowed-skips: >-
+            ${{ !fromJSON(needs.change-detection.outputs.run-codeql)
+            && 'codeql' || '' }}
+          jobs: ${{ toJSON(needs) }}
+
   # This job does nothing and is only used for branch protection. `if: always()` is what
   # makes it usable as a required check: without it a failed dependency would *skip* the
   # guard, and a skipped required context leaves a pull request waiting forever.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # _fiction_ &ndash; Design Automation for Field-coupled Nanotechnologies
 
-[![CI](https://img.shields.io/github/actions/workflow/status/cda-tum/fiction/ci.yml?branch=main&label=CI&logo=github&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
-[![CD](https://img.shields.io/github/actions/workflow/status/cda-tum/fiction/cd.yml?label=CD&logo=github&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/cd.yml)
 [![Ubuntu](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%90%A7%20Ubuntu&label=Ubuntu&logo=ubuntu&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
 [![macOS](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%8D%8E%20macOS&label=macOS&logo=apple&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
 [![Windows](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%AA%9F%20Windows&label=Windows&logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMyAyMyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KIDxwYXRoIGQ9Ik0xIDFoMTB2MTBIMXoiIGZpbGw9IiNmMzUzMjUiLz4KIDxwYXRoIGQ9Ik0xMiAxaDEwdjEwSDEyeiIgZmlsbD0iIzgxYmMwNiIvPgogPHBhdGggZD0iTTEgMTJoMTB2MTBIMXoiIGZpbGw9IiMwNWE2ZjAiLz4KIDxwYXRoIGQ9Ik0xMiAxMmgxMHYxMEgxMnoiIGZpbGw9IiNmZmJhMDgiLz4KPC9zdmc+Cg==&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/cda-tum/fiction/ci.yml?branch=main&label=CI&logo=github&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
 [![CD](https://img.shields.io/github/actions/workflow/status/cda-tum/fiction/cd.yml?label=CD&logo=github&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/cd.yml)
+[![Ubuntu](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%90%A7%20Ubuntu&label=Ubuntu&logo=ubuntu&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
+[![macOS](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%8D%8E%20macOS&label=macOS&logo=apple&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
+[![Windows](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%AA%9F%20Windows&label=Windows&logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCAyMyAyMyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KIDxwYXRoIGQ9Ik0xIDFoMTB2MTBIMXoiIGZpbGw9IiNmMzUzMjUiLz4KIDxwYXRoIGQ9Ik0xMiAxaDEwdjEwSDEyeiIgZmlsbD0iIzgxYmMwNiIvPgogPHBhdGggZD0iTTEgMTJoMTB2MTBIMXoiIGZpbGw9IiMwNWE2ZjAiLz4KIDxwYXRoIGQ9Ik0xMiAxMmgxMHYxMEgxMnoiIGZpbGw9IiNmZmJhMDgiLz4KPC9zdmc+Cg==&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
+[![Docker](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%90%B3%20Docker%20Image&label=Docker&logo=docker&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
+[![CodeQL](https://img.shields.io/github/check-runs/cda-tum/fiction/main?nameFilter=%F0%9F%93%9D%20CodeQL%20Analysis&label=CodeQL&logo=github&style=flat-square)](https://github.com/cda-tum/fiction/actions/workflows/ci.yml)
 [![Documentation Status](https://img.shields.io/readthedocs/fiction?label=Docs&logo=readthedocs&style=flat-square)](https://fiction.readthedocs.io/)
 [![codecov](https://img.shields.io/codecov/c/github/cda-tum/fiction?label=Coverage&logo=codecov&style=flat-square)](https://codecov.io/gh/cda-tum/fiction)
 [![License](https://img.shields.io/github/license/cda-tum/fiction?label=License&style=flat-square)](https://github.com/cda-tum/fiction/blob/main/LICENSE.txt)


### PR DESCRIPTION
## Description

Restores the Ubuntu, macOS, Windows, Docker, and CodeQL badges that #1134 dropped from the README.

They cannot simply be re-pointed at the new workflow files. `img.shields.io/github/actions/workflow/status/…` resolves *workflow runs*, and a `workflow_call`-only file never produces one — it contributes jobs to the caller's run:

```
gh api repos/cda-tum/fiction/actions/workflows/cpp-tests-ubuntu.yml/runs  ->  total_count: 0
gh api repos/cda-tum/fiction/actions/workflows/ci.yml/runs                ->  total_count: 47
```

What does exist per platform is a check run, and shields can address one by name via `img.shields.io/github/check-runs/:owner/:repo/:ref?nameFilter=`. `nameFilter` matches the name **exactly**, though, and the jobs carry their matrix entry in theirs (`🐧 Test (ubuntu-24.04, g++-13) / 🐧 ubuntu-24.04 g++-13`), which leaves nothing fixed to point at.

So each badged group gains a job that collapses it into a single check run with a stable name — `🚦 Check` in miniature, built the same way and for the same reasons. `if: always()` keeps a failed dependency from skipping the job, and `allowed-skips` makes a group that change detection skipped conclude anyway: a check run that never appears reads as a grey "no check runs", not as success.

| job | check run | badge |
| --- | --- | --- |
| `cpp-tests-ubuntu-badge` | `🐧 Ubuntu` | Ubuntu |
| `cpp-tests-macos-badge` | `🍎 macOS` | macOS |
| `cpp-tests-windows-badge` | `🪟 Windows` | Windows |
| `docker-badge` | `🐳 Docker Image` | Docker |
| `codeql-badge` | `📝 CodeQL Analysis` | CodeQL |

Five no-op jobs on `ubuntu-slim`, a few seconds each. None of them belong in `required-checks-pass` — they restate jobs the guard already covers, and branch protection keeps its one required context.

`🐳 Docker` produces a single check run today, so its name could have been filtered directly. It gets a job anyway: that name embeds the called workflow's job name, and a change-detection skip would leave the badge grey.

The Windows badge keeps the base64 data-URI logo from #582, lifted verbatim from `2da8e8da^`.

### Known trade-off

The check-runs endpoint reads check runs on **main's head commit**, whereas the workflow-status endpoint behind the `CI` badge reads the branch's latest run. GitHub creates a `needs`-gated job's check run only once it becomes eligible, so for the ~1h15m a fresh push to main spends in CI, these five badges read a grey "no check runs" instead of holding their last state.

There is no way around that with a per-check-run badge. The alternative — a JSON endpoint badge written to a side branch by CI — buys freshness at the cost of write permissions and a badge that can go stale silently. Worth a look once this is live; if the grey window is too visible, that is the fallback.

### Verified before pushing

- All five badge URLs return `HTTP 200 image/svg+xml`, base64 logo included.
- Each README `nameFilter`, percent-decoded, equals its job's `name:` in `ci.yml` — the one mismatch that would fail silently.
- `check-github-workflows` passes, `zizmor` reports no findings, full pre-commit suite green.

What only a real run can confirm is that the check runs appear with those names, and that the skip path concludes success rather than skipping. The badges are pinned to `main`, so they stay grey until this merges; the URLs can be proven against this branch's head meanwhile:

```bash
curl -s --get "https://img.shields.io/github/check-runs/cda-tum/fiction/$(git rev-parse HEAD).json" \
  --data-urlencode "nameFilter=🐧 Ubuntu"
```

### `CI` and `CD` badges removed

The five platform badges cover what `CI` stood in for while there was nothing finer to point at. `CD` goes with it, which does leave a gap: nothing else reports a failed release, so a publishing failure now surfaces only in the Actions tab. Re-adding it is one line if that turns out to matter.

Coverage the badge row no longer shows at a glance: `🚨 Lint`, `☂️ Coverage`, `🧪 Experiments`, `🐍 Lint`, `🐍 Minimums`, `🐍 Packaging`, `🌈 Zizmor`. All are still gated by `🚦 Check`, so nothing merges past them — they are just no longer visible from the README.

### Run on `65d840f0`

38 passed, 0 failed, 1 skipped. All five badge jobs concluded and the endpoint resolved each to `passing`/brightgreen against the PR head.

The one skip belongs to the `github-advanced-security` app — GitHub's CodeQL default-setup context, unrelated to this workflow. Every job in `ci.yml` ran.

**The `allowed-skips` path is therefore still unverified.** It only fires when change detection skips a group, and it cannot fire in this pull request: the diff against `main` touches `.github/workflows/ci.yml`, so every group runs. The code is the same `alls-green` call `🚦 Check` has used since #1134, but the first real proof will be the first docs-only commit on `main` after this merges — if a badge goes grey there instead of staying green, `allowed-skips` is the place to look.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation. — n/a, CI and README plumbing
- [ ] I have added a changelog entry. — n/a, `docs/changelog.rst` records release deltas
- [ ] I have created/adjusted the Python bindings for any new or updated functionality. — n/a
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced generic CI/CD badges with separate status badges for Ubuntu, macOS, Windows, Docker, and CodeQL.
  * Linked each badge to the relevant CI workflow for clearer build and analysis status visibility.

* **Improvements**
  * Added dedicated status reporting for each supported platform and quality check, making build results easier to monitor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->