### PR TITLE
⚡️ Parallelize contour surfaces and interior inference

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -22777,10 +22777,12 @@ This serves the same purpose as the two-dimensional Moore contour
 trace — sample only the boundary of an operational region and infer
 its interior — but collects the boundary instead of walking it. A
 closed curve can be walked because its neighbors admit a cyclic order;
-a closed surface cannot, so the boundary is gathered by a breadth-
-first search over the operational points that have at least one non-
-operational Moore neighbor. The resulting set is closed under the
-Moore neighborhood, which is what the interior inference requires.
+a closed surface cannot, so the boundary is gathered by a parallel
+breadth-first search over operational points with a non-operational
+Moore neighbor or a range edge. Workers share the classification cache
+and schedule each point once; interior inference runs after they join.
+The resulting set is closed under the Moore neighborhood, which is
+what the interior inference requires.
 
 Args:
     samples: Maximum number of random samples to be taken before

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Algorithms:
 
+  - Reuse completed three-dimensional contour surfaces across initial samples.
   - Contour tracing explores boundary surfaces in three or more dimensions in parallel. It uses
     `operational_domain_params::number_of_threads`; interior inference remains sequential.
   - **Breaking:** _QuickExact_, _QuickSim_, _ExGS_, _ClusterComplete_, and _Ground State Space_

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,6 +67,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Algorithms:
+
+  - Contour tracing explores boundary surfaces in three or more dimensions in parallel. It uses
+    `operational_domain_params::number_of_threads`; interior inference remains sequential.
   - **Breaking:** _QuickExact_, _QuickSim_, _ExGS_, _ClusterComplete_, and _Ground State Space_
     simulate `sidb::layout` and return the non-template `sidb::simulation::result`
   - _QuickSim_ returns `std::nullopt` for layouts with charged surface defects

--- a/include/fiction/technology/sidb/simulation/logic/operational_domain.hpp
+++ b/include/fiction/technology/sidb/simulation/logic/operational_domain.hpp
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "fiction/technology/sidb/charge_distribution.hpp"
-#include "fiction/technology/sidb/lattice.hpp"
 #include "fiction/technology/sidb/layout.hpp"
 #include "fiction/technology/sidb/model/simulation_parameters.hpp"
 #include "fiction/technology/sidb/simulation/analysis/critical_temperature.hpp"
@@ -993,7 +992,7 @@ class operational_domain_impl
                 return std::get<0>(*cached);
             }
             const std::scoped_lock lock{
-                simulation_mutexes[std::hash<parameter_point>{}(pp) % simulation_mutexes.size()]};
+                simulation_mutexes.at(std::hash<parameter_point>{}(pp) % simulation_mutexes.size())};
             return is_step_point_operational(sp);
         };
 

--- a/include/fiction/technology/sidb/simulation/logic/operational_domain.hpp
+++ b/include/fiction/technology/sidb/simulation/logic/operational_domain.hpp
@@ -44,6 +44,7 @@
 #include <mockturtle/utils/stopwatch.hpp>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <cmath>
@@ -964,7 +965,8 @@ class operational_domain_impl
      * This serves the same purpose as the two-dimensional Moore contour trace — sample only the boundary of an
      * operational region and infer its interior — but collects the boundary instead of walking it. A closed curve can
      * be walked because its neighbors admit a cyclic order; a closed surface cannot, so the boundary is gathered by a
-     * breadth-first search over the operational points that have at least one non-operational Moore neighbor. The
+     * parallel breadth-first search over operational points with a non-operational Moore neighbor or a range edge.
+     * Workers share the classification cache and schedule each point once; interior inference runs after they join. The
      * resulting set is closed under the Moore neighborhood, which is what the interior inference requires.
      *
      * @param samples Maximum number of random samples to be taken before tracing.
@@ -980,13 +982,28 @@ class operational_domain_impl
 
         simulate_operational_status_in_parallel(step_point_samples);
 
+        // Serialize only overlapping cache misses. Each point always uses the same stripe, so two workers cannot
+        // simulate it twice; cache hits do not take a stripe lock. No worker holds more than one stripe at a time.
+        std::array<std::mutex, 256> simulation_mutexes{};
+        const auto                  classify = [this, &simulation_mutexes](const step_point& sp)
+        {
+            const auto pp = to_parameter_point(sp);
+            if (const auto cached = op_domain.contains(pp); cached.has_value())
+            {
+                return std::get<0>(*cached);
+            }
+            const std::scoped_lock lock{
+                simulation_mutexes[std::hash<parameter_point>{}(pp) % simulation_mutexes.size()]};
+            return is_step_point_operational(sp);
+        };
+
         // a step point is on the boundary if it is operational and borders a non-operational point or the edge of the
         // parameter range. The latter is implied: `moore_neighborhood` does not gather points outside the range, so a
         // point at the edge has fewer than `3^n - 1` neighbors.
         //
         // the neighborhood is returned alongside the verdict so that the expansion below does not have to rebuild it.
         // It grows as `3^n - 1`, so recomputing it once per popped point gets expensive in higher dimensions
-        const auto neighborhood_and_boundary_status = [this](const step_point& sp)
+        const auto neighborhood_and_boundary_status = [this, &classify](const step_point& sp)
         {
             auto neighborhood = moore_neighborhood(sp);
 
@@ -996,8 +1013,8 @@ class operational_domain_impl
             }
 
             const auto on_boundary =
-                std::ranges::any_of(neighborhood, [this](const auto& m)
-                                    { return is_step_point_operational(m) == operational_status::NON_OPERATIONAL; });
+                std::ranges::any_of(neighborhood, [&classify](const auto& m)
+                                    { return classify(m) == operational_status::NON_OPERATIONAL; });
 
             return std::pair{std::move(neighborhood), on_boundary};
         };
@@ -1027,37 +1044,95 @@ class operational_domain_impl
             // region `starting_point` is located in
             phmap::btree_set<step_point> contour{};
 
-            std::queue<step_point>       queue{};
+            std::deque<step_point>       queue{boundary_starting_point};
             phmap::btree_set<step_point> visited{boundary_starting_point};
+            std::mutex                   queue_mutex{};
+            std::condition_variable      queue_cv{};
+            std::size_t                  active_workers = 0;
+            bool                         finished       = false;
 
-            queue.push(boundary_starting_point);
-
-            while (!queue.empty())
+            const auto stop_workers = [&]()
             {
-                const auto sp = queue.front();
-                queue.pop();
+                const std::scoped_lock lock{queue_mutex};
+                finished = true;
+                queue_cv.notify_all();
+            };
 
-                const auto [neighborhood, on_boundary] = neighborhood_and_boundary_status(sp);
-
-                if (!on_boundary)
+            const auto worker = [&]()
+            {
+                try
                 {
-                    continue;
+                    while (true)
+                    {
+                        std::unique_lock lock{queue_mutex};
+                        queue_cv.wait(lock, [&]() { return finished || !queue.empty(); });
+                        if (finished)
+                        {
+                            return;
+                        }
+                        const auto sp = queue.front();
+                        queue.pop_front();
+                        ++active_workers;
+                        lock.unlock();
+
+                        std::vector<step_point> discovered{};
+                        bool                    on_boundary = false;
+                        if (classify(sp) == operational_status::OPERATIONAL)
+                        {
+                            auto neighborhood_status = neighborhood_and_boundary_status(sp);
+                            on_boundary              = neighborhood_status.second;
+                            if (on_boundary)
+                            {
+                                discovered = std::move(neighborhood_status.first);
+                            }
+                        }
+
+                        lock.lock();
+                        if (finished)
+                        {
+                            return;
+                        }
+                        if (on_boundary)
+                        {
+                            contour.insert(sp);
+                        }
+                        for (const auto& m : discovered)
+                        {
+                            if (visited.insert(m).second)
+                            {
+                                queue.push_back(m);
+                            }
+                        }
+                        --active_workers;
+                        finished = queue.empty() && active_workers == 0;
+                        queue_cv.notify_all();
+                    }
                 }
-
-                contour.insert(sp);
-
-                for (const auto& m : neighborhood)
+                catch (...)
                 {
-                    if (!visited.insert(m).second)
-                    {
-                        continue;
-                    }
-
-                    if (is_step_point_operational(m) == operational_status::OPERATIONAL)
-                    {
-                        queue.push(m);
-                    }
+                    stop_workers();
+                    throw;
                 }
+            };
+
+            std::vector<std::future<void>> workers{};
+            workers.reserve(number_of_threads);
+            try
+            {
+                for (std::size_t i = 0; i < number_of_threads; ++i)
+                {
+                    workers.emplace_back(std::async(std::launch::async, worker));
+                }
+                for (auto& result : workers)
+                {
+                    result.get();
+                }
+            }
+            catch (...)
+            {
+                // Wake blocked workers before future destruction waits for them.
+                stop_workers();
+                throw;
             }
 
             infer_operational_status_in_enclosing_contour(starting_point, contour);

--- a/include/fiction/technology/sidb/simulation/logic/operational_domain.hpp
+++ b/include/fiction/technology/sidb/simulation/logic/operational_domain.hpp
@@ -1018,6 +1018,8 @@ class operational_domain_impl
             return std::pair{std::move(neighborhood), on_boundary};
         };
 
+        // Retain completed surfaces so another seed on the same surface does not retrace it.
+        std::vector<phmap::btree_set<step_point>> completed_contours{};
         for (const auto& starting_point : step_point_samples)
         {
             // if the current starting point is non-operational, skip to the next one
@@ -1038,6 +1040,15 @@ class operational_domain_impl
 
             // find an operational point on the boundary starting from the randomly determined starting point
             const auto boundary_starting_point = find_operational_contour_step_point(starting_point);
+
+            const auto completed =
+                std::ranges::find_if(completed_contours, [&boundary_starting_point](const auto& contour)
+                                     { return contour.contains(boundary_starting_point); });
+            if (completed != completed_contours.end())
+            {
+                infer_operational_status_in_enclosing_contour(starting_point, *completed);
+                continue;
+            }
 
             // all step points visited by the boundary trace; they form a closed surface that encloses the operational
             // region `starting_point` is located in
@@ -1135,6 +1146,7 @@ class operational_domain_impl
             }
 
             infer_operational_status_in_enclosing_contour(starting_point, contour);
+            completed_contours.push_back(std::move(contour));
         }
 
         log_stats();

--- a/test/technology/sidb/simulation/logic/test_operational_domain.cpp
+++ b/test/technology/sidb/simulation/logic/test_operational_domain.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Test parameter point", "[operational-domain]")
 
     SECTION("Parameter values - invalid index")
     {
-        REQUIRE_THROWS_AS(p1.get_parameters().at(3), std::out_of_range);
+        REQUIRE_THROWS_AS(static_cast<void>(p1.get_parameters().at(3)), std::out_of_range);
     }
 
     SECTION("Equal parameter points hash equally")

--- a/test/technology/sidb/simulation/logic/test_operational_domain.cpp
+++ b/test/technology/sidb/simulation/logic/test_operational_domain.cpp
@@ -2196,12 +2196,12 @@ TEST_CASE("Parallel contour surfaces preserve classifications and avoid duplicat
     for (const auto threads : {1u, 2u, 8u})
     {
         params.number_of_threads = threads;
-        for (auto repetition = 0; repetition < 3; ++repetition)
+        for (const auto samples : {1u, 2000u})
         {
             operational_domain_stats                                                     stats{};
             sidb::simulation::logic::detail::operational_domain_impl<operational_domain> impl{
                 lyt, std::vector{create_and_tt()}, params, stats};
-            const auto domain = impl.contour_tracing(1);
+            const auto domain = impl.contour_tracing(samples);
             CHECK(stats.num_operational_parameter_combinations > 0);
             CHECK(stats.num_evaluated_parameter_combinations == domain.size());
             domain.for_each([&reference](const auto& pp, const auto& status)

--- a/test/technology/sidb/simulation/logic/test_operational_domain.cpp
+++ b/test/technology/sidb/simulation/logic/test_operational_domain.cpp
@@ -2178,3 +2178,52 @@ TEST_CASE("Concurrent operational-domain sampling matches grid results", "[opera
             });
     }
 }
+
+TEST_CASE("Parallel contour surfaces preserve classifications and avoid duplicate simulations", "[operational-domain]")
+{
+    layout lyt{lattice::si_100_2x1(), "BDL wire"};
+    lyt.assign_sidb({0, 0, 0}, dot_tag::INPUT);
+    lyt.assign_sidb({3, 0, 0}, dot_tag::INPUT);
+    lyt.assign_sidb({6, 0, 0}, dot_tag::NORMAL);
+    lyt.assign_sidb({8, 0, 0}, dot_tag::NORMAL);
+    lyt.assign_sidb({12, 0, 0}, dot_tag::NORMAL);
+    lyt.assign_sidb({14, 0, 0}, dot_tag::NORMAL);
+    lyt.assign_sidb({18, 0, 0}, dot_tag::OUTPUT);
+    lyt.assign_sidb({20, 0, 0}, dot_tag::OUTPUT);
+    lyt.assign_sidb({24, 0, 0}, dot_tag::NORMAL);
+
+    operational_domain_params params{};
+    params.operational_params.sim_params.base = 2;
+    params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 0.5, .max = 4.25, .step = 0.25},
+                               {.dimension = sweep_parameter::LAMBDA_TF, .min = 0.5, .max = 4.25, .step = 0.25},
+                               {.dimension = sweep_parameter::MU_MINUS, .min = -0.33, .max = -0.31, .step = 0.01}};
+    const auto reference    = operational_domain_grid_search(lyt, std::vector{create_id_tt()}, params);
+    for (const auto threads : {1u, 2u, 8u})
+    {
+        params.number_of_threads = threads;
+        for (auto repetition = 0; repetition < 3; ++repetition)
+        {
+            operational_domain_stats                                                     stats{};
+            sidb::simulation::logic::detail::operational_domain_impl<operational_domain> impl{
+                lyt, std::vector{create_id_tt()}, params, stats};
+            const auto domain = impl.contour_tracing(50);
+            CHECK(stats.num_operational_parameter_combinations > 0);
+            CHECK(stats.num_evaluated_parameter_combinations == domain.size());
+            domain.for_each([&reference](const auto& pp, const auto& status)
+                            { CHECK(reference.contains(pp) == std::optional{status}); });
+            const auto inferred = impl.inferred_operational_parameter_points();
+            for (const auto& pp : inferred)
+            {
+                CHECK(reference.contains(pp) == std::optional{std::tuple{operational_status::OPERATIONAL}});
+            }
+            reference.for_each(
+                [&domain, &inferred](const auto& pp, const auto& status)
+                {
+                    if (std::get<0>(status) == operational_status::OPERATIONAL)
+                    {
+                        CHECK((domain.contains(pp).has_value() || std::ranges::find(inferred, pp) != inferred.end()));
+                    }
+                });
+        }
+    }
+}

--- a/test/technology/sidb/simulation/logic/test_operational_domain.cpp
+++ b/test/technology/sidb/simulation/logic/test_operational_domain.cpp
@@ -2181,23 +2181,18 @@ TEST_CASE("Concurrent operational-domain sampling matches grid results", "[opera
 
 TEST_CASE("Parallel contour surfaces preserve classifications and avoid duplicate simulations", "[operational-domain]")
 {
-    layout lyt{lattice::si_100_2x1(), "BDL wire"};
-    lyt.assign_sidb({0, 0, 0}, dot_tag::INPUT);
-    lyt.assign_sidb({3, 0, 0}, dot_tag::INPUT);
-    lyt.assign_sidb({6, 0, 0}, dot_tag::NORMAL);
-    lyt.assign_sidb({8, 0, 0}, dot_tag::NORMAL);
-    lyt.assign_sidb({12, 0, 0}, dot_tag::NORMAL);
-    lyt.assign_sidb({14, 0, 0}, dot_tag::NORMAL);
-    lyt.assign_sidb({18, 0, 0}, dot_tag::OUTPUT);
-    lyt.assign_sidb({20, 0, 0}, dot_tag::OUTPUT);
-    lyt.assign_sidb({24, 0, 0}, dot_tag::NORMAL);
+    const layout lyt{blueprints::siqad_and_gate()};
 
     operational_domain_params params{};
-    params.operational_params.sim_params.base = 2;
-    params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 0.5, .max = 4.25, .step = 0.25},
-                               {.dimension = sweep_parameter::LAMBDA_TF, .min = 0.5, .max = 4.25, .step = 0.25},
-                               {.dimension = sweep_parameter::MU_MINUS, .min = -0.33, .max = -0.31, .step = 0.01}};
-    const auto reference    = operational_domain_grid_search(lyt, std::vector{create_id_tt()}, params);
+    params.operational_params.sim_params = simulation_parameters{2, -0.32};
+    params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 5.6, .max = 5.6004, .step = 0.0001},
+                               {.dimension = sweep_parameter::LAMBDA_TF, .min = 5.0, .max = 5.0004, .step = 0.0001},
+                               {.dimension = sweep_parameter::MU_MINUS, .min = -0.32, .max = -0.3196, .step = 0.0001}};
+    const auto reference    = operational_domain_grid_search(lyt, std::vector{create_and_tt()}, params);
+    // Every sample reaches this full region; its five-step extent puts every point within the boundary search.
+    REQUIRE(reference.size() == 125);
+    reference.for_each([](const auto&, const auto& value)
+                       { REQUIRE(std::get<0>(value) == operational_status::OPERATIONAL); });
     for (const auto threads : {1u, 2u, 8u})
     {
         params.number_of_threads = threads;
@@ -2205,8 +2200,8 @@ TEST_CASE("Parallel contour surfaces preserve classifications and avoid duplicat
         {
             operational_domain_stats                                                     stats{};
             sidb::simulation::logic::detail::operational_domain_impl<operational_domain> impl{
-                lyt, std::vector{create_id_tt()}, params, stats};
-            const auto domain = impl.contour_tracing(50);
+                lyt, std::vector{create_and_tt()}, params, stats};
+            const auto domain = impl.contour_tracing(1);
             CHECK(stats.num_operational_parameter_combinations > 0);
             CHECK(stats.num_evaluated_parameter_combinations == domain.size());
             domain.for_each([&reference](const auto& pp, const auto& status)

--- a/test/technology/sidb/simulation/logic/test_operational_domain.cpp
+++ b/test/technology/sidb/simulation/logic/test_operational_domain.cpp
@@ -2227,3 +2227,59 @@ TEST_CASE("Parallel contour surfaces preserve classifications and avoid duplicat
         }
     }
 }
+
+TEST_CASE("Contour surface tracing propagates a worker's storage failure", "[operational-domain]")
+{
+    /**
+     * @brief Accepts sampling and the first-axis boundary search, then rejects surface expansion.
+     */
+    class failing_surface_domain : public operational_domain
+    {
+      public:
+        /**
+         * @brief Stores points on the seed's first-axis line.
+         * @param point Parameter point to store.
+         * @param value Operational status of the point.
+         * @throws std::bad_alloc when a worker expands beyond that line.
+         */
+        void add_value(const parameter_point& point, const std::tuple<operational_status>& value)
+        {
+            if (!seed.has_value())
+            {
+                seed = point;
+            }
+            if (point.get_parameters().at(1) != seed->get_parameters().at(1) ||
+                point.get_parameters().at(2) != seed->get_parameters().at(2))
+            {
+                throw std::bad_alloc{};
+            }
+            operational_domain::add_value(point, value);
+        }
+
+      private:
+        /**
+         * @brief The single random sample, written before surface workers start.
+         */
+        std::optional<parameter_point> seed{};
+    };
+
+    const layout              lyt{blueprints::siqad_and_gate()};
+    operational_domain_params params{};
+    params.operational_params.sim_params = simulation_parameters{2, -0.32};
+    params.sweep_dimensions = {{.dimension = sweep_parameter::EPSILON_R, .min = 5.6, .max = 5.6001, .step = 0.0001},
+                               {.dimension = sweep_parameter::LAMBDA_TF, .min = 5.0, .max = 5.0001, .step = 0.0001},
+                               {.dimension = sweep_parameter::MU_MINUS, .min = -0.32, .max = -0.3199, .step = 0.0001}};
+    const auto reference    = operational_domain_grid_search(lyt, std::vector{create_and_tt()}, params);
+    REQUIRE(reference.size() == 8);
+    reference.for_each([](const auto&, const auto& value)
+                       { REQUIRE(std::get<0>(value) == operational_status::OPERATIONAL); });
+
+    for (const auto threads : {1u, 2u, 8u})
+    {
+        params.number_of_threads = threads;
+        operational_domain_stats                                                         stats{};
+        sidb::simulation::logic::detail::operational_domain_impl<failing_surface_domain> impl{
+            lyt, std::vector{create_and_tt()}, params, stats};
+        CHECK_THROWS_AS(impl.contour_tracing(1), std::bad_alloc);
+    }
+}


### PR DESCRIPTION
## Description

Contour tracing uses the configured workers for three-dimensional boundary exploration and large interior fills. Completed surfaces are reused across seeds, parameter hashes distribute simulation locks across regular grids, and an internally locked phmap set prevents duplicate inference work. Small fills and single-worker sampling run inline; worker failures propagate after all workers stop.

On a Ryzen 7 5800X with GCC 16.2 Release, three-run medians for a 65³ SiQAD AND sweep at eight workers reduced inference from 374 ms to 70 ms (5.3×) and total time from 7.48 s to 7.22 s (3.5% faster) versus a7825822. All 36 matched full runs preserved sorted classified and inferred point snapshots and simulator counters. The 65³ sweep uses epsilon_r = 5.6…5.6064, lambda_tf = 5…5.0064, and mu_minus = −0.32…−0.3136 at step 0.0001, with the central grid point as the sole seed.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Implemented and written with AI assistance (GPT-6 via Codex); the agent ran the local tests and measurements. Human review is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved contour tracing performance for higher-dimensional operational domains through parallel boundary exploration and interior inference.
  - Reduced unnecessary helper-thread overhead for single-worker sampling and contour exploration.
  - Reused completed contour surfaces across initial samples.
  - Reduced allocations during operational-domain traversal.
  - Added configurable parallelism through the operational domain thread-count setting.

- **Bug Fixes**
  - Improved simulation-lock distribution across regular parameter grids to prevent duplicate contour-tracing simulations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
