### PR TITLE
⚡️ Adopt nanobind 3.0's split mode for the `pyfiction` wheels

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -45,7 +45,7 @@ jobs:
         # config discoverable via `python -m nanobind --cmake_dir` (see
         # bindings/mnt/pyfiction/CMakeLists.txt); unlike the previous pybind11-based bindings,
         # this isn't fetched by CMake and must be pip-installed ahead of time
-        run: python3 -m pip install --break-system-packages --disable-pip-version-check "nanobind~=2.13.0"
+        run: python3 -m pip install --break-system-packages --disable-pip-version-check "nanobind~=3.0.0"
 
       - name: Setup Z3 Solver
         id: z3

--- a/bindings/mnt/pyfiction/CMakeLists.txt
+++ b/bindings/mnt/pyfiction/CMakeLists.txt
@@ -37,8 +37,19 @@ if(NOT nanobind_exec_result EQUAL 0)
 endif()
 find_package(nanobind CONFIG REQUIRED PATHS "${nanobind_ROOT}" NO_DEFAULT_PATH)
 
-nanobind_add_module(pyfiction STABLE_ABI FREE_THREADED LTO NB_SUPPRESS_WARNINGS
-                    pyfiction.cpp)
+# Split mode: the extension links no nanobind library code and resolves it at
+# import time from the `nanobind-backend` wheel, so one abi3 binary covers
+# Python 3.10 up. It implies STABLE_ABI. Free-threaded interpreters need the
+# `abi3t` of Python 3.15 (PEP 803); below that, nanobind stops the configure
+# with a message naming the version.
+nanobind_add_module(
+  pyfiction
+  BACKEND_MODULE
+  nanobind_backend
+  FREE_THREADED
+  LTO
+  NB_SUPPRESS_WARNINGS
+  pyfiction.cpp)
 target_link_libraries(pyfiction PRIVATE libfiction)
 target_include_directories(pyfiction
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -196,11 +196,9 @@ Changed
       directly must be renamed
     - ``mnt.pyfiction`` now advertises developers and information technology as intended audiences
       and physics as a topic on PyPI
-    - Adopted nanobind's split mode, so one ``abi3`` wheel per platform now covers every supported
-      Python from 3.10 up. A platform previously needed four: version-specific wheels for 3.10,
-      3.11, and free-threaded 3.14, plus one ``abi3`` wheel for 3.12 and above. The extension no
-      longer carries its own copy of the nanobind library and instead resolves it at import time
-      from the new ``nanobind-backend`` runtime dependency
+    - Adopted nanobind's split mode, so one ``abi3`` wheel per platform now covers Python 3.10 and
+      up instead of four. ``mnt.pyfiction`` gains ``nanobind-backend`` as a runtime dependency,
+      which ``pip`` installs along with it
 
 Removed
 #######
@@ -222,9 +220,9 @@ Removed
       ``coordinates()``/``ground_coordinates()`` now return a ``std::ranges::subrange`` instead, with no
       change in usage
 - Python bindings:
-    - Removed the free-threaded (``cp314t``) wheel. Split mode needs the ``abi3t`` stable ABI that
-      arrives with Python 3.15 (`PEP 803 <https://peps.python.org/pep-0803/>`_); until then,
-      building on a free-threaded interpreter stops with a message naming that version
+    - Removed the free-threaded (``cp314t``) wheel. Free-threaded interpreters are unsupported,
+      source builds included, until Python 3.15 gives them the ``abi3t`` stable ABI
+      (`PEP 803 <https://peps.python.org/pep-0803/>`_)
     - Removed the ``DISABLE_GIL`` scikit-build-core override for free-threaded Windows builds. No
       CMake code ever read the define, and split mode rejects free-threaded interpreters outright
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -196,6 +196,11 @@ Changed
       directly must be renamed
     - ``mnt.pyfiction`` now advertises developers and information technology as intended audiences
       and physics as a topic on PyPI
+    - Adopted nanobind's split mode, so one ``abi3`` wheel per platform now covers every supported
+      Python from 3.10 up. A platform previously needed four: version-specific wheels for 3.10,
+      3.11, and free-threaded 3.14, plus one ``abi3`` wheel for 3.12 and above. The extension no
+      longer carries its own copy of the nanobind library and instead resolves it at import time
+      from the new ``nanobind-backend`` runtime dependency
 
 Removed
 #######
@@ -216,6 +221,12 @@ Removed
     - Removed ``range_t`` (``fiction/utils/range.hpp``); ``cartesian_layout``'s and ``hexagonal_layout``'s
       ``coordinates()``/``ground_coordinates()`` now return a ``std::ranges::subrange`` instead, with no
       change in usage
+- Python bindings:
+    - Removed the free-threaded (``cp314t``) wheel. Split mode needs the ``abi3t`` stable ABI that
+      arrives with Python 3.15 (`PEP 803 <https://peps.python.org/pep-0803/>`_); until then,
+      building on a free-threaded interpreter stops with a message naming that version
+    - Removed the ``DISABLE_GIL`` scikit-build-core override for free-threaded Windows builds. No
+      CMake code ever read the define, and split mode rejects free-threaded interpreters outright
 
 Fixed
 #####

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -309,6 +309,15 @@ there.
    ``-DPython_EXECUTABLE=<path_to_repo>/.venv/bin/python3`` (or the equivalent ``.venv\Scripts\python.exe`` on
    Windows) if CMake would otherwise pick up a different interpreter.
 
+.. note::
+
+   nanobind is used in *split mode*: the extension contains no nanobind library code and resolves it at import time
+   from the separate ``nanobind-backend`` package, which is therefore a runtime dependency of ``mnt.pyfiction``.
+   That is what lets a single ``abi3`` wheel per platform serve every supported interpreter. Free-threaded
+   interpreters are not supported until Python 3.15 gives them a stable ABI
+   (`PEP 803 <https://peps.python.org/pep-0803/>`_); building on an earlier one stops the CMake configure with a
+   message naming that version.
+
 ---
 
 Advanced Configuration

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -103,7 +103,7 @@ them automatically. Should the repository have been cloned before, the commands:
   git submodule update --init --recursive
 
 will fetch the latest version of all external modules used. Additionally, only ``CMake`` and a C++20 compiler are
-required for the C++ part. If you want to work with the Python bindings, you need a Python 3.9+ installation.
+required for the C++ part. If you want to work with the Python bindings, you need a Python 3.10+ installation.
 
 At the time of writing, for parallel STL algorithms to work when using GCC, the TBB library (``libtbb-dev`` on Ubuntu) is
 needed. It is an optional dependency that can be installed for a performance boost in certain scenarios. For your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "scikit-build-core~=1.0.3",
     "vcs-versioning~=2.3.0",
-    "nanobind~=2.15.0"
+    "nanobind~=3.0.0"
 ]
 build-backend = "scikit_build_core.build"
 
@@ -46,7 +46,11 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "z3-solver>=4.8.5"
+    "z3-solver>=4.8.5",
+    # the split-mode extension carries no copy of the nanobind library and resolves it at import
+    # time from this wheel. Never pin or upper-bound it: two projects pinning different versions
+    # could not be installed together
+    "nanobind-backend>=1.0"
 ]
 
 [project.urls]
@@ -69,8 +73,9 @@ cmake.build-type = "Release"
 build-dir = "build/{wheel_tag}/{build_type}"
 # Explicitly set the package directory
 wheel.packages = ["bindings/mnt"]
-# Enable Stable ABI builds for CPython 3.12+
-wheel.py-api = "cp312"
+# One Stable ABI wheel per platform serves every supported CPython. The 3.10 floor is what
+# nanobind's split mode buys: a linked stable-ABI build cannot go below 3.12
+wheel.py-api = "cp310"
 # Only build the Python bindings target
 build.targets = ["pyfiction"]
 # Only install the Python package component
@@ -121,13 +126,6 @@ cmake.args = [
     "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold"
 ]
 
-[[tool.scikit-build.overrides]]
-if.python-version = ">=3.13"
-if.abi-flags = "t"
-if.platform-system = "win32"
-inherit.cmake.define = "append"
-cmake.define.DISABLE_GIL = "1"
-
 
 [[tool.dynamic-metadata]]
 provider = "vcs_versioning"
@@ -169,9 +167,16 @@ testpaths = ["bindings/mnt/pyfiction/test"]
 
 
 [tool.cibuildwheel]
+# cp310 builds the one abi3 wheel that serves every supported CPython; the later interpreters find
+# it already built, skip the build step, and go straight to `test-command`. Narrowing this to
+# `cp310-*` would produce the same single wheel but shrink the Python test suite to one interpreter
 build = "cp3*"
 archs = "auto64"
-skip = ["*-musllinux*"]
+# nanobind-backend publishes no musllinux wheels.
+# The free-threaded identifiers are not gated behind `enable` from 3.14 on, so they are skipped
+# here: split mode needs the `abi3t` stable ABI of Python 3.15 (PEP 803) and stops the CMake
+# configure below it
+skip = ["*-musllinux*", "cp3*t-*"]
 build-frontend = "build[uv]"
 manylinux-x86_64-image = "manylinux_2_28"
 # The wheel does not ship its own tests, so the suite is copied in next to the installed
@@ -202,8 +207,8 @@ select = "*-macosx_arm64"
 environment = { MACOSX_DEPLOYMENT_TARGET = "13.0" }
 
 [[tool.cibuildwheel.overrides]]
-# cp312-* wheels carry the abi3 tag (Stable ABI); verify no non-limited-API symbols leaked in
-select = "cp312-*"
+# the cp310-* wheel carries the abi3 tag (Stable ABI); verify no non-limited-API symbols leaked in
+select = "cp310-*"
 inherit.repair-wheel-command = "append"
 repair-wheel-command = "uvx abi3audit --strict --report {wheel}"
 
@@ -317,7 +322,7 @@ docstring-code-format = true
 build = [
     "scikit-build-core~=1.0.3",
     "vcs-versioning~=2.3.0",
-    "nanobind~=2.15.0",
+    "nanobind~=3.0.0",
 ]
 docs = [
     "sphinx==8.1.3; python_version < '3.11'",

--- a/uv.lock
+++ b/uv.lock
@@ -447,6 +447,7 @@ wheels = [
 name = "mnt-pyfiction"
 source = { editable = "." }
 dependencies = [
+    { name = "nanobind-backend" },
     { name = "z3-solver" },
 ]
 
@@ -479,16 +480,19 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "z3-solver", specifier = ">=4.8.5" }]
+requires-dist = [
+    { name = "nanobind-backend", specifier = ">=1.0" },
+    { name = "z3-solver", specifier = ">=4.8.5" },
+]
 
 [package.metadata.requires-dev]
 build = [
-    { name = "nanobind", specifier = "~=2.15.0" },
+    { name = "nanobind", specifier = "~=3.0.0" },
     { name = "scikit-build-core", specifier = "~=1.0.3" },
     { name = "vcs-versioning", specifier = "~=2.3.0" },
 ]
 dev = [
-    { name = "nanobind", specifier = "~=2.15.0" },
+    { name = "nanobind", specifier = "~=3.0.0" },
     { name = "nox", specifier = ">=2025.11.12" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
@@ -511,11 +515,66 @@ test = [
 
 [[package]]
 name = "nanobind"
-version = "2.15.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/08/cef3343279d2bde0baa57aadaacf7196ee336f12449c50c27f799c45b3f7/nanobind-2.15.0.tar.gz", hash = "sha256:3eace37a3b8cdadd531fcc6145263985b29821467161d34ff722b0644cf445b5", size = 1060056, upload-time = "2026-08-15T19:01:04.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/37/5f136054cfdba93e763d956898048a21997b7478ccadcfec6dfebf4b72aa/nanobind-3.0.0.tar.gz", hash = "sha256:68583c41d58af77649b830407d2ba84627f21f07ad4ae2e32c6988fb96eaa71a", size = 1141160, upload-time = "2026-08-22T04:23:31.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/72/16a606cbea58be568475f450ece121b3fd62cffb390fd0f8eb8b410904f5/nanobind-2.15.0-py3-none-any.whl", hash = "sha256:91dae9305c6242cf63ab11a5c41594e234e7a22fd9fcc2c5c4ba80724abc1787", size = 271648, upload-time = "2026-08-15T19:01:02.477Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8b/cbd87788012d98179686ecdce7d73d154e277c50859458157ec5575c0352/nanobind-3.0.0-py3-none-any.whl", hash = "sha256:3808620334b1e7e647d71feb1bf525496216b48ee2a8cd4c4a31ae1f1cbb1c6f", size = 316362, upload-time = "2026-08-22T04:23:29.737Z" },
+]
+
+[[package]]
+name = "nanobind-backend"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/23/e892b9c91154b16987ebc7efd795b3a23e244e8fba3ed071f9ac84224c3b/nanobind_backend-1.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e096d976adfd4d2950095e40134832d9325e62b180c6548174996f20d44d0e82", size = 80457, upload-time = "2026-08-22T04:22:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7e/ef67e5cfc1436fb9759797fdd5fb68062d1d5cf50e36182c208749870d06/nanobind_backend-1.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2946667fb8cc7bbb52d0151c090540576a528e48dcd7d1bebe007688e70f8a5d", size = 76473, upload-time = "2026-08-22T04:22:40.135Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/13/eebc40c9d083aa032e56a3ea1cf316b621e32de46b4c4daa3274ab5b1ed5/nanobind_backend-1.0.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2cc095faf04db1b8c05e4685b6b6ed1155d67a148cb892ead6b7b64574184b0e", size = 98418, upload-time = "2026-08-22T04:22:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/97/96/ee9bf6a053d8a2f505eab8cafc36ff8a3e4f928d0b01fd9befac579d537a/nanobind_backend-1.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7ea25c4b69a337eae4377e0c53f0a000dfd996bfe61303bc03996e8b2bf5735", size = 106625, upload-time = "2026-08-22T04:22:42.41Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d2/590dd301da0d44a02ac297331e1e2a22934f851aa0b3d390156ecc6573fb/nanobind_backend-1.0.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:a6d17ca7457000f848556a31f5884b2286a70db1b20aa0ccb090241f2dafd83d", size = 100054, upload-time = "2026-08-22T04:22:43.55Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/74/1cd06a4ab1fbb03aaba84f27d2536c925a0c87d6873fc794c0258de45264/nanobind_backend-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:e27e34cb764d0dbb07319e3e956be3e08392e55f1e778c823f2f3951246bfd4c", size = 264722, upload-time = "2026-08-22T04:22:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/76/49/a4c01de9c358b5749560a5415b899a8b57399381e5c8ae64962381302a59/nanobind_backend-1.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:b20b3e4bbb672987f9d65e52f1829299589c1ccf0502360879846a922e9cb1ed", size = 80577, upload-time = "2026-08-22T04:22:45.852Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/65/c3ff5ef09109a163a3cbe8a69250ae7c4b0b4d8df79b1cb447d03747529f/nanobind_backend-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:89c582f83d491ba01aa1a5ad39ed6c59bdead67ec3b8c88b288b7e4b6bac18df", size = 76586, upload-time = "2026-08-22T04:22:46.756Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/14/40f0a465df491562debf55044bcfc728dca7cb8e3ef76f532aa8f75e775b/nanobind_backend-1.0.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdf41e97cfb9f149c89b323b7850bd9dc6316d1d79adf99081511b9a1d0858b1", size = 98356, upload-time = "2026-08-22T04:22:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9a/0db4d9982ac708b6c532ca6ea2a523d5c85a25f7fc288558c4d6fad725b0/nanobind_backend-1.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33bdec0da2f78669d5c95bd546ff2bb7744dafa43a16bb72b2eecdf83d8c3b3a", size = 106460, upload-time = "2026-08-22T04:22:48.716Z" },
+    { url = "https://files.pythonhosted.org/packages/49/77/45d11f991aa78e8dfaac490c6330e38912d414b60a6b624024e8eaa4cadb/nanobind_backend-1.0.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d77ecad0d4b8526865f6bec7cd77603c686ef65b57cc7ec81795b3a468dba0f1", size = 100025, upload-time = "2026-08-22T04:22:49.763Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/22/8a2576123da22743a1ca6b683e2e1a046990dd75ab3f70c21c0c8690d936/nanobind_backend-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:691be892dcd6b4b1317d628b49bf3e688470f4f927ac316dca233ee19fab7ecd", size = 264783, upload-time = "2026-08-22T04:22:50.856Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/fbaa64393f5ed253de5879e8d30477d05f53a3c2b106b9db4f33db7da310/nanobind_backend-1.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:dc199056cbd534c5317899539a36245aa14bce6b8afd48c217e578b2463e0594", size = 435095, upload-time = "2026-08-22T04:22:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/57/f02cc977a0ba1ddf2a41ebad61bcf2fbfd905aef7753082d9f39389a13e1/nanobind_backend-1.0.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:9fd9145b1aa8e9b78029308a73e1ade94369d7250c826783655210d1800f1493", size = 80504, upload-time = "2026-08-22T04:22:53.269Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3a/40e9ef3133573dddf32f7dcaf1bc7d4f459ecb632b2274c7a619fbfa40ea/nanobind_backend-1.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dca8999e4e87a4e39e162c55b70f39fe1882913c4d7de1adab81cf82bb8cb9ad", size = 75568, upload-time = "2026-08-22T04:22:54.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3b/806d3346ae8175746853b204efd59a4ad8bbddf91d48d03f4eac48d15245/nanobind_backend-1.0.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a42503f65cd595f97a31f24d21c6ddbd017ffcb808626d0134e475e0db25f3d", size = 97730, upload-time = "2026-08-22T04:22:55.085Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2c/7fb13ecb1e8c0c268e26c6bc44be4a7f51996b2a3c006749ce6fc4fd7da2/nanobind_backend-1.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aa9864050cc5fd1ff59d1f9b79740efa278515eed27af848efae07125c029b8", size = 106063, upload-time = "2026-08-22T04:22:55.973Z" },
+    { url = "https://files.pythonhosted.org/packages/18/bf/2f6dbcedcca065c20b73346f037d69d78fdb545c9abbf7ad8b27da7890c5/nanobind_backend-1.0.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:00dadccfa92d0f9eac0b1877fdc3fd99d2ebb1a651fbe44daff365a173bd2faa", size = 99415, upload-time = "2026-08-22T04:22:57.03Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/da/f6af805e0737652d4b6aa2e51e3ec1485d906e77ee9389b126adbb9f9644/nanobind_backend-1.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:9b1502e3f160358feff92f60a634e198c76754f50a60fdacd9a8b5dccbe5d9d0", size = 264454, upload-time = "2026-08-22T04:22:58.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/45/851847d5246c0c47dbebe473ecfbb0ed44a41fae9ef7e2ec73cd7c8975a3/nanobind_backend-1.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:a1f6e6320aee495e5cad933d671e9d60ee42f4bf460930ef7afed191243aa733", size = 434441, upload-time = "2026-08-22T04:22:59.442Z" },
+    { url = "https://files.pythonhosted.org/packages/06/eb/1c4f3e1fcc41093e321b1c4eb7ca79f628a36057496398bb9fba4d97e417/nanobind_backend-1.0.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:a6dd7a66fb7416d62be577d41d64478a187d9f36d089759555698bb08addc2c3", size = 80547, upload-time = "2026-08-22T04:23:00.75Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c2/d59e5b6af43e45088c18895035e053c4585bce7d1bde9679368ef5b960e0/nanobind_backend-1.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:28a4c397d6d36dfb712acbab817c02ad2f8658a85fb1dbbae7385689d28d20e9", size = 75630, upload-time = "2026-08-22T04:23:01.674Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a1/97ffb303def8e5a4e48694b01d58477899392468295e8af5c60fdae5f035/nanobind_backend-1.0.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ddf018fc62a2bd51e9d7cc6477af7ae13ccc0db69b775d67d837ba7e0bc41b4", size = 97824, upload-time = "2026-08-22T04:23:02.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/0a2143308fd413ae10da3fb8732e9d2fc87de4605a1126d304ffe9f63414/nanobind_backend-1.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2c78ed4b88ef6c59a835eebe7f5e91ab6869f17f915a61c7d4eec24a1e2b85", size = 106253, upload-time = "2026-08-22T04:23:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/7bb71f0a2566cb398d6877e3540307c3d0e684797001eb1128c2c3732a52/nanobind_backend-1.0.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:36a116471c3ca0b6cd3af1e1fa2e38c52086a2d2daf00b86f90a99da5efdde53", size = 99504, upload-time = "2026-08-22T04:23:04.644Z" },
+    { url = "https://files.pythonhosted.org/packages/90/49/8038eedfd35433968e638081ca4eb6881869e517f766beff0f095387dc9a/nanobind_backend-1.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:915c6ff4ce92584cdde18a24cc5d730f04a70c2f26bc0bc4db903ca54043eb86", size = 264501, upload-time = "2026-08-22T04:23:05.606Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/6c515cac31f723d2ce2c3155de4343a3ccf612025171cde25d48290c3680/nanobind_backend-1.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:6b7c31403e6f39fd704359ce4a0687d894a9ffa67813da6a54c6d0eb6fde93aa", size = 434433, upload-time = "2026-08-22T04:23:06.626Z" },
+    { url = "https://files.pythonhosted.org/packages/33/82/474e530e562a2c98db0dbd35cc2bc08500895be7cab6b13c5c990c09a650/nanobind_backend-1.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:04a35c7395daeb9a33f6801ca3d1e11e0384702ae22b8e3e251ef9f6a4a54c10", size = 80613, upload-time = "2026-08-22T04:23:07.851Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/36/7f79710b96ba643c91db149f7ba1b454124cf2cf97e379ef6c3529d97dd0/nanobind_backend-1.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:574d104bf6322711e5db55ed49409289df9582e8c1fd2a2f2d643d2136428e13", size = 76216, upload-time = "2026-08-22T04:23:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/08/08/fecefa8c4e5774222b2ed1b715822bca5c9bfb5623fef9be7cc9133df18c/nanobind_backend-1.0.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:926ba1e7e12bbf3f701f7a200e8801c5f9bd05ba2244962692fcafbd32b8a0d2", size = 98152, upload-time = "2026-08-22T04:23:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/65/8073c078a91e2fed8c54154f6a0b1d39e362c0ab5ffa7cb93c73f87c9954/nanobind_backend-1.0.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a42a2d594f22e689f15cbdbdf4bf1468ef7a8287da41842515c1cc836a1f2dec", size = 106486, upload-time = "2026-08-22T04:23:10.771Z" },
+    { url = "https://files.pythonhosted.org/packages/37/fe/69f69fbcd6d4e6cee3e27e65a2b10e354da8adfd0d88a87c4c33a845864f/nanobind_backend-1.0.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:ce93f26da63eaa24729d214fa6669525293d75e56f394f2980839cd65a75d2e5", size = 99382, upload-time = "2026-08-22T04:23:11.881Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3e/e33c10a7b0a728e83d492673612146ed7cd47c5d28c242969b4296cb6265/nanobind_backend-1.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:b0eabf671c91fdcd6a61d2177aa434731680442aa2317de54acfabeac4a4cc06", size = 273371, upload-time = "2026-08-22T04:23:12.895Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f2/7a44d3b12d4a876c123445fe6f4971eff1260c6f7660ee00e261cdbe2770/nanobind_backend-1.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:1e5f8217887d1d83ccbe1e61c37d1502ab951fef466a06df2abb1161e246ef79", size = 450418, upload-time = "2026-08-22T04:23:13.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/3104f9a204271cd57192bdf50577980c030ad3e53dd6ae6fe1aef9bbb5d8/nanobind_backend-1.0.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:4816cf6f998b0c2435aa643df7a5c59492202778c96e575e55da802e51c75461", size = 80862, upload-time = "2026-08-22T04:23:15.118Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/441ddd77a34b013350289c2fc99279d76403d45ab6cfdd6ea60be3e09a75/nanobind_backend-1.0.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:7a7c76fc958eb7bf4b5454d9c036f1e92f8b406343c7b7b7f4e53302718ffee6", size = 76556, upload-time = "2026-08-22T04:23:16.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/29/101f4ebf5d0455ddab57785d8a341c1bd25d248e0c444ef9cb6ce85df9bb/nanobind_backend-1.0.0-cp315-cp315-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9a15c8155c465066fdf43a2589223cd41f4a688f52046f59edcded0790a8ad3", size = 98453, upload-time = "2026-08-22T04:23:17.215Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e1/5630f4e2297fb03749551592e9850ba45d498952a135d3065b49bc68e603/nanobind_backend-1.0.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9574cc624b9fff2e8f5946211422476977e43f6b796b83e143b289ecb70df4cf", size = 106886, upload-time = "2026-08-22T04:23:18.314Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/698c970f8df703be42720b96678ce0de08536938c95b3ab551e64a33f9ca/nanobind_backend-1.0.0-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:fac95e67ba91c639c52298388d22595c1d912a09a671d4793c8d16711a0dd1be", size = 99637, upload-time = "2026-08-22T04:23:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/29/6dd73fdcd3deed710d0dc3b2a4a86ad491450dbc2cd58018a9091a4164f1/nanobind_backend-1.0.0-cp315-cp315-win_amd64.whl", hash = "sha256:4ae0214ad6708b8001d82f1dd6c302aaba9627d81aa0573efc896a3b90f95bce", size = 273532, upload-time = "2026-08-22T04:23:20.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/14/cd5789bb09cb3a82b9e85b5164f2b4d7cff2ca6b861d4f89a7df9ae8d207/nanobind_backend-1.0.0-cp315-cp315-win_arm64.whl", hash = "sha256:a7a97a1326fa2d70e013b7af769305796047a01dc4567f5f90d769c6a2e2344d", size = 450650, upload-time = "2026-08-22T04:23:21.317Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/60/7754c00b60994a790574ec6190aeafeb8878e7c72c2c1877b84ebc911451/nanobind_backend-1.0.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:d8581ccc5f000a76b4304f9c8c4ee9e60499a9d9502e6e0e885c1606d6b29f60", size = 84440, upload-time = "2026-08-22T04:23:22.405Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e8/526799c68933550776b2002a0240ff770474d11a527962541b212f9d23fc/nanobind_backend-1.0.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:17a9ddc6cc096d713151fbbaabe41d960d1d596c0e046abcd2b17c6d6565c443", size = 80036, upload-time = "2026-08-22T04:23:23.459Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/29/a953f8be0c7b69509793d179f8f709b2c5d301bf65089bb3d87afa859f25/nanobind_backend-1.0.0-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a83f1c86aa2c7da33ce4a8df4304d34d6364335b2c455a490983059471e21c4d", size = 100522, upload-time = "2026-08-22T04:23:24.394Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/cce583c8177b061a3ee82c23da857f64975c1f28bdd614ecf7beda52f38a/nanobind_backend-1.0.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ea3fe04341040b09444cc946f5cd39145290b2de3b90ca9868b1b59cc75c23e", size = 108352, upload-time = "2026-08-22T04:23:25.411Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d0/7e56cf0b6faae40d23ec7b5c4d90ad74480038bc99dd9f8b05c58dc70726/nanobind_backend-1.0.0-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:983aaeaf65e61ddff125a3eea463675d322d9981510f6f6e462e6bcfc915dca6", size = 103571, upload-time = "2026-08-22T04:23:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/cf/941d624be0dd41f4bb139fe74d489d83845909dadc9f19fe7d4da5d5c3d1/nanobind_backend-1.0.0-cp315-cp315t-win_amd64.whl", hash = "sha256:2a42cd509c1889cbccdcf8a23dc3733c4b7e2388973ac4292db094576e3e27d0", size = 279141, upload-time = "2026-08-22T04:23:27.535Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/badc51c6b13ccb0f7a6ef88e8be014193cfe727f0849eaafa28489a848a2/nanobind_backend-1.0.0-cp315-cp315t-win_arm64.whl", hash = "sha256:8975422479b145ce46d4d79b4fc03dbfab40254470468a99ea417090bb1ce460", size = 453221, upload-time = "2026-08-22T04:23:28.568Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adopts [nanobind 3.0's split mode](https://nanobind.readthedocs.io/en/latest/split_mode.html), porting
[marcelwa/aigverse#463](https://github.com/marcelwa/aigverse/pull/463) to `pyfiction`.

Split mode keeps the nanobind library out of the extension and resolves it at import time from the tiny
`nanobind-backend` wheel. That is what lifts the stable-ABI floor from 3.12 to 3.10: a *linked* stable-ABI build
cannot go below 3.12, which is why a platform needed four wheels today — version-specific ones for 3.10, 3.11, and
free-threaded 3.14, plus one `abi3` wheel for 3.12 and above. One `cp310-abi3` wheel now serves every supported
interpreter.

The switch is one CMake keyword:

```diff
-nanobind_add_module(pyfiction STABLE_ABI FREE_THREADED LTO NB_SUPPRESS_WARNINGS
-                    pyfiction.cpp)
+nanobind_add_module(
+  pyfiction
+  BACKEND_MODULE
+  nanobind_backend
+  ...
```

No C++ source changes were needed. The bindings use no trampolines, no custom type casters, and no `ndarray`, and
`grep -rn rv_policy bindings/` returns nothing — compile-time `nb::rv_policy` literals are what 3.0 now requires.

`.github/workflows/cpp-linter.yml` pinned `nanobind~=2.13.0`, which has no `BACKEND_MODULE`. The `ci-tidy` preset
builds the bindings, so that pin had to move to `~=3.0.0` or 🚨 Lint would fail at configure time.

### Two deliberate divergences from the aigverse change

**`[tool.cibuildwheel] build` stays `cp3*`; aigverse narrows it to `cp310-*`.** `ci.yml` says outright that the
wheel jobs are what runs this project's Python test suite — the 🐍 CI workflow was removed in favor of them.
cibuildwheel finds the already-built `abi3` wheel for cp311–cp314, skips the build step, and goes straight to
`test-command`, so `cp3*` produces the same single wheel while keeping the suite on five interpreters. Narrowing it
would have quietly cut Python testing to 3.10. aigverse can narrow because it runs `nox -s tests` in CI separately.

**Free-threaded builds had to be skipped explicitly.** cibuildwheel 3.3 only gates `cp313t` behind
`enable = ["cpython-freethreading"]`; `cp314t` is on by default, so this repository ships that wheel today. Split
mode needs the `abi3t` stable ABI of Python 3.15 ([PEP 803](https://peps.python.org/pep-0803/)) and stops the CMake
configure below it, so `skip` now excludes `cp3*t-*`. The `DISABLE_GIL` scikit-build-core override goes with them —
no CMake code in this repository ever read that define.

Free-threading support is worth revisiting when 3.15 lands: `nanobind-backend` already publishes `cp315t` wheels,
and it then collapses into the keywords this pull request already passes. aigverse#463 documents why implementing it
*now* costs ~150 lines of dynamic-metadata machinery for a wheel of exactly the per-version shape this change moves
away from.

### On the performance claim

aigverse measured split mode as a **packaging** win, not a speed one: ~1–3% aggregate on 3.12+, parity below, and
nothing end-to-end. I did not re-benchmark for _fiction_, whose workloads are even more compute-dominated, so the
changelog entry claims only the packaging effect.

### Verification

Run locally on Linux/x86-64:

- `nox -s tests-3.10` — 331 passed (source build at the new `abi3` floor)
- the single `cp310-abi3` wheel installed and run against the full suite on 3.11, 3.12, 3.13, and 3.14 — 331 passed
  on each
- `nox -s minimums` — 331 passed against the lowest declared direct dependencies
- `abi3audit --strict` — clean, computed baseline 3.10
- the built `.so` has zero undefined `nanobind` symbols and carries the `nanobind_backend` resolution string, so the
  library really is out of the binary
- a standalone CMake probe with none of the scikit-build variables set — confirms the `ci-tidy`/`pyfiction` preset
  path still configures and builds, and nanobind itself prints `requires 'nanobind-backend>=1.0' at runtime`,
  matching the declared bound
- `cibuildwheel --print-build-identifiers` — cp310–cp314 with no `cp314t`, on Linux, macOS, and Windows
- `nox -s check_sdist`, `prek run --all-files`

### CI confirms the `cp3*` reasoning

From the Windows wheel job, which is also the platform I could not test locally (split mode needs
`Python::SABIModule` there):

```
Building cp310-win_amd64 wheel
*** Created mnt_pyfiction-...-cp310-abi3-win_amd64.whl
  Testing wheel...  331 passed
Building cp311-win_amd64 wheel
Found previously built wheel ...-cp310-abi3-win_amd64.whl, that's compatible with cp311-win_amd64. Skipping build step...
  Testing wheel...  331 passed
... likewise cp312, cp313, cp314 -- 331 passed on each
```

One wheel built, four reused, and the suite still ran on all five interpreters. Narrowing `build` to
`cp310-*` would have produced that same single wheel and silently dropped four of those five test runs.

No workflow file needed changing beyond the `cpp-linter` pin: `cibuildwheel` reads its configuration from
`pyproject.toml`, so the packaging jobs pick the new matrix up as-is.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

---

Drafted with AI assistance; every measurement above was reproduced locally, and CI is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python wheels now use the stable ABI and support CPython 3.10 and newer across supported platforms.
  * Nanobind is provided through the `nanobind-backend` runtime package.

* **Bug Fixes**
  * Improved build compatibility by standardizing supported wheel targets.

* **Documentation**
  * Added installation and compatibility guidance for the new Python bindings.
  * Clarified that free-threaded Python builds are unsupported until Python 3.15 stabilizes the ABI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
