### PR TITLE
🔬 Measure sccache without PCH against ccache with PCH on Windows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,7 +84,11 @@ jobs:
         with:
           key: "codeql-ubuntu-24.04-clang++-17"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,7 +89,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         if: matrix.language == 'cpp'

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -54,7 +54,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/cpp-coverage.yml
+++ b/.github/workflows/cpp-coverage.yml
@@ -49,7 +49,11 @@ jobs:
         with:
           key: "ubuntu-24.04-g++-13-coverage"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/cpp-experiments.yml
+++ b/.github/workflows/cpp-experiments.yml
@@ -48,7 +48,11 @@ jobs:
         with:
           key: "ubuntu-24.04-experiments"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/cpp-experiments.yml
+++ b/.github/workflows/cpp-experiments.yml
@@ -53,7 +53,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/cpp-tests-macos.yml
+++ b/.github/workflows/cpp-tests-macos.yml
@@ -59,7 +59,11 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.compiler }}"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup Z3 Solver

--- a/.github/workflows/cpp-tests-macos.yml
+++ b/.github/workflows/cpp-tests-macos.yml
@@ -64,7 +64,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup Z3 Solver
         id: z3

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -69,7 +69,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Setup mold
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/cpp-tests-ubuntu.yml
+++ b/.github/workflows/cpp-tests-ubuntu.yml
@@ -64,7 +64,11 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.compiler }}"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup mold

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -66,7 +66,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 800M
 
       - name: Setup Z3 Solver
         id: z3

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -61,7 +61,11 @@ jobs:
         with:
           key: "${{ inputs.runs-on }}-${{ inputs.toolset }}"
           variant: ccache
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Setup Z3 Solver

--- a/.github/workflows/cpp-tests-windows.yml
+++ b/.github/workflows/cpp-tests-windows.yml
@@ -56,17 +56,33 @@ jobs:
       - name: Set up MSVC development environment
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+      # EXPERIMENT ARM: sccache instead of ccache, with PCH necessarily off --
+      # sccache cannot cache a precompiled-header compilation at all. Comparison
+      # arm is #1150. Saves on every run, unlike #1150, so the arms stay
+      # comparable while neither is merged.
+      - name: Configure sccache
+        shell: bash
+        run: |
+          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=900M" >> "$GITHUB_ENV"
+          # The server shuts down after 600s idle, and ctest between the Debug
+          # and Release builds exceeds that. The restart resets the counters:
+          # the previous run reported 301 compile requests where Ninja executed
+          # 602, so its hit rate described half the job.
+          echo "SCCACHE_IDLE_TIMEOUT=0" >> "$GITHUB_ENV"
+
+      - name: Cache sccache objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: "${{ inputs.runs-on }}-${{ inputs.toolset }}"
-          variant: ccache
-          # Only `main` writes, so a pull request restores main's cache without
-          # adding an entry of its own. Every job saving 400-700 MB on every push
-          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
-          # evicting caches faster than they could be reused.
-          save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 800M
+          path: .sccache
+          key: sccache-${{ inputs.runs-on }}-${{ inputs.toolset }}-${{ github.run_id }}
+          restore-keys: sccache-${{ inputs.runs-on }}-${{ inputs.toolset }}-
+
+      - name: Install sccache
+        shell: bash
+        run: |
+          python -m pip install --disable-pip-version-check sccache
+          python -c "import shutil,sys; print(shutil.which('sccache') or sys.exit('sccache not on PATH'))"
 
       - name: Setup Z3 Solver
         id: z3
@@ -83,6 +99,8 @@ jobs:
           cmake -S . --preset ci-debug
           -DCMAKE_CXX_COMPILER="$env:COMPILER"
           -DCMAKE_C_COMPILER="$env:COMPILER"
+          -DFICTION_ENABLE_PCH=OFF
+          -DCACHE_OPTION=sccache
 
       - name: Build (Debug)
         run: cmake --build --preset ci-debug
@@ -97,9 +115,17 @@ jobs:
           cmake -S . --preset ci-release
           -DCMAKE_CXX_COMPILER="$env:COMPILER"
           -DCMAKE_C_COMPILER="$env:COMPILER"
+          -DFICTION_ENABLE_PCH=OFF
+          -DCACHE_OPTION=sccache
 
       - name: Build (Release)
         run: cmake --build --preset ci-release
 
       - name: Test (Release)
         run: ctest --preset ci-release --output-on-failure --repeat until-pass:3
+
+      - if: always()
+        name: sccache statistics
+        run: |
+          sccache --show-stats
+          sccache --stop-server || true

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -35,12 +35,25 @@ jobs:
       - name: Set up MSVC development environment (Windows only)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+      # ccache was configured here and never invoked once: every wheel job ended
+      # with `Cache size (GB): 0.0 / 10.0` and no cacheable calls. It is replaced
+      # on Windows by sccache, which at least gets invoked, and dropped elsewhere.
+      # Whether sccache can actually hit here is being measured -- see the PR.
+      - if: runner.os == 'Windows'
+        name: Configure sccache
+        shell: bash
+        run: |
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
+
+      - if: runner.os == 'Windows'
+        name: Cache sccache objects
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: "${{ inputs.runs-on }}-pyfiction"
-          save: true
-          max-size: 10G
+          path: .sccache
+          key: sccache-${{ inputs.runs-on }}-pyfiction-${{ github.run_id }}
+          restore-keys: sccache-${{ inputs.runs-on }}-pyfiction-
 
       # on Linux, the action does not work because it can't install to the manylinux container
       - if: runner.os != 'Linux'
@@ -59,8 +72,18 @@ jobs:
           version: "latest"
           enable-cache: false
 
+      - if: runner.os == 'Windows'
+        name: Install sccache
+        run: uv tool install sccache
+
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
+
+      - if: always() && runner.os == 'Windows'
+        name: sccache statistics
+        run: |
+          sccache --show-stats
+          sccache --stop-server
 
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -79,15 +79,18 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3
 
-      - if: always() && runner.os == 'Windows'
-        name: sccache statistics
-        run: |
-          sccache --show-stats
-          sccache --stop-server
-
       - name: Upload wheel as an artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cibw-wheels-${{ inputs.runs-on }}
           path: ./wheelhouse/*.whl
           overwrite: true
+
+      # Never gate the job: `--stop-server` exits non-zero when sccache was
+      # never invoked, which is itself one of the outcomes being measured.
+      - if: always() && runner.os == 'Windows'
+        name: sccache statistics
+        continue-on-error: true
+        run: |
+          sccache --show-stats || true
+          sccache --stop-server || true

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -86,11 +86,12 @@ jobs:
           path: ./wheelhouse/*.whl
           overwrite: true
 
-      # Never gate the job: `--stop-server` exits non-zero when sccache was
-      # never invoked, which is itself one of the outcomes being measured.
+      # `--show-stats` still succeeds when nothing was cached -- it starts a
+      # server and reports zeros -- so it is left to fail the job, since it only
+      # fails when sccache itself is broken. `--stop-server` exits non-zero when
+      # no server was ever started, which is not an error.
       - if: always() && runner.os == 'Windows'
         name: sccache statistics
-        continue-on-error: true
         run: |
-          sccache --show-stats || true
+          sccache --show-stats
           sccache --stop-server || true

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -46,6 +46,10 @@ jobs:
           echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
           echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_CACHE_SIZE=600M" >> "$GITHUB_ENV"
+          # `Cache.cmake` defaults to ccache, which is not installed here, so the
+          # launcher has to be named explicitly or nothing is cached at all --
+          # the previous run reported `Compile requests 0`.
+          echo "CMAKE_ARGS=-DCACHE_OPTION=sccache" >> "$GITHUB_ENV"
 
       - if: runner.os == 'Windows'
         name: Cache sccache objects

--- a/.github/workflows/python-minimums.yml
+++ b/.github/workflows/python-minimums.yml
@@ -54,7 +54,7 @@ jobs:
           # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
           # evicting caches faster than they could be reused.
           save: ${{ github.ref == 'refs/heads/main' }}
-          max-size: 10G
+          max-size: 500M
 
       - name: Install Z3
         uses: cda-tum/setup-z3@7bfe87519f27304460db44284cb8cc59f50f5fc9 # v1.7.2

--- a/.github/workflows/python-minimums.yml
+++ b/.github/workflows/python-minimums.yml
@@ -49,7 +49,11 @@ jobs:
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: "ubuntu-24.04-minimums"
-          save: true
+          # Only `main` writes, so a pull request restores main's cache without
+          # adding an entry of its own. Every job saving 400-700 MB on every push
+          # had the repository sitting at 10.19 GB against GitHub's 10 GB limit,
+          # evicting caches faster than they could be reused.
+          save: ${{ github.ref == 'refs/heads/main' }}
           max-size: 10G
 
       - name: Install Z3

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ Thumbs.db
 CLAUDE.md
 CLAUDE.local.md
 AGENTS.local.md
+
+# compiler cache written by the Windows CI jobs
+.sccache/

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -14,7 +14,19 @@ function(fiction_enable_cache)
     )
   endif()
 
-  find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
+  # Honour the requested cache first. Searching CACHE_OPTION_VALUES directly
+  # made CACHE_OPTION inert: ccache comes first in the list and is present on
+  # every runner, so asking for sccache silently got ccache.
+  find_program(CACHE_BINARY NAMES ${CACHE_OPTION})
+  if(NOT CACHE_BINARY)
+    list(REMOVE_ITEM CACHE_OPTION_VALUES ${CACHE_OPTION})
+    find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
+    if(CACHE_BINARY)
+      message(STATUS "${CACHE_OPTION} was not found, falling back to "
+                     "${CACHE_BINARY}")
+    endif()
+  endif()
+
   if(CACHE_BINARY)
     # The Visual Studio generator ignores compiler launchers outright, so
     # configuring one there looks like it works and caches nothing.

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -16,6 +16,15 @@ function(fiction_enable_cache)
 
   find_program(CACHE_BINARY NAMES ${CACHE_OPTION_VALUES})
   if(CACHE_BINARY)
+    # The Visual Studio generator ignores compiler launchers outright, so
+    # configuring one there looks like it works and caches nothing.
+    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+      message(
+        WARNING
+          "${CACHE_BINARY} was found, but the '${CMAKE_GENERATOR}' generator ignores "
+          "compiler launchers, so nothing will be cached. Configure with -G Ninja "
+          "to make the cache effective.")
+    endif()
     message(STATUS "${CACHE_BINARY} found and enabled")
 
     set(CACHE_LAUNCHER ${CACHE_BINARY})

--- a/cmake/ProjectOptions.cmake
+++ b/cmake/ProjectOptions.cmake
@@ -124,6 +124,14 @@ macro(fiction_local_options)
   # conform to memory limitations
   if(FICTION_LIGHTWEIGHT_DEBUG_BUILDS)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      # /Z7 is also what makes a Debug compilation cacheable, since ccache
+      # refuses /Zi. Appending it to the flags is not enough: CMake adds its own
+      # /Zi afterwards and wins, which the build log reports 304 times as
+      # `D9025: overriding '/Z7' with '/Zi'`. Setting the debug information
+      # format is what actually removes the /Zi.
+      set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
+      string(REGEX REPLACE "/Zi" "" CMAKE_CXX_FLAGS_DEBUG
+                           "${CMAKE_CXX_FLAGS_DEBUG}")
       set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Z7 /Ob0")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID
                                                    MATCHES ".*Clang")


### PR DESCRIPTION
Experiment arm for #1150 — not for merge. Measures sccache with `FICTION_ENABLE_PCH=OFF` against #1150's ccache + PCH + `/Z7` fix on the 4391s `🪟 windows-2025 v143` job. The two are mutually exclusive: sccache cannot cache precompiled headers at all.

Also fixes `CACHE_OPTION` being inert in `Cache.cmake`, which is why the arm could not otherwise be built.