### PR TITLE
📝 Tell agents how much code and how much prose to write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,9 @@ one guard per caller, and it leaves no sibling caller broken.
   template-heavy, so every added template parameter costs compile time and instantiation
   surface in every translation unit that includes the header.
 - No scaffolding for a caller that does not exist yet. That caller can scaffold.
-- Deletion over addition. Boring over clever. Fewest files.
+- Deletion over addition. Boring over clever. Fewest files. That last one describes the
+  shape of the solution; it is not a reason to leave a cleanup you found on the way for
+  someone else, which `Working Principles` requires you to ship here.
 - Two options of the same size? Take the one that is correct at the edges. The goal is less
   code, not a flimsier algorithm.
 - Mark a deliberate simplification that cuts a real corner with a known ceiling — an O(n²)
@@ -96,13 +98,15 @@ Cutting one of these is a defect, not minimalism:
   entry, the boxes in `.github/pull_request_template.md`.
 - The check. Non-trivial logic — a branch, a loop, a lifetime, a bound — leaves behind one
   runnable test that fails if the logic breaks. Match the style of the tests around it and
-  add the case, not a suite. A one-line change needs no test.
+  add the case, not a suite. Size is not the criterion: a one-line fix to a bound or a
+  branch is exactly what a regression test protects. A mechanical or documentation-only
+  change needs none.
 
 ### Explaining the code
 
 Code first, then at most three lines: what you skipped, and when to add it. If the
 explanation outruns the code, delete the explanation — a paragraph defending a
-simplification is complexity smuggled back in as prose. A report, walkthrough, or review the
+simplification adds back the complexity it removed. A report, walkthrough, or review the
 maintainer asked for is not padding; give that one in full.
 
 A subagent inherits none of this. Any subagent that plans, writes, or reviews code gets the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,35 @@ code comments, and error messages.
   it in a code comment at the site or in the pull request — not in the changelog.
 - Break any of these rules rather than write something unclear or imprecise.
 
+### Pull request, issue, and comment bodies
+
+Default: **one paragraph, three sentences at most** — why the change was needed, what it
+does, and the one thing a reviewer needs in order to read the diff. Six lines is the
+ceiling. The title carries the _what_; the body carries only what the title and the diff
+cannot.
+
+`.github/pull_request_template.md` mandates the sections, not their length: `## Description`
+is that one paragraph, and the checklist is ticked, not annotated. The AI-disclosure line
+required under `Git and GitHub` sits outside the ceiling.
+
+Go longer only for a reason you can name:
+
+- a decision a reviewer cannot infer from the diff, with its reason;
+- a reproduction, a measurement, or a number that makes a claim checkable.
+
+Keep out of a pull request body: a restatement of the issue, a walk through the diff file by
+file, a list of tests by name, a log of every design decision considered, a closing summary.
+That detail belongs in the commit messages, attached to the code it explains, and in the
+issue. Length reads as padding, not thoroughness.
+
+An issue body takes the same shape: the symptom, what you observed, how to reproduce it. A
+review reply or a report of review findings gets a line or two per defect, then stops.
+
+Never hard-wrap prose you type into GitHub — pull request and issue bodies, review bodies,
+thread comments and replies. One line per paragraph, per list item, and per table row; let
+GitHub reflow it. The wrap in this repository belongs to the Markdown and reStructuredText
+files in the tree, not to a web textarea.
+
 ### Documentation describes the status quo
 
 Documentation, Doxygen comments, and docstrings state what the code does now and why. They

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,8 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
 ## Working Principles
 
 - Prefer the smallest change that fully solves the task, then improve what you found on
-  the way there. Dependency bumps are the one thing that still belongs in its own pull
-  request; Renovate opens those itself.
-- Never add an abstraction, a template parameter, or a configuration option until a
-  second concrete caller needs it. _fiction_ is header-only and template-heavy, so every
-  added template parameter costs compile time and instantiation surface in every
-  translation unit that includes the header.
-- Prefer an existing facility from the STL, `mockturtle`, or `kitty` over a new
-  implementation. If you add a helper that duplicates one of them, say in the pull request
-  description why the existing one does not fit.
+  the way there. `Coding` below says how to get there. Dependency bumps are the one thing
+  that still belongs in its own pull request; Renovate opens those itself.
 - Test the documented contract. Never pin down a provisional implementation choice: a
   test that asserts on an internal detail blocks the next refactor without protecting a
   user.
@@ -45,6 +38,76 @@ Subdirectories carry their own `AGENTS.md` with rules that apply only there.
 - A redesign is the exception, because it costs more to review than to write. Say what you
   would change and why, and act once the maintainer agrees.
 - Prioritize the architecture and maintainability of the project as a whole.
+
+## Coding
+
+How much code to write. `Writing` governs the prose and `Code Style` governs how the code
+looks; this section governs how much of it there is.
+
+### The ladder
+
+Understand the problem before you climb: read the task, read the code it touches, and trace
+the real flow end to end. Then stop at the first rung that holds.
+
+1. Does this need to exist? A speculative need is no need. Skip it, and say so in one line.
+2. Does _fiction_ already have it? Reuse the trait, the type, or the pattern that sits a few
+   headers over. Re-implementing what `include/fiction/` already carries is the most common
+   way a change grows.
+3. Do the STL, `mockturtle`, or `kitty` do it? Use them. If you add a helper that duplicates
+   one of them, say in the pull request description why the existing one does not fit.
+4. Does a build or language feature cover it? A CMake option, a compiler flag, a
+   `static_assert`, or a concept beats runtime code.
+5. Does a dependency already in the tree solve it? Use it. Never add one for what a few
+   lines cover; adding one is an ask-first case, see `Boundaries`.
+6. Can it be one line? Write one line.
+7. Only then: the minimum code that works.
+
+The ladder shortens the solution, never the reading. A small diff in the wrong place is not
+a lazy win, it is a second bug.
+
+Fix the root cause, not the symptom. A bug report names a symptom. Grep every caller of the
+function you touch and fix the shared function once: one guard there is a smaller diff than
+one guard per caller, and it leaves no sibling caller broken.
+
+### Rules
+
+- No abstraction nobody asked for: no template parameter, no configuration option, no
+  policy class until a second concrete caller needs it. _fiction_ is header-only and
+  template-heavy, so every added template parameter costs compile time and instantiation
+  surface in every translation unit that includes the header.
+- No scaffolding for a caller that does not exist yet. That caller can scaffold.
+- Deletion over addition. Boring over clever. Fewest files.
+- Two options of the same size? Take the one that is correct at the edges. The goal is less
+  code, not a flimsier algorithm.
+- Mark a deliberate simplification that cuts a real corner with a known ceiling — an O(n²)
+  scan, a naive heuristic, a bound that holds only for the layouts in `benchmarks/` — in one
+  comment naming the ceiling and the upgrade path. Name the ceiling, never the tool or the
+  agent that wrote the code.
+
+### Never cut
+
+Cutting one of these is a defect, not minimalism:
+
+- Input validation at a public API boundary, and error handling that prevents a silent wrong
+  answer.
+- Anything the task explicitly asked for. If the maintainer wants the full version after you
+  argue for the small one, build it and stop re-arguing.
+- What this repository mandates: the Doxygen block on every symbol, the `docs/changelog.rst`
+  entry, the boxes in `.github/pull_request_template.md`.
+- The check. Non-trivial logic — a branch, a loop, a lifetime, a bound — leaves behind one
+  runnable test that fails if the logic breaks. Match the style of the tests around it and
+  add the case, not a suite. A one-line change needs no test.
+
+### Explaining the code
+
+Code first, then at most three lines: what you skipped, and when to add it. If the
+explanation outruns the code, delete the explanation — a paragraph defending a
+simplification is complexity smuggled back in as prose. A report, walkthrough, or review the
+maintainer asked for is not padding; give that one in full.
+
+A subagent inherits none of this. Any subagent that plans, writes, or reviews code gets the
+ladder and the `Never cut` list in its prompt, or the absolute path to this file. A plan is
+where the abstraction nobody asked for gets designed in, and every later step inherits it.
 
 ## Writing
 


### PR DESCRIPTION
## Description

`AGENTS.md` told agents to prefer the smallest change but not how to arrive at one, and said nothing about how long a pull request body should be. This adds a `Coding` section — a ladder to climb before writing code, plus the `Never cut` list that keeps minimalism from eating validation, the mandated Doxygen block and changelog entry, or the one test that fails when the logic breaks — and caps pull request, issue, and comment bodies at one paragraph. Both are adapted from the agentic harness; the three Working Principles bullets the ladder now covers move into it rather than being restated twice.

Fixes # (no issue)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Tests, changelog, and bindings are not applicable: this changes only the agent instructions, which are not user-facing and have no test surface.

---

Drafted with AI assistance; the wording was checked by hand against the sections it replaces and against `.github/pull_request_template.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance with a coding decision hierarchy and practical rules for focused, edge-correct changes.
  * Added guidance on preserving validation, requested features, repository requirements, and tests for non-trivial logic.
  * Clarified expectations for concise code explanations, subagent prompts, and pull request, issue, and comment descriptions.
  * Added recommendations to avoid unnecessary abstractions, scaffolding, and complexity while documenting deliberate simplifications.
  * Refined dependency-bump wording without changing its meaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->