### PR TITLE
🐛 Ship mockturtle's dependency headers in the installed package

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -154,7 +154,7 @@ set(MOCKTURTLE_INSTALL ON)
 FetchContent_Declare(
   mockturtle
   GIT_REPOSITORY https://github.com/marcelwa/mockturtle.git
-  GIT_TAG e8ac516305ee1e9174d7d9f401881cdbddb5fec6 # Head of the mnt branch
+  GIT_TAG 8b0d39057f6ef9f952911b2a705bff182a732597 # Head of the mnt branch
 )
 FetchContent_MakeAvailable(mockturtle)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -154,7 +154,7 @@ set(MOCKTURTLE_INSTALL ON)
 FetchContent_Declare(
   mockturtle
   GIT_REPOSITORY https://github.com/marcelwa/mockturtle.git
-  GIT_TAG 8b0d39057f6ef9f952911b2a705bff182a732597 # Head of the mnt branch
+  GIT_TAG 50d48fe526f904149f9776de116a7f8d79731ad5 # Head of the mnt branch
 )
 FetchContent_MakeAvailable(mockturtle)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -146,19 +146,15 @@ FetchContent_MakeAvailable(alice)
 # submodule directories empty, so a tarball build fails on `#include
 # <parallel_hashmap/phmap.h>`. Do not convert this to a `URL` without first
 # arranging for that header to resolve.
-set(MOCKTURTLE_EXAMPLES
-    OFF
-    CACHE BOOL "" FORCE)
-set(MOCKTURTLE_EXPERIMENTS
-    OFF
-    CACHE BOOL "" FORCE)
-set(MOCKTURTLE_TEST
-    OFF
-    CACHE BOOL "" FORCE)
+#
+# mockturtle builds neither its examples, tests nor experiments when it is not
+# the top-level project. It does not install itself either, and _fiction_ needs
+# it to: an installed `libfiction` re-exports mockturtle's headers.
+set(MOCKTURTLE_INSTALL ON)
 FetchContent_Declare(
   mockturtle
   GIT_REPOSITORY https://github.com/marcelwa/mockturtle.git
-  GIT_TAG 59e5b71f6d346ec04116478f045143abbedb32d8 # Head of the mnt branch
+  GIT_TAG e8ac516305ee1e9174d7d9f401881cdbddb5fec6 # Head of the mnt branch
 )
 FetchContent_MakeAvailable(mockturtle)
 

--- a/cmake/fictionConfig.cmake.in
+++ b/cmake/fictionConfig.cmake.in
@@ -1,5 +1,10 @@
 @PACKAGE_INIT@
 
+# mockturtle is installed into this prefix alongside _fiction_, so look there
+# first rather than asking the consumer to put the prefix on CMAKE_PREFIX_PATH.
+include(CMakeFindDependencyMacro)
+find_dependency(mockturtle CONFIG PATHS "${PACKAGE_PREFIX_DIR}")
+
 include("${CMAKE_CURRENT_LIST_DIR}/fictionTargets.cmake")
 
 # Helper macro to define imported interface library
@@ -15,7 +20,6 @@ endmacro()
 
 # Define dependencies
 fiction_define_imported_target(fiction::alice "")
-fiction_define_imported_target(fiction::mockturtle "")
 fiction_define_imported_target(fiction::nlohmann_json "")
 fiction_define_imported_target(fiction::graph-coloring "graph-coloring")
 fiction_define_imported_target(fiction::undirected_graph "undirected_graph")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -94,6 +94,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `print`, `show`, and statistics use stored ground states; `sqd` exports geometry and defects
   - SiDB shell descriptions and JSON statistics report dot counts as `dots`.
 
+- Build system:
+  - **Fixed:** an installed _fiction_ shipped mockturtle's own headers but none of the vendored
+    dependencies they include, so `find_package(fiction)` produced a package that failed on
+    `#include <kitty/...>`. mockturtle now installs itself into the same prefix and
+    `fictionConfig.cmake` resolves it from there ([#1204](https://github.com/cda-tum/fiction/pull/1204))
+  - **Fixed:** the installed `libfiction` referenced `include/parallel_hashmap` without declaring it
+
 - Continuous integration:
   - Reusable workflows now use GitHub's self-repository reference syntax.
   - Clang-Tidy skips Python-only changes in the bindings tree.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -98,7 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - **Fixed:** an installed _fiction_ shipped mockturtle's own headers but none of the vendored
     dependencies they include, so `find_package(fiction)` produced a package that failed on
     `#include <kitty/...>`. mockturtle now installs itself into the same prefix and
-    `fictionConfig.cmake` resolves it from there ([#1204](https://github.com/cda-tum/fiction/pull/1204))
+    `fictionConfig.cmake` resolves it from there ([#1206](https://github.com/cda-tum/fiction/pull/1206))
   - **Fixed:** the installed `libfiction` referenced `include/parallel_hashmap` without declaring it
 
 - Continuous integration:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -172,6 +172,16 @@ disable it by passing `-DFICTION_CLI=OFF` to your `cmake` call or adding
 `set(FICTION_CLI OFF CACHE BOOL "" FORCE)` **before** `add_subdirectory(fiction/)`.
 :::
 
+An installed _fiction_ package provides `fiction::libfiction`:
+
+```cmake
+find_package(fiction CONFIG REQUIRED)
+target_link_libraries(fanfiction PRIVATE fiction::libfiction)
+```
+
+_fiction_ installs mockturtle into the same prefix and its package configuration finds it there,
+so no extra `CMAKE_PREFIX_PATH` entry is needed for it.
+
 Then include what you need:
 
 ```c++

--- a/vendors/CMakeLists.txt
+++ b/vendors/CMakeLists.txt
@@ -25,11 +25,9 @@ target_link_system_libraries(libfiction INTERFACE
 install(DIRECTORY ${alice_SOURCE_DIR}/include/ DESTINATION include)
 
 # mockturtle
-target_link_system_libraries(libfiction INTERFACE
-    $<BUILD_INTERFACE:mockturtle>
-    $<INSTALL_INTERFACE:fiction::mockturtle>
-)
-install(DIRECTORY ${mockturtle_SOURCE_DIR}/include/ DESTINATION include)
+# Installs itself, so the same target works in both trees. Its own include
+# directories are already marked SYSTEM.
+target_link_libraries(libfiction INTERFACE mockturtle::mockturtle)
 
 # nlohmann_json
 target_link_system_libraries(libfiction INTERFACE
@@ -41,6 +39,7 @@ install(DIRECTORY ${nlohmann_json_SOURCE_DIR}/include/ DESTINATION include)
 # parallel-hashmap
 target_include_directories(libfiction SYSTEM INTERFACE
     $<BUILD_INTERFACE:${parallel-hashmap_SOURCE_DIR}/parallel_hashmap>
+    $<INSTALL_INTERFACE:include/parallel_hashmap>
 )
 install(DIRECTORY ${parallel-hashmap_SOURCE_DIR}/parallel_hashmap DESTINATION include)
 


### PR DESCRIPTION
## Description

Supersedes #1204. Depends on marcelwa/mockturtle#17; the aigverse companion is marcelwa/aigverse#501.

An installed _fiction_ copied mockturtle's own headers into the prefix but none of the vendored libraries they include, and pointed `fiction::mockturtle` at the bare include directory. Any consumer of `find_package(fiction)` therefore failed on the first _fiction_ header, which includes `<kitty/constructors.hpp>`. Nothing in CI builds against an installed _fiction_, so this went unnoticed.

mockturtle now installs itself, so it is fetched with `MOCKTURTLE_INSTALL ON` and `libfiction` links `mockturtle::mockturtle` in both trees.

Three further fixes fall out of it:

- `fictionConfig.cmake` resolves the co-installed mockturtle from `PACKAGE_PREFIX_DIR`, so a consumer does not have to add the prefix to `CMAKE_PREFIX_PATH` just to find a dependency _fiction_ shipped itself.
- The installed `libfiction` advertised `include/parallel_hashmap` without declaring it in its interface.
- The three `MOCKTURTLE_*` overrides set `MOCKTURTLE_EXAMPLES`, `MOCKTURTLE_EXPERIMENTS` and `MOCKTURTLE_TEST`, none of which mockturtle has read since it renamed them to `MOCKTURTLE_BUILD_*`. _fiction_ has been building mockturtle's five examples on every configure. mockturtle now builds none of them when it is not the top-level project, so the overrides are gone rather than renamed.

No CI changes, no preset changes, and the CMake floor stays at 3.23.

Unlike #1204 this links `mockturtle::mockturtle` rather than a `mockturtle::sat` component. #1204 set `MOCKTURTLE_INSTALL ON` too, so both archives were built regardless — its own documentation said so — which left the component split with nothing to save here.

### Verification

A/B against an installed and relocated package, using a consumer that includes _fiction_ and mockturtle headers and calls `equivalence_checking`:

- `main` today: `fatal error: kitty/constructors.hpp: No such file or directory`, on the first _fiction_ header.
- This branch: compiles, links against the SAT archive and runs, from a prefix that has been moved after installation with the build tree deleted.

### Two pre-existing issues this does not address

- `target_link_system_libraries(libfiction INTERFACE TBB::tbb)` in `vendors/CMakeLists.txt` is unguarded, so the installed interface names a target `fictionConfig.cmake` never calls `find_dependency(TBB)` for. This breaks `find_package(fiction)` on its own; the verification above ran with `-DCMAKE_DISABLE_FIND_PACKAGE_TBB=ON` to isolate the mockturtle change. Fixing it means recording the build-time TBB decision in the config template.
- alice bundles fmt 12.1.0 and mockturtle bundles 11.0.2. In the build tree alice's include directory comes first and wins, unchanged by this PR. The installed package now gets mockturtle's 11.0.2, because alice's `lib/fmt` is never installed — previously there was no fmt in the prefix at all, so this is strictly better, but the two trees now disagree on the version.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installed-package configuration so bundled dependencies are installed under the same prefix and resolved automatically.
  * Fixed the installed library to declare its required header dependency.
  * Updated the bundled mockturtle version and installation settings.

* **Documentation**
  * Added guidance for consuming an installed Fiction package with CMake, including linking and dependency discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->