### PR TITLE
♻️ Consume mockturtle CMake components and package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project (https://github.com/lefticus/cpp_starter_project) and CMake Template
 # (https://github.com/cpp-best-practices/cmake_template)
 
-cmake_minimum_required(VERSION 3.23...4.4)
+cmake_minimum_required(VERSION 3.25...4.4)
 
 # Only set the CMAKE_CXX_STANDARD if it is not set by someone else
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 4,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 23,
+    "minor": 25,
     "patch": 0
   },
   "configurePresets": [
@@ -83,7 +83,7 @@
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "MOCKTURTLE_EXAMPLES": "OFF",
+        "MOCKTURTLE_BUILD_EXAMPLES": "OFF",
         "FICTION_PROGRESS_BARS": "OFF",
         "FICTION_CLI": "OFF",
         "FICTION_TEST": "OFF",
@@ -118,7 +118,7 @@
         "FICTION_ALGLIB": "ON",
         "FICTION_PROGRESS_BARS": "ON",
         "FICTION_WARNINGS_AS_ERRORS": "OFF",
-        "MOCKTURTLE_EXAMPLES": "OFF"
+        "MOCKTURTLE_BUILD_EXAMPLES": "OFF"
       }
     },
     {
@@ -150,7 +150,7 @@
         "FICTION_ALGLIB": "ON",
         "FICTION_PROGRESS_BARS": "OFF",
         "FICTION_WARNINGS_AS_ERRORS": "OFF",
-        "MOCKTURTLE_EXAMPLES": "OFF",
+        "MOCKTURTLE_BUILD_EXAMPLES": "OFF",
         "FICTION_ENABLE_PCH": "ON"
       }
     },
@@ -199,7 +199,7 @@
         "FICTION_Z3": "ON",
         "FICTION_ALGLIB": "ON",
         "FICTION_PYTHON_BINDINGS": "ON",
-        "MOCKTURTLE_EXAMPLES": "OFF"
+        "MOCKTURTLE_BUILD_EXAMPLES": "OFF"
       }
     }
   ],

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -159,7 +159,7 @@ set(MOCKTURTLE_INSTALL ON)
 FetchContent_Declare(
   mockturtle
   GIT_REPOSITORY https://github.com/marcelwa/mockturtle.git
-  GIT_TAG 59e5b71f6d346ec04116478f045143abbedb32d8 # Head of the mnt branch
+  GIT_TAG 5d62f61b75e0ed28f8fb867a22ff1732f0e983b5 # Head of the mnt branch
 )
 FetchContent_MakeAvailable(mockturtle)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -159,7 +159,7 @@ set(MOCKTURTLE_INSTALL ON)
 FetchContent_Declare(
   mockturtle
   GIT_REPOSITORY https://github.com/marcelwa/mockturtle.git
-  GIT_TAG d99744f6803802e750014471e3a1db1bdfe74aca # Head of the mnt branch
+  GIT_TAG dcd9791644734897d0ac3ca07cf3a3d7762b1a76 # Head of the mnt branch
 )
 FetchContent_MakeAvailable(mockturtle)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -159,7 +159,7 @@ set(MOCKTURTLE_INSTALL ON)
 FetchContent_Declare(
   mockturtle
   GIT_REPOSITORY https://github.com/marcelwa/mockturtle.git
-  GIT_TAG 5d62f61b75e0ed28f8fb867a22ff1732f0e983b5 # Head of the mnt branch
+  GIT_TAG d99744f6803802e750014471e3a1db1bdfe74aca # Head of the mnt branch
 )
 FetchContent_MakeAvailable(mockturtle)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -146,15 +146,16 @@ FetchContent_MakeAvailable(alice)
 # submodule directories empty, so a tarball build fails on `#include
 # <parallel_hashmap/phmap.h>`. Do not convert this to a `URL` without first
 # arranging for that header to resolve.
-set(MOCKTURTLE_EXAMPLES
+set(MOCKTURTLE_BUILD_EXAMPLES
     OFF
     CACHE BOOL "" FORCE)
-set(MOCKTURTLE_EXPERIMENTS
+set(MOCKTURTLE_BUILD_EXPERIMENTS
     OFF
     CACHE BOOL "" FORCE)
-set(MOCKTURTLE_TEST
+set(MOCKTURTLE_BUILD_TESTS
     OFF
     CACHE BOOL "" FORCE)
+set(MOCKTURTLE_INSTALL ON)
 FetchContent_Declare(
   mockturtle
   GIT_REPOSITORY https://github.com/marcelwa/mockturtle.git

--- a/cmake/fictionConfig.cmake.in
+++ b/cmake/fictionConfig.cmake.in
@@ -1,3 +1,6 @@
+include(CMakeFindDependencyMacro)
+find_dependency(mockturtle CONFIG)
+
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/fictionTargets.cmake")
@@ -15,7 +18,6 @@ endmacro()
 
 # Define dependencies
 fiction_define_imported_target(fiction::alice "")
-fiction_define_imported_target(fiction::mockturtle "")
 fiction_define_imported_target(fiction::nlohmann_json "")
 fiction_define_imported_target(fiction::graph-coloring "graph-coloring")
 fiction_define_imported_target(fiction::undirected_graph "undirected_graph")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -88,6 +88,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `fiction::physical_design`. `surface_analysis` takes the surface as a `sidb::layout`, and `exact` has no
     SiDB header dependency
 
+- Build system:
+  - Require CMake 3.25 and link the SAT component of `mockturtle`. Installed packages resolve
+    `mockturtle` through its CMake package, including its compiled dependencies.
+
 - CLI:
   - **Breaking:** SiDB commands use `sidb::layout` and simulation results. `read --sqd` reads the lattice
     from the file; `--lattice_orientation` is removed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -90,7 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Build system:
   - Require CMake 3.25 and link the SAT component of `mockturtle`. Installed packages resolve
-    `mockturtle` through its CMake package, including its compiled dependencies.
+    `mockturtle` through its CMake package, including its compiled dependencies ([#1204](https://github.com/cda-tum/fiction/pull/1204)).
 
 - CLI:
   - **Breaking:** SiDB commands use `sidb::layout` and simulation results. `read --sqd` reads the lattice

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -77,7 +77,7 @@ them automatically. Should the repository have been cloned before, the commands:
 git submodule update --init --recursive
 ```
 
-will fetch the latest version of all external modules used. Additionally, only `CMake` and a C++20 compiler are
+will fetch the latest version of all external modules used. Additionally, only CMake 3.25 or newer and a C++20 compiler are
 required for the C++ part. If you want to work with the Python bindings, you need a Python 3.10+ installation.
 
 At the time of writing, for parallel STL algorithms to work when using GCC, the TBB library (`libtbb-dev` on Ubuntu) is
@@ -171,6 +171,18 @@ By default _fiction_'s CLI is enabled and will be built, which can be time-consu
 disable it by passing `-DFICTION_CLI=OFF` to your `cmake` call or adding
 `set(FICTION_CLI OFF CACHE BOOL "" FORCE)` **before** `add_subdirectory(fiction/)`.
 :::
+
+An installed _fiction_ package provides `fiction::libfiction`:
+
+```cmake
+find_package(fiction CONFIG REQUIRED)
+target_link_libraries(fanfiction PRIVATE fiction::libfiction)
+```
+
+The package resolves `mockturtle::sat` through `find_package(mockturtle CONFIG)`.
+_fiction_ installs the `mockturtle` package alongside its own headers; this builds both
+SAT and ESOP archives even though _fiction_ links only SAT. Add the installation prefix
+to `CMAKE_PREFIX_PATH` when it is outside CMake's default search paths.
 
 Then include what you need:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ sdist.exclude = [
 ]
 
 [tool.scikit-build.cmake.define]
-MOCKTURTLE_EXAMPLES = "OFF"
+MOCKTURTLE_BUILD_EXAMPLES = "OFF"
 FICTION_PROGRESS_BARS = "OFF"
 FICTION_CLI = "OFF"
 FICTION_TEST = "OFF"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,9 +48,8 @@ foreach(FILE IN LISTS FILENAMES)
     # replacement.
     target_link_libraries(${TEST_NAME} PRIVATE fiction::fiction_options
                                                fiction::fiction_warnings fmt)
-    target_include_directories(
-      ${TEST_NAME}
-      PRIVATE $<TARGET_PROPERTY:libfiction,INTERFACE_INCLUDE_DIRECTORIES>)
+    target_include_directories(${TEST_NAME}
+                               PRIVATE ${PROJECT_SOURCE_DIR}/include)
     target_compile_options(
       ${TEST_NAME}
       PRIVATE $<TARGET_PROPERTY:libfiction,INTERFACE_COMPILE_OPTIONS>)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,8 +48,9 @@ foreach(FILE IN LISTS FILENAMES)
     # replacement.
     target_link_libraries(${TEST_NAME} PRIVATE fiction::fiction_options
                                                fiction::fiction_warnings fmt)
-    target_include_directories(${TEST_NAME}
-                               PRIVATE ${PROJECT_SOURCE_DIR}/include)
+    target_include_directories(
+      ${TEST_NAME}
+      PRIVATE $<TARGET_PROPERTY:libfiction,INTERFACE_INCLUDE_DIRECTORIES>)
     target_compile_options(
       ${TEST_NAME}
       PRIVATE $<TARGET_PROPERTY:libfiction,INTERFACE_COMPILE_OPTIONS>)

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -25,11 +25,7 @@ target_link_system_libraries(libfiction INTERFACE
 install(DIRECTORY ${alice_SOURCE_DIR}/include/ DESTINATION include)
 
 # mockturtle
-target_link_system_libraries(libfiction INTERFACE
-    $<BUILD_INTERFACE:mockturtle>
-    $<INSTALL_INTERFACE:fiction::mockturtle>
-)
-install(DIRECTORY ${mockturtle_SOURCE_DIR}/include/ DESTINATION include)
+target_link_libraries(libfiction INTERFACE mockturtle::sat)
 
 # nlohmann_json
 target_link_system_libraries(libfiction INTERFACE

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -37,6 +37,7 @@ install(DIRECTORY ${nlohmann_json_SOURCE_DIR}/include/ DESTINATION include)
 # parallel-hashmap
 target_include_directories(libfiction SYSTEM INTERFACE
     $<BUILD_INTERFACE:${parallel-hashmap_SOURCE_DIR}/parallel_hashmap>
+    $<INSTALL_INTERFACE:include/parallel_hashmap>
 )
 install(DIRECTORY ${parallel-hashmap_SOURCE_DIR}/parallel_hashmap DESTINATION include)
 


### PR DESCRIPTION
## Description

The `mockturtle` component package requires an explicit SAT link and a real installed dependency lookup. This migrates both build paths, installs the complete `mockturtle` package, and requires CMake 3.25; it depends on https://github.com/marcelwa/mockturtle/pull/16, with the aigverse companion at https://github.com/marcelwa/aigverse/pull/500.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Implemented with AI assistance; Codex ran the local lint, CMake integration, and C++ checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build System**
  * Updated the minimum required CMake version to 3.25.
  * Improved integration with the mockturtle package, including SAT support and installed-package resolution.
  * Updated build configuration names for controlling examples, experiments, and tests.

* **Documentation**
  * Added guidance for installing and using the C++ library with CMake.
  * Documented package discovery requirements, including `CMAKE_PREFIX_PATH` for custom installation locations.
  * Updated the unreleased changelog with the build-system changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->