### PR TITLE
🔧 Delay fresh Renovate dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -118,10 +118,20 @@
     enabled: true,
     automerge: true
   },
+  minimumReleaseAge: "3 days",
   schedule: [
     "every weekend"
   ],
   packageRules: [
+    {
+      // These datasources provide no release timestamps, so requiring one
+      // would prevent their updates indefinitely.
+      matchDatasources: [
+        "git-refs",
+        "github-runners"
+      ],
+      minimumReleaseAgeBehaviour: "timestamp-optional"
+    },
     {
       matchManagers: [
         "github-actions"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Continuous integration:
+  - Renovate now waits three days for dated dependency releases before updating.
+
 - Documentation:
   - Migrated the documentation to MyST Markdown and the Furo theme with light and dark modes.
   - Documentation now displays the installed package version.


### PR DESCRIPTION
## Description

Renovate waits three days before suggesting dependency releases with timestamps. Git refs and GitHub runner updates remain eligible because their datasources provide no timestamps; the existing schedule and automerge rules still apply. This addresses the release-age item in #1123.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Implemented with AI assistance. Codex checked Renovate's documented timestamp and automerge behavior, ran the existing Renovate schema validator, and ran all repository hooks locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Automated dependency updates for releases with available timestamps now wait three days before being proposed.
  - Updates without release timestamps continue to be handled without requiring a release age.
  - PyPI releases now use trusted publishing instead of an API token.

- **Documentation**
  - Updated the Unreleased changelog with the dependency update timing and PyPI publishing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->