### PR TITLE
🐛 Stop `/Zi` overriding the `/Z7` that makes Windows Debug builds cacheable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,7 +84,11 @@ jobs:
         with:
           key: "codeql-ubuntu-24.04-clang++-17"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,10 +84,8 @@ jobs:
         with:
           key: "codeql-ubuntu-24.04-clang++-17"
           variant: ccache
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
+          # Only `main` writes; pull requests restore its cache. Caches are
+          # branch-scoped and the repository shares a 10 GB budget.
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 500M
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,7 +89,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         if: matrix.language == 'cpp'

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -54,7 +54,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -49,7 +49,11 @@ jobs:
         with:
           key: "ubuntu-24.04-g++-13-coverage"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -49,10 +49,8 @@ jobs:
         with:
           key: "ubuntu-24.04-g++-13-coverage"
           variant: ccache
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
+          # Only `main` writes; pull requests restore its cache. Caches are
+          # branch-scoped and the repository shares a 10 GB budget.
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 500M
 

--- a/.github/workflows/cpp-experiments.yml
+++ b/.github/workflows/cpp-experiments.yml
@@ -48,7 +48,11 @@ jobs:
         with:
           key: "ubuntu-24.04-experiments"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/cpp-experiments.yml
+++ b/.github/workflows/cpp-experiments.yml
@@ -53,7 +53,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/cpp-experiments.yml
+++ b/.github/workflows/cpp-experiments.yml
@@ -48,10 +48,8 @@ jobs:
         with:
           key: "ubuntu-24.04-experiments"
           variant: ccache
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
+          # Only `main` writes; pull requests restore its cache. Caches are
+          # branch-scoped and the repository shares a 10 GB budget.
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 500M
 

--- a/.github/workflows/cpp-tests-macos.yml
+++ b/.github/workflows/cpp-tests-macos.yml
@@ -59,7 +59,11 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.compiler }}"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup Z3 Solver

--- a/.github/workflows/cpp-tests-macos.yml
+++ b/.github/workflows/cpp-tests-macos.yml
@@ -64,7 +64,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup Z3 Solver
         id: z3

--- a/.github/workflows/cpp-tests-macos.yml
+++ b/.github/workflows/cpp-tests-macos.yml
@@ -59,10 +59,8 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.compiler }}"
           variant: ccache
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
+          # Only `main` writes; pull requests restore its cache. Caches are
+          # branch-scoped and the repository shares a 10 GB budget.
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 500M
 

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -64,10 +64,8 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.compiler }}"
           variant: ccache
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
+          # Only `main` writes; pull requests restore its cache. Caches are
+          # branch-scoped and the repository shares a 10 GB budget.
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 500M
 

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -69,7 +69,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -64,7 +64,11 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.compiler }}"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -66,7 +66,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 800M
 
       - name: Setup Z3 Solver
         id: z3

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -61,7 +61,11 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.toolset }}"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup Z3 Solver

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -61,10 +61,8 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.toolset }}"
           variant: ccache
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
+          # Only `main` writes; pull requests restore its cache. Caches are
+          # branch-scoped and the repository shares a 10 GB budget.
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 800M
 

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -35,12 +35,25 @@ jobs:
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+      # ccache was configured here and never invoked once: every wheel job ended
+      # with `Cache size (GB): 0.0 / 10.0` and no cacheable calls. It is replaced
+      # on Windows by sccache, which at least gets invoked, and dropped elsewhere.
+      # Whether sccache can actually hit here is being measured -- see the PR.
+      - if: runner.os == 'Windows'
+        name: Configure sccache
+        shell: bash
+        run: |
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
+
+      - if: runner.os == 'Windows'
+        name: Cache sccache objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: "${{ inputs.runs-on }}-pyfiction"
-          save: true
-          max-size: 10G
+          path: .sccache
+          key: sccache-${{ inputs.runs-on }}-pyfiction-${{ github.run_id }}
+          restore-keys: sccache-${{ inputs.runs-on }}-pyfiction-
 
       # on Linux, the action does not work because it can't install to the manylinux container
       - if: runner.os != 'Linux'
@@ -59,8 +72,18 @@ jobs:
           version: "latest"
           enable-cache: false
 
+      - if: runner.os == 'Windows'
+        name: Install sccache
+        run: uv tool install sccache
+
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
+
+      - if: always() && runner.os == 'Windows'
+        name: sccache statistics
+        run: |
+          sccache --show-stats
+          sccache --stop-server
 
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -50,17 +50,19 @@ jobs:
         name: Configure sccache
         shell: bash
         run: |
-          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
-          # One server for the whole job. The default 600s idle shutdown fires
-          # during the per-wheel test phases, and the restart resets the
-          # counters, so the reported hit rate would cover only the last build.
-          echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
-          # `Cache.cmake` defaults to ccache, which is not installed here, so the
-          # launcher has to be named explicitly or nothing is cached at all --
-          # the previous run reported `Compile requests 0`.
-          echo "CMAKE_ARGS=-DCACHE_OPTION=sccache" >> "$GITHUB_ENV"
+          {
+            echo "CMAKE_GENERATOR=Ninja"
+            echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache"
+            echo "SCCACHE_CACHE_SIZE=600M"
+            # One server for the whole job. The default 600s idle shutdown fires
+            # during the per-wheel test phases, and the restart resets the
+            # counters, so the reported hit rate would cover only the last build.
+            echo "SCCACHE_IDLE_TIMEOUT=0"
+            # `Cache.cmake` defaults to ccache, which is not installed here, so
+            # the launcher has to be named explicitly or nothing is cached at
+            # all -- the previous run reported `Compile requests 0`.
+            echo "CMAKE_ARGS=-DCACHE_OPTION=sccache"
+          } >> "$GITHUB_ENV"
 
       # on Linux, the action does not work because it can't install to the manylinux container
       - if: runner.os != 'Linux'

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -36,9 +36,16 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       # ccache was configured here and never invoked once: every wheel job ended
-      # with `Cache size (GB): 0.0 / 10.0` and no cacheable calls. It is replaced
-      # on Windows by sccache, which at least gets invoked, and dropped elsewhere.
-      # Whether sccache can actually hit here is being measured -- see the PR.
+      # with `Cache size (GB): 0.0 / 10.0` and no cacheable calls.
+      #
+      # sccache replaces it on Windows, deliberately without cross-run
+      # persistence. Measured: 93 of 573 hits cold, 124 warm -- so persisting it
+      # buys 31 hits for a ~500 MB entry, in a repository already at its 10 GB
+      # cache limit where that pressure starves the C++ jobs. Nearly all of the
+      # benefit is dedup within the job, between the four wheel builds, and that
+      # costs nothing. The Python-dependent compilations cannot cache at all:
+      # uv's build-isolation directory is named randomly per run, so their
+      # include path differs on every build.
       - if: runner.os == 'Windows'
         name: Configure sccache
         shell: bash
@@ -50,14 +57,6 @@ jobs:
           # launcher has to be named explicitly or nothing is cached at all --
           # the previous run reported `Compile requests 0`.
           echo "CMAKE_ARGS=-DCACHE_OPTION=sccache" >> "$GITHUB_ENV"
-
-      - if: runner.os == 'Windows'
-        name: Cache sccache objects
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .sccache
-          key: sccache-${{ inputs.runs-on }}-pyfiction-${{ github.run_id }}
-          restore-keys: sccache-${{ inputs.runs-on }}-pyfiction-
 
       # on Linux, the action does not work because it can't install to the manylinux container
       - if: runner.os != 'Linux'

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -35,17 +35,9 @@ jobs:
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      # ccache was configured here and never invoked once: every wheel job ended
-      # with `Cache size (GB): 0.0 / 10.0` and no cacheable calls.
-      #
-      # sccache replaces it on Windows, deliberately without cross-run
-      # persistence. Measured: 93 of 573 hits cold, 124 warm -- so persisting it
-      # buys 31 hits for a ~500 MB entry, in a repository already at its 10 GB
-      # cache limit where that pressure starves the C++ jobs. Nearly all of the
-      # benefit is dedup within the job, between the four wheel builds, and that
-      # costs nothing. The Python-dependent compilations cannot cache at all:
-      # uv's build-isolation directory is named randomly per run, so their
-      # include path differs on every build.
+      # Job-local only. uv's build-isolation directory is named randomly per
+      # run, so nothing carries across runs; what does help is dedup between the
+      # four wheel builds within one job.
       - if: runner.os == 'Windows'
         name: Configure sccache
         shell: bash
@@ -54,13 +46,9 @@ jobs:
             echo "CMAKE_GENERATOR=Ninja"
             echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache"
             echo "SCCACHE_CACHE_SIZE=600M"
-            # One server for the whole job. The default 600s idle shutdown fires
-            # during the per-wheel test phases, and the restart resets the
-            # counters, so the reported hit rate would cover only the last build.
+            # One server for the whole job; a restart would reset the counters
             echo "SCCACHE_IDLE_TIMEOUT=0"
-            # `Cache.cmake` defaults to ccache, which is not installed here, so
-            # the launcher has to be named explicitly or nothing is cached at
-            # all -- the previous run reported `Compile requests 0`.
+            # ccache is not installed here, so name the launcher explicitly
             echo "CMAKE_ARGS=-DCACHE_OPTION=sccache"
           } >> "$GITHUB_ENV"
 
@@ -95,10 +83,8 @@ jobs:
           path: ./wheelhouse/*.whl
           overwrite: true
 
-      # `--show-stats` still succeeds when nothing was cached -- it starts a
-      # server and reports zeros -- so it is left to fail the job, since it only
-      # fails when sccache itself is broken. `--stop-server` exits non-zero when
-      # no server was ever started, which is not an error.
+      # `--show-stats` fails only when sccache itself is broken, so it gates the
+      # job; `--stop-server` exits non-zero with no server running, which is fine.
       - if: always() && runner.os == 'Windows'
         name: sccache statistics
         run: |

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -79,15 +79,18 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
 
-      - if: always() && runner.os == 'Windows'
-        name: sccache statistics
-        run: |
-          sccache --show-stats
-          sccache --stop-server
-
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cibw-wheels-${{ inputs.runs-on }}
           path: ./wheelhouse/*.whl
           overwrite: true
+
+      # Never gate the job: `--stop-server` exits non-zero when sccache was
+      # never invoked, which is itself one of the outcomes being measured.
+      - if: always() && runner.os == 'Windows'
+        name: sccache statistics
+        continue-on-error: true
+        run: |
+          sccache --show-stats || true
+          sccache --stop-server || true

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -86,11 +86,12 @@ jobs:
           path: ./wheelhouse/*.whl
           overwrite: true
 
-      # Never gate the job: `--stop-server` exits non-zero when sccache was
-      # never invoked, which is itself one of the outcomes being measured.
+      # `--show-stats` still succeeds when nothing was cached -- it starts a
+      # server and reports zeros -- so it is left to fail the job, since it only
+      # fails when sccache itself is broken. `--stop-server` exits non-zero when
+      # no server was ever started, which is not an error.
       - if: always() && runner.os == 'Windows'
         name: sccache statistics
-        continue-on-error: true
         run: |
-          sccache --show-stats || true
+          sccache --show-stats
           sccache --stop-server || true

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -53,6 +53,10 @@ jobs:
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
           echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
+          # One server for the whole job. The default 600s idle shutdown fires
+          # during the per-wheel test phases, and the restart resets the
+          # counters, so the reported hit rate would cover only the last build.
+          echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
           # `Cache.cmake` defaults to ccache, which is not installed here, so the
           # launcher has to be named explicitly or nothing is cached at all --
           # the previous run reported `Compile requests 0`.

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -46,6 +46,10 @@ jobs:
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
           echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
+          # `Cache.cmake` defaults to ccache, which is not installed here, so the
+          # launcher has to be named explicitly or nothing is cached at all --
+          # the previous run reported `Compile requests 0`.
+          echo "CMAKE_ARGS=-DCACHE_OPTION=sccache" >> "$GITHUB_ENV"
 
       - if: runner.os == 'Windows'
         name: Cache sccache objects

--- a/.github/workflows/python-minimums.yml
+++ b/.github/workflows/python-minimums.yml
@@ -49,10 +49,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: "ubuntu-24.04-minimums"
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
+          # Only `main` writes; pull requests restore its cache. Caches are
+          # branch-scoped and the repository shares a 10 GB budget.
           save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 500M
 

--- a/.github/workflows/python-minimums.yml
+++ b/.github/workflows/python-minimums.yml
@@ -54,7 +54,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Install Z3
         uses: cda-tum/setup-z3@7bfe87519f27304460db44284cb8cc59f50f5fc9 # v1.7.2

--- a/.github/workflows/python-minimums.yml
+++ b/.github/workflows/python-minimums.yml
@@ -49,7 +49,11 @@ jobs:
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: "ubuntu-24.04-minimums"
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Install Z3

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ Thumbs.db
 CLAUDE.md
 CLAUDE.local.md
 AGENTS.local.md
+
+# compiler cache written by the Windows CI jobs
+.sccache/

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -14,7 +14,19 @@ function(fiction_enable_cache)
     )
   endif()
 
-  find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
+  # Honour the requested cache first. Searching CACHE_OPTION_VALUES directly
+  # made CACHE_OPTION inert: ccache comes first in the list and is present on
+  # every runner, so asking for sccache silently got ccache.
+  find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
+  if(NOT CACHE_BINARY)
+    list(REMOVE_ITEM CACHE_OPTION_VALUES ${CACHE_OPTION})
+    find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
+    if(CACHE_BINARY)
+      message(STATUS "${CACHE_OPTION} was not found, falling back to "
+                     "${CACHE_BINARY}")
+    endif()
+  endif()
+
   if(CACHE_BINARY)
     # The Visual Studio generator ignores compiler launchers outright, so
     # configuring one there looks like it works and caches nothing.

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -14,11 +14,8 @@ function(fiction_enable_cache)
     )
   endif()
 
-  # Honour the requested cache first. Searching CACHE_OPTION_VALUES directly
-  # made CACHE_OPTION inert: ccache comes first in the list and is present on
-  # every runner, so asking for sccache silently got ccache. find_program
-  # short-circuits on a cached result, so without this a reconfigure keeps
-  # whatever was found last time and CACHE_OPTION is ignored.
+  # Search for the requested cache, then the other. find_program keeps a cached
+  # result, so clear it or a reconfigure ignores CACHE_OPTION.
   unset(CACHE_BINARY CACHE)
   find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
   if(NOT CACHE_BINARY)
@@ -31,8 +28,7 @@ function(fiction_enable_cache)
   endif()
 
   if(CACHE_BINARY)
-    # The Visual Studio generator ignores compiler launchers outright, so
-    # configuring one there looks like it works and caches nothing.
+    # The Visual Studio generator ignores compiler launchers.
     if(CMAKE_GENERATOR MATCHES "Visual Studio")
       message(
         WARNING

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -16,6 +16,15 @@ function(fiction_enable_cache)
 
   find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
   if(CACHE_BINARY)
+    # The Visual Studio generator ignores compiler launchers outright, so
+    # configuring one there looks like it works and caches nothing.
+    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+      message(
+        WARNING
+          "${CACHE_BINARY} was found, but the '${CMAKE_GENERATOR}' generator ignores "
+          "compiler launchers, so nothing will be cached. Configure with -G Ninja "
+          "to make the cache effective.")
+    endif()
     message(STATUS "${CACHE_BINARY} found and enabled")
 
     set(CACHE_LAUNCHER ${CACHE_BINARY})

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -16,7 +16,10 @@ function(fiction_enable_cache)
 
   # Honour the requested cache first. Searching CACHE_OPTION_VALUES directly
   # made CACHE_OPTION inert: ccache comes first in the list and is present on
-  # every runner, so asking for sccache silently got ccache.
+  # every runner, so asking for sccache silently got ccache. find_program
+  # short-circuits on a cached result, so without this a reconfigure keeps
+  # whatever was found last time and CACHE_OPTION is ignored.
+  unset(CACHE_BINARY CACHE)
   find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
   if(NOT CACHE_BINARY)
     list(REMOVE_ITEM CACHE_OPTION_VALUES ${CACHE_OPTION})

--- a/cmake/ProjectOptions.cmake
+++ b/cmake/ProjectOptions.cmake
@@ -124,6 +124,14 @@ macro(fiction_local_options)
   # conform to memory limitations
   if(FICTION_LIGHTWEIGHT_DEBUG_BUILDS)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      # /Z7 is also what makes a Debug compilation cacheable, since ccache
+      # refuses /Zi. Appending it to the flags is not enough: CMake adds its own
+      # /Zi afterwards and wins, which the build log reports 304 times as
+      # `D9025: overriding '/Z7' with '/Zi'`. Setting the debug information
+      # format is what actually removes the /Zi.
+      set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
+      string(REGEX REPLACE "/Zi" "" CMAKE_CXX_FLAGS_DEBUG
+                           "${CMAKE_CXX_FLAGS_DEBUG}")
       set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Z7 /Ob0")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID
                                                    MATCHES ".*Clang")

--- a/cmake/ProjectOptions.cmake
+++ b/cmake/ProjectOptions.cmake
@@ -124,11 +124,8 @@ macro(fiction_local_options)
   # conform to memory limitations
   if(FICTION_LIGHTWEIGHT_DEBUG_BUILDS)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-      # /Z7 is also what makes a Debug compilation cacheable, since ccache
-      # refuses /Zi. Appending it to the flags is not enough: CMake adds its own
-      # /Zi afterwards and wins, which the build log reports 304 times as
-      # `D9025: overriding '/Z7' with '/Zi'`. Setting the debug information
-      # format is what actually removes the /Zi.
+      # /Z7 also makes Debug compilations cacheable; ccache refuses /Zi. The
+      # format has to be set, not just the flag, or CMake appends /Zi after it.
       set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
       string(REGEX REPLACE "/Zi" "" CMAKE_CXX_FLAGS_DEBUG
                            "${CMAKE_CXX_FLAGS_DEBUG}")


### PR DESCRIPTION
## Description

Fixes #1149.

`🪟 windows-2025 v143` takes **4391s** and is the pipeline's bottleneck. The compiler cache was doing far less than it appeared to, for three independent reasons — none of which was the cache software.

### 1. `/Z7` was silently overridden by `/Zi`

`FICTION_LIGHTWEIGHT_DEBUG_BUILDS` adds `/Z7`, which is also what makes a Debug compilation cacheable at all: ccache refuses `/Zi`. Appending it to `CMAKE_CXX_FLAGS_DEBUG` was never enough, because CMake appends its own `/Zi` afterwards (`CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` defaults to `ProgramDatabase`) and the last flag wins. The build log said so **304 times per run**:

```
cl : Command line warning D9025 : overriding '/Z7' with '/Zi'
```

matching the 306 of 608 `Uncacheable calls` almost exactly.

| v143 | before | after |
| --- | --- | --- |
| Uncacheable calls | 306 / 608 (50%) | **4 / 608 (0.7%)** |
| D9025 warnings | 304 | **0** |

### 2. The cache could not survive

The repository sits at **10.19 GB against GitHub's 10 GB limit** with 23 entries. `ccache-ubuntu-24.04` alone held 7001 MB across 17 entries, because the Ubuntu matrix runs eight configurations and every job wrote an entry on every push.

Compounding it, Actions caches are **branch-scoped**: only `main`'s are visible repo-wide. Every PR branch was spending the shared budget on caches almost nothing else could reuse. Writes are now restricted to `main`, and entries bounded to their real working sets — the 10G ceiling was ~14× the largest (714 MB for v143, ~412 MB average for Ubuntu).

### 3. `CACHE_OPTION` was inert

`find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})` searched both names in list order, so asking for sccache silently got ccache — ccache is first and present on every runner.

## Why ccache, and not sccache

Measured directly, in #1151 and the control in #1152. At equal cache warmth:

| `🪟 windows-2025 ClangCL` | duration | hits | vs 2970s baseline |
| --- | --- | --- | --- |
| **ccache + PCH + `/Z7`** | **2019s** | 512 / 604 (84.8%) | **−32%** |
| sccache, no PCH | 2414s | 512 / 602 (85.0%) | −19% |

**ccache and sccache reach an identical hit rate**, so the cache technology was never the variable. At equal warmth ccache wins by 16%, because it keeps PCH — which sccache cannot cache at all — and PCH still accelerates the ~15% of compilations that actually run.

An earlier reading suggested sccache won by 24%. That was sccache-warm measured against ccache-cold.

## Also here

- The wheel jobs' ccache is dropped: it was never invoked once, all four ending at `Cache size (GB): 0.0 / 10.0`. Windows keeps sccache **job-local**, no cross-run entry — measured at 93 of 573 hits cold and 124 warm, so persisting it buys 31 hits for a ~500 MB entry this repository cannot spare. Nearly all the benefit is dedup between the four wheel builds inside one job. The Python-dependent compilations cannot cache at all, because uv's build-isolation directory is randomised per run.
- `Cache.cmake` warns when a launcher is configured under a Visual Studio generator, which ignores it. That warning is what would have surfaced this class of bug years earlier.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry for any noteworthy addition, change, fix, or removal.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build and CI Improvements**
  - Optimized compiler caching across automated builds by restricting cache saves to the main branch and applying smaller cache limits.
  - Improved Windows wheel-build cache handling and cleanup.
  - Updated build tooling and pinned action versions for greater consistency.
  - Improved cache-tool selection, including fallback support when the preferred tool is unavailable.

- **Developer Experience**
  - Added generated Windows compiler-cache files to ignore rules.
  - Improved debug information settings for lightweight MSVC builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->