### PR TITLE
🔧 Hide the embedded static libraries' symbols from the `pyfiction` extension

### DIFF
--- a/bindings/mnt/pyfiction/CMakeLists.txt
+++ b/bindings/mnt/pyfiction/CMakeLists.txt
@@ -55,6 +55,34 @@ target_include_directories(pyfiction
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_property(TARGET pyfiction PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+# Keep the embedded static libraries' symbols local. `fiction_options` adds
+# `-fvisibility=hidden` to everything that links `libfiction`, and nanobind adds
+# `CXX_VISIBILITY_PRESET hidden` on the module's own objects; the vendored
+# archives -- `tinyxml2`, `graph-coloring`, ALGLIB -- consume neither and keep
+# default visibility, so the extension re-exports them. Ported from
+# marcelwa/aigverse#490.
+if(APPLE)
+  target_link_options(pyfiction PRIVATE
+                      "LINKER:-exported_symbol,_PyInit_pyfiction")
+elseif(UNIX)
+  target_link_options(pyfiction PRIVATE "LINKER:--exclude-libs,ALL")
+
+  # `--gc-sections` has little to collect without these: nanobind's own size
+  # tuning stops at `-Os`, and neither the bindings nor the vendored archives
+  # emit per-function sections. A linked build inherited both from
+  # `nanobind-static`; split mode links no nanobind target.
+  target_compile_options(
+    pyfiction
+    PRIVATE
+      "$<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>:-ffunction-sections;-fdata-sections>"
+  )
+  target_link_options(
+    pyfiction
+    PRIVATE
+    "$<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>:LINKER:--gc-sections>"
+  )
+endif()
+
 # Collect pyfiction headers under bindings/mnt/pyfiction/
 file(
   GLOB_RECURSE FICTION_PYFICTION_HEADERS CONFIGURE_DEPENDS

--- a/bindings/mnt/pyfiction/CMakeLists.txt
+++ b/bindings/mnt/pyfiction/CMakeLists.txt
@@ -67,10 +67,11 @@ if(APPLE)
 elseif(UNIX)
   target_link_options(pyfiction PRIVATE "LINKER:--exclude-libs,ALL")
 
-  # `--gc-sections` has little to collect without these: nanobind's own size
-  # tuning stops at `-Os`, and neither the bindings nor the vendored archives
-  # emit per-function sections. A linked build inherited both from
-  # `nanobind-static`; split mode links no nanobind target.
+  # `--gc-sections` collects nothing that was not compiled per-function and
+  # per-data, and nanobind's own size tuning stops at `-Os`. These cover the
+  # bindings; `vendors/CMakeLists.txt` covers the static archives, which is
+  # where most of the collectable code turns out to be. A linked build inherited
+  # both flags from `nanobind-static`; split mode links no nanobind target.
   target_compile_options(
     pyfiction
     PRIVATE

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -214,7 +214,9 @@ Changed
       which ``pip`` installs along with it
     - The ``pyfiction`` extension no longer re-exports the internals of the static libraries it
       embeds. ``tinyxml2``, ``graph-coloring``, and ALGLIB are built with default visibility, so
-      the dynamic linker was free to interpose them
+      the dynamic linker was free to interpose all 4539 of their symbols. The extension also
+      collects unreferenced sections again, which it stopped doing when it dropped its nanobind
+      link, and now ships 9.1 MB instead of 12.0 MB
 
 Removed
 #######

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -212,6 +212,9 @@ Changed
     - Adopted nanobind's split mode, so one ``abi3`` wheel per platform now covers Python 3.10 and
       up instead of four. ``mnt.pyfiction`` gains ``nanobind-backend`` as a runtime dependency,
       which ``pip`` installs along with it
+    - The ``pyfiction`` extension no longer re-exports the internals of the static libraries it
+      embeds. ``tinyxml2``, ``graph-coloring``, and ALGLIB are built with default visibility, so
+      the dynamic linker was free to interpose them
 
 Removed
 #######

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -13,12 +13,6 @@ target_compile_features(libfiction INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 target_link_libraries(libfiction INTERFACE fiction::fiction_options
                                            fiction::fiction_warnings)
 
-set_target_properties(
-  libfiction
-  PROPERTIES VERSION ${PROJECT_VERSION}
-             CXX_VISIBILITY_PRESET hidden
-             VISIBILITY_INLINES_HIDDEN YES)
-
 # Set UTF-8 encoding for MSVC
 if(MSVC)
   target_compile_options(libfiction INTERFACE /utf-8 /Zm10)

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -5,6 +5,14 @@ set(CMAKE_DISABLE_FIND_PACKAGE_fmt TRUE)
 # Include Dependencies (FetchContent) configuration
 include(${PROJECT_SOURCE_DIR}/cmake/Dependencies.cmake)
 
+# The static archives below are compiled per-function and per-data so that `--gc-sections` has
+# something to discard. Only the archives need this: they are separate targets that consume
+# neither `fiction_options` nor anything the consuming target sets, and they are where the
+# unreferenced code is. Dropping it costs `pyfiction` 2.4 MB of the 9.1 MB it ships.
+set(FICTION_SECTION_FLAGS
+    "$<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>,$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>>:-ffunction-sections;-fdata-sections>"
+)
+
 ################################################################################
 # Fetched Dependencies (Managed via FetchContent in Dependencies.cmake)
 ################################################################################
@@ -38,6 +46,7 @@ install(DIRECTORY ${parallel-hashmap_SOURCE_DIR}/parallel_hashmap DESTINATION in
 
 # tinyxml2
 set_property(TARGET tinyxml2 PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_options(tinyxml2 PRIVATE "${FICTION_SECTION_FLAGS}")
 target_link_system_libraries(libfiction INTERFACE
     $<BUILD_INTERFACE:tinyxml2::tinyxml2>
     $<INSTALL_INTERFACE:fiction::tinyxml2>
@@ -55,6 +64,7 @@ if (FICTION_ALGLIB)
         $<BUILD_INTERFACE:ALGLIB>
         $<INSTALL_INTERFACE:fiction::alglib>
     )
+    target_compile_options(ALGLIB PRIVATE "${FICTION_SECTION_FLAGS}")
     install(DIRECTORY ${alglib-cmake_SOURCE_DIR}/src/cpp/src/headers/ DESTINATION include/alglib)
 endif ()
 
@@ -83,6 +93,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/combinations/ DESTINATION include/
 
 # Graph Coloring
 add_subdirectory(graph-coloring EXCLUDE_FROM_ALL)
+target_compile_options(graph-coloring PRIVATE "${FICTION_SECTION_FLAGS}")
 target_include_directories(libfiction SYSTEM INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/graph-coloring/Header>
 )


### PR DESCRIPTION
## Description

`pyfiction` exports the internals of every static archive it embeds. Measured on a local Release
build (Linux x86-64, GCC, LTO, `FICTION_ALGLIB=ON` as the wheels set it), the extension exports
**4790 dynamic symbols**, of which exactly one -- `PyInit_pyfiction` -- is intentional:

| | before | after |
|---|---|---|
| exported dynamic symbols | **4790** | **251** |
| `alglib::`/`alglib_impl::` | 4486 | 0 |
| `GraphColoring::` | 51 | 0 |
| `PyInit_pyfiction` | 1 | 1 |
| `.so` size | 11,996,624 B | **9,070,968 B** (**-24.4%**) |

The 251 that remain are libstdc++ template instantiations -- `std::ranges::*`,
`std::any::_Manager_*`, `std::__detail::*` -- which `--exclude-libs` correctly leaves alone
because they come from the extension's own objects, not from an archive. All of the archive
symbols are gone. `tinyxml2` did not appear in either build of this configuration.

Every one of the 4790 was exported `GLOBAL`, so the dynamic linker was free to interpose them
against anything else in the process.

`-fvisibility=hidden` does not cover this. It rides on `fiction_options`, which only the
extension's own 101 translation units link, and nanobind's `CXX_VISIBILITY_PRESET hidden`
likewise covers only the module's own objects. `tinyxml2`, `graph-coloring`, and ALGLIB are
separate targets in their own directories that consume neither, so their archive members keep
default visibility and land in `.dynsym`. Nothing in the pipeline catches it either:
`abi3audit --strict` checks only that no non-limited-API CPython symbols are *imported*.

**This is not a split-mode regression.** nanobind has never hidden the archives it links, in
any mode, so #1160 did not introduce it. The one option split mode genuinely dropped is the
section pair: a linked build inherited `-ffunction-sections`/`-fdata-sections` and
`--gc-sections` from `nanobind-static` as `PUBLIC` options, and
`nanobind_add_module(... BACKEND_MODULE ...)` skips `target_link_libraries` entirely, so the
extension links no nanobind target to inherit them from. Both halves are re-added here, since
`--gc-sections` has little to collect without the sections and nanobind's own size tuning stops
at `-Os`.

Ported from [marcelwa/aigverse#490](https://github.com/marcelwa/aigverse/pull/490), which in
turn follows [munich-quantum-toolkit/scpd#96](https://github.com/munich-quantum-toolkit/scpd/pull/96)
and MQT Core's `cmake/AddMQTPythonBinding.cmake`.

### Deliberate divergences from those sources

- **No Windows branch.** MQT Core and scpd set `WINDOWS_EXPORT_ALL_SYMBOLS OFF` per module, but
  they first set it `ON` project-wide in `StandardProjectSettings.cmake`. This project never
  sets it and CMake defaults it to `OFF` — the same reason aigverse deleted its Windows branch
  in a follow-up commit.
- **The section flags are included**, unlike MQT Core and scpd. Their omission is defensible
  there because LLVM and MLIR already build their archives with per-function sections, so
  `--gc-sections` alone still halved their MLIR extension. Nothing _fiction_ links does that.
- **No Intel-macOS RTTI guard.** Both MQT projects added `-exported_symbol` entries for
  `nanobind::abi1::python_error`/`builtin_exception` typeinfo and then removed them once x86
  macOS was dropped; aigverse never shipped one. In split mode those types have their key
  functions in the backend shared library, so the extension imports that typeinfo instead of
  carrying a copy of its own, and the guard is unnecessary regardless of architecture.
- **The module name is hardcoded** rather than routed through a helper function. `pyfiction`
  is a single extension; the sibling projects have helpers because they build five and one
  respectively through a shared macro. `AGENTS.md` asks for no abstraction until a second
  caller needs one.

### Third commit

The section flags started out `PRIVATE` to `pyfiction`, which covered its own 101 translation
units and nothing else. CodeRabbit pointed out that the archives therefore still had one
`.text` apiece, leaving `--gc-sections` able to discard them only whole. That turned out to be
where nearly all the collectable code was:

| | `.so` size |
|---|---|
| no link options | 11,996,624 B |
| + `--exclude-libs,ALL` + `--gc-sections` | 11,537,160 B |
| + section flags on the three archives | **9,070,968 B** |

A further **2,466,192 bytes, 21.4%**, almost all of it ALGLIB. Exported symbols are unchanged
at 251 across the last two rows -- `--exclude-libs` decides what is visible, `--gc-sections`
what is present. The flags go on the three archive-producing targets rather than on a shared
interface, because `libfiction` is an `INTERFACE` target they do not consume, which is the
reason the gap existed in the first place.

### Second commit

`include/CMakeLists.txt` set `VERSION`, `CXX_VISIBILITY_PRESET`, and `VISIBILITY_INLINES_HIDDEN`
on `libfiction`, which is an `INTERFACE` library. None of the three is an `INTERFACE_*`
property, so CMake stores them and never reads them back, and nothing in the project queries
them. The visibility they appear to set is really supplied by `fiction_options`. Kept as a
separate commit so it can be dropped without touching the first.

## Verification

- `cmake --preset pyfiction -DCMAKE_BUILD_TYPE=Release` configures cleanly in split mode
  (`nanobind: split-mode extensions require 'nanobind-backend>=1.0' at runtime`), and the
  generated `build.ninja` confirms the flags reach the target: `-ffunction-sections`,
  `-fdata-sections` on the compile line; `-Wl,--exclude-libs,ALL` and `-Wl,--gc-sections` on
  the link line, alongside nanobind's own `-Os`, `-Wl,-s`, `-flto`, and `Py_LIMITED_API`.
  `-exported_symbol` is correctly absent on Linux.
- `prek run --all-files` clean.
- The figures come from Release builds sharing one object set wherever the flags allow, so each
  row isolates one change. The link-option row is one build and two links with a byte-identical
  compile line.
- **331 tests pass** against the stripped extension (`pytest bindings/mnt/pyfiction/test`), and
  `PyInit_pyfiction` is the only non-libstdc++ export that remains.
- `🐍 Packaging (ubuntu-24.04)` is green, so the Linux wheel builds and passes its suite with
  the new flags.
- macOS and Windows are only checkable in CI: the 🐍 Packaging wheel jobs on `macos-15` and
  `windows-2025` are what exercise `-exported_symbol` and the absence of a Windows branch.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

---

Drafted with AI assistance; the configure-level verification above was reproduced locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Python bindings now keep embedded library internals private, reducing unintended symbol exposure and improving compatibility with other software.
  * Release builds remove unused native code where supported, reducing the extension size from 12.0 MB to 9.1 MB.

* **Documentation**
  * Updated the unreleased changelog with details about symbol visibility, linker behavior, and the reduced Python extension size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->