### PR TITLE
🐛 Make formatting hooks stable on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 benchmarks/* linguist-vendored
 benchmarks/TOY/* linguist-vendored
 benchmarks/ISCAS89/* linguist-vendored

--- a/.license-tools-config.json
+++ b/.license-tools-config.json
@@ -6,6 +6,7 @@
   "force_author": true,
   "force_license": true,
   "license": "MIT",
+  "lines_after_license": "ignore",
   "title": false,
   "style_override_for_suffix": {
     ".pyi": "DOCSTRING_STYLE"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,10 @@ exclude: "^vendors/|^benchmarks/|bindings/mnt/pyfiction/include/pyfiction/pybind
 # than 9 so that `ruff-check` at 8 lints the header in the same pass. Its `types_or` is what
 # makes it disjoint from `nb-clean`, which also sits at 7 and takes `types: [text]`, so both
 # would otherwise receive the same notebooks.
+#
+# Every formatter uses LF. `mixed-line-ending` enforces that policy before the language
+# formatters run. `license-tools` ignores whitespace-only differences because it otherwise
+# rewrites a license-only file with the host newline and changes LF back to CRLF on Windows.
 
 repos:
   # Standard hooks
@@ -70,6 +74,7 @@ repos:
       - id: end-of-file-fixer
         priority: 1
       - id: mixed-line-ending
+        args: ["--fix=lf"]
         priority: 2
       - id: trailing-whitespace
         priority: 3

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -176,6 +176,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `write_sqd_sim_result` accepts the `sidb_simulation_result_100` and `_111` results
     Python produces; it was bound for a result type Python cannot construct
 
+- Tooling:
+
+  - Git checkouts and formatting hooks enforce LF without rewriting license-only files to
+    CRLF on Windows.
+
 ## v0.8.0 - 2026-09-02
 
 :::{epigraph}


### PR DESCRIPTION
## Description

Windows checkouts could leave the formatting hooks alternating between LF and CRLF. This PR makes Git and `mixed-line-ending` enforce LF and lets `license-tools` ignore whitespace-only differences so license-only files preserve LF. The targeted reproduction and a fresh worktree's first full hook pass succeed on Windows.

Fixes #1187

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Drafted with AI assistance; no human review has been recorded yet.