### PR TITLE
🔧 Share editor whitespace settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{c,cpp,h,hpp,py,pyi}]
+indent_size = 4
+max_line_length = 120
+
+[{CMakeLists.txt,*.cmake,CMakeLists.txt.in,*.cmake.in}]
+max_line_length = 80
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   - Exposed `write_location_and_ground_state`, whose binding existed but was never registered
 
+- Tooling:
+
+  - Added EditorConfig settings that match the repository's formatters.
+
 ### Changed
 
 - Documentation:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -44,6 +44,7 @@ Nevertheless, please try to follow the guidelines below as well as you can to he
 - Document your code thoroughly and write readable code.
 - Keep your code clean. Remove any debug statements, left-over comments, or code unrelated to your contribution.
 - Follow the style and conventions used throughout the project.
+- Enable EditorConfig support in your editor to apply the repository's indentation, line endings, and final-newline settings. The formatter hooks check the full style.
 - Run `clang-format` and `clang-tidy` to check your code for style and linting errors before committing.
 - We recommend installing [prek](https://prek.j178.dev/) and running `prek install` once so that formatting and linting checks run automatically before every commit.
 


### PR DESCRIPTION
## Description

Editors now share whitespace settings that match the existing formatters, including four-space C++ and Python indentation and LF line endings. This addresses the EditorConfig finding in #1118; the remaining repository-standards work stays open.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Implemented with AI assistance. Codex checked effective settings with the existing Prettier parser and ran `prek run -a`; no human validation is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for enabling EditorConfig support in editors.
  * Documented the new formatting standards in the unreleased changelog.

* **Tooling**
  * Added shared editor settings for consistent indentation, line endings, character encoding, whitespace handling, and line-length limits across supported file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
