### PR TITLE
✨ Add SiDB gate and circuit design timeouts

### DIFF
--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3250,7 +3250,7 @@ Returns:
 
 )doc";
 
-static const char *mkd_doc_fiction_layouts_coords_offset_operator_unsigned_long_long =
+static const char *mkd_doc_fiction_layouts_coords_offset_operator_unsigned_long =
 R"doc(Allows explicit conversion to `uint64_t`. Segments an unsigned 64-bit
 integer into four parts (from MSB to LSB):
  - 1 bit for the dead indicator - 1 bit for the z position - 31 bit
@@ -18571,7 +18571,7 @@ Returns:
 
 )doc";
 
-static const char *mkd_doc_fiction_sidb_simulation_engines_detail_cluster_charge_state_operator_unsigned_long_long =
+static const char *mkd_doc_fiction_sidb_simulation_engines_detail_cluster_charge_state_operator_unsigned_long =
 R"doc(Explicit instructions for the compiler on how to cast a cluster charge
 state to an 64-bit unsigned integer.
 

--- a/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
+++ b/bindings/mnt/pyfiction/include/pyfiction/pybind11_mkdoc_docstrings.hpp
@@ -3250,7 +3250,7 @@ Returns:
 
 )doc";
 
-static const char *mkd_doc_fiction_layouts_coords_offset_operator_unsigned_long =
+static const char *mkd_doc_fiction_layouts_coords_offset_operator_unsigned_long_long =
 R"doc(Allows explicit conversion to `uint64_t`. Segments an unsigned 64-bit
 integer into four parts (from MSB to LSB):
  - 1 bit for the dead indicator - 1 bit for the z position - 31 bit
@@ -13917,6 +13917,10 @@ finish.
 Random placement samples at most `maximal_random_design_attempts`
 candidates without enumerating canvas layouts.
 
+The timeout covers setup and all search phases. Expiration discards
+partial results and stops all workers before throwing. Allocation and
+non-interruptible setup may exceed the cooperative deadline.
+
 *QuickCell* is described in "Towards Fast Automatic Design of Silicon
 Dangling Bond Logic" by J. Drewniok, M. Walter, S. S. H. Ng, K. Walus,
 and R. Wille in DATE 2025
@@ -13941,6 +13945,7 @@ Returns:
 Raises:
     std::invalid_argument: if `spec` is empty or the input wire count
                            differs from the specification.
+    utils::timeout_error: if the gate-design deadline is reached.
 
 )doc";
 
@@ -13983,6 +13988,13 @@ static const char *mkd_doc_fiction_sidb_generators_design_gates_params_terminati
 static const char *mkd_doc_fiction_sidb_generators_design_gates_params_termination_condition_AFTER_FIRST_SOLUTION = R"doc(Stop after the first operational gate.)doc";
 
 static const char *mkd_doc_fiction_sidb_generators_design_gates_params_termination_condition_ALL_COMBINATIONS_ENUMERATED = R"doc(Enumerate every combination of canvas SiDBs.)doc";
+
+static const char *mkd_doc_fiction_sidb_generators_design_gates_params_timeout =
+R"doc(Timeout in milliseconds, including candidate generation and
+simulation. The maximum value means unlimited; zero expires
+immediately. Checks are cooperative, so allocation and non-
+interruptible setup can exceed the budget. Finite budgets support
+QUICKEXACT, EXGS, and QUICKSIM, but not CLUSTERCOMPLETE.)doc";
 
 static const char *mkd_doc_fiction_sidb_generators_design_gates_stats = R"doc(Statistics of the gate designers.)doc";
 
@@ -14256,6 +14268,11 @@ Returns:
 
 Raises:
     unsuccessful_gate_design_error: if a gate cannot be designed.
+    utils::timeout_error: if the shared circuit budget or an
+                          individual gate budget expires. No partial
+                          circuit is returned. Deadline checks are
+                          cooperative and do not interrupt allocation
+                          or layout conversion.
 
 )doc";
 
@@ -14323,6 +14340,13 @@ static const char *mkd_doc_fiction_sidb_generators_on_the_fly_circuit_design_on_
 static const char *mkd_doc_fiction_sidb_generators_on_the_fly_circuit_design_params = R"doc(This struct stores the parameters to design an SiDB circuit.)doc";
 
 static const char *mkd_doc_fiction_sidb_generators_on_the_fly_circuit_design_params_sidb_on_the_fly_gate_library_parameters = R"doc(Parameters for the SiDB on-the-fly gate library.)doc";
+
+static const char *mkd_doc_fiction_sidb_generators_on_the_fly_circuit_design_params_timeout =
+R"doc(Total timeout in milliseconds for all gates and layout conversion. The
+maximum value means unlimited; zero expires immediately. Every gate
+shares the same deadline, including crossings and double wires.
+Timeout checks are cooperative; allocation and non-interruptible setup
+can exceed the budget.)doc";
 
 static const char *mkd_doc_fiction_sidb_generators_unsuccessful_gate_design_error =
 R"doc(Exception thrown if the gate design was unsuccessful. Depending on the
@@ -15963,6 +15987,8 @@ Raises:
                                                  unsupported.
     fcn::unsupported_gate_type_exception: if the gate type is
                                           unsupported.
+    utils::timeout_error: if the shared circuit-design deadline is
+                          reached.
 
 )doc";
 
@@ -18545,7 +18571,7 @@ Returns:
 
 )doc";
 
-static const char *mkd_doc_fiction_sidb_simulation_engines_detail_cluster_charge_state_operator_unsigned_long =
+static const char *mkd_doc_fiction_sidb_simulation_engines_detail_cluster_charge_state_operator_unsigned_long_long =
 R"doc(Explicit instructions for the compiler on how to cast a cluster charge
 state to an 64-bit unsigned integer.
 
@@ -20504,12 +20530,16 @@ landscape.
 Args:
     lyt: Layout to simulate.
     params: Physical parameters.
+    deadline: Shared caller deadline. `time_point::max()` leaves the
+              simulation unlimited.
 
 Returns:
     The physically valid charge distributions.
 
 Raises:
     std::out_of_range: if a site has an invalid lattice basis index.
+    utils::timeout_error: if the shared caller deadline expires. No
+                          partial result is returned.
 
 )doc";
 
@@ -20675,6 +20705,8 @@ Returns:
 
 Raises:
     std::out_of_range: if a site has an invalid lattice basis index.
+    utils::timeout_error: if the shared caller deadline expires. No
+                          partial result is returned.
 
 )doc";
 
@@ -20695,6 +20727,10 @@ static const char *mkd_doc_fiction_sidb_simulation_engines_quickexact_params_bas
 R"doc(If `ON`, *QuickExact* checks which base number is required for the
 simulation, i.e., whether positively charged SiDBs can occur. If
 `OFF`, the base number from the physical parameters is used.)doc";
+
+static const char *mkd_doc_fiction_sidb_simulation_engines_quickexact_params_deadline =
+R"doc(Shared caller deadline. `time_point::max()` leaves the simulation
+unlimited.)doc";
 
 static const char *mkd_doc_fiction_sidb_simulation_engines_quickexact_params_global_potential =
 R"doc(Global external electrostatic potential (unit: V). Value is applied on
@@ -20730,12 +20766,19 @@ Returns:
 
 Raises:
     std::out_of_range: if a site has an invalid lattice basis index.
+    utils::timeout_error: if the shared caller deadline expires. No
+                          partial result is returned.
 
 )doc";
 
 static const char *mkd_doc_fiction_sidb_simulation_engines_quicksim_params = R"doc(This struct stores the parameters for the *QuickSim* algorithm.)doc";
 
 static const char *mkd_doc_fiction_sidb_simulation_engines_quicksim_params_alpha = R"doc(`alpha` parameter for the *QuickSim* algorithm.)doc";
+
+static const char *mkd_doc_fiction_sidb_simulation_engines_quicksim_params_deadline =
+R"doc(Shared caller deadline. Expiration throws instead of returning an
+incomplete simulation. `time_point::max()` leaves the caller budget
+unlimited; `timeout` still applies.)doc";
 
 static const char *mkd_doc_fiction_sidb_simulation_engines_quicksim_params_iteration_steps = R"doc(Number of iterations to run the simulation for.)doc";
 
@@ -21856,6 +21899,22 @@ R"doc(Sanity checks shared by every entry point.
 Args:
     lyt: The layout.
     spec: The specification.
+
+)doc";
+
+static const char *mkd_doc_fiction_sidb_simulation_logic_detail_checked_parameters =
+R"doc(Validates the shared deadline before setting up an operational check.
+
+Args:
+    params: Operational parameters.
+
+Returns:
+    The validated parameters.
+
+Raises:
+    utils::timeout_error: if the deadline expires.
+    std::invalid_argument: if ClusterComplete is selected with a
+                           finite deadline.
 
 )doc";
 
@@ -23047,6 +23106,11 @@ Raises:
 
 static const char *mkd_doc_fiction_sidb_simulation_logic_is_operational_params = R"doc(Parameters for the `is_operational` algorithm.)doc";
 
+static const char *mkd_doc_fiction_sidb_simulation_logic_is_operational_params_deadline =
+R"doc(Shared caller deadline for pruning and simulation. `time_point::max()`
+leaves the check unlimited. Finite deadlines support QuickExact, ExGS,
+and QuickSim; ClusterComplete is unsupported.)doc";
+
 static const char *mkd_doc_fiction_sidb_simulation_logic_is_operational_params_input_bdl_iterator_params = R"doc(Parameters for the BDL input iterator.)doc";
 
 static const char *mkd_doc_fiction_sidb_simulation_logic_is_operational_params_op_condition =
@@ -24101,6 +24165,7 @@ corners may be given in any order.
 Args:
     first_corner: One corner of the rectangle.
     second_corner: The opposite corner.
+    deadline: Shared execution deadline; unlimited by default.
 
 Returns:
     The sites in the rectangle in raster order.
@@ -24108,6 +24173,8 @@ Returns:
 Raises:
     std::length_error: if the rectangle exceeds the maximum vector
                        size.
+    utils::timeout_error: if the deadline is reached during
+                          enumeration.
 
 )doc";
 
@@ -25038,6 +25105,17 @@ static const char *mkd_doc_fiction_synthesis_technology_mapping_stats_mapper_sta
 
 static const char *mkd_doc_fiction_synthesis_technology_mapping_stats_report = R"doc(Report statistics.)doc";
 
+static const char *mkd_doc_fiction_utils_check_deadline =
+R"doc(Checks a shared monotonic deadline.
+
+Args:
+    deadline: Expiration time; the maximum time point means unlimited.
+
+Raises:
+    timeout_error: if the deadline has been reached.
+
+)doc";
+
 static const char *mkd_doc_fiction_utils_graph_detail_graph_coloring_impl = R"doc()doc";
 
 static const char *mkd_doc_fiction_utils_graph_detail_graph_coloring_impl_convert_node_index =
@@ -25664,6 +25742,18 @@ Template Args:
 
 )doc";
 
+static const char *mkd_doc_fiction_utils_make_deadline =
+R"doc(Starts a millisecond budget without extending an enclosing deadline.
+
+Args:
+    timeout: Milliseconds from now; the maximum value means unlimited.
+    enclosing: Deadline shared with an enclosing algorithm.
+
+Returns:
+    The earlier deadline, saturated at the clock's maximum time point.
+
+)doc";
+
 static const char *mkd_doc_fiction_utils_math_binomial_coefficient =
 R"doc(Calculates the binomial coefficient :math:`\binom{n}{k}`.
 
@@ -25726,6 +25816,7 @@ of indices, where each index indicates the position of an entity.
 Args:
     k: The number of entities to distribute.
     n: The number of positions available for distribution.
+    deadline: Shared execution deadline; unlimited by default.
 
 Returns:
     A vector of vectors representing all possible combinations of
@@ -25734,6 +25825,7 @@ Returns:
 Raises:
     std::length_error: if the number of combinations exceeds the
                        vector's capacity.
+    timeout_error: if the deadline is reached during enumeration.
 
 )doc";
 
@@ -26385,6 +26477,12 @@ Returns:
     `val` is not contained.
 
 )doc";
+
+static const char *mkd_doc_fiction_utils_timeout_error =
+R"doc(An algorithm reached its execution deadline without producing a
+complete result.)doc";
+
+static const char *mkd_doc_fiction_utils_timeout_error_timeout_error = R"doc(Constructs an execution-timeout error.)doc";
 
 static const char *mkd_doc_fiction_verification_count_gate_types =
 R"doc(Gives a detailed listing of all gate types present in the provided

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/design_gates.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/design_gates.cpp
@@ -98,6 +98,7 @@ void design_gates(nanobind::module_& m)
 
     m.def(
         "design_sidb_gates",
+        // NOLINTNEXTLINE(performance-unnecessary-value-param): Own inputs while Python can mutate the originals.
         [](const layout skeleton, const std::vector<py_tt> spec, const design_gates_params params,
            design_gates_stats* stats)
         {

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/design_gates.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/design_gates.cpp
@@ -25,6 +25,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/pair.h>    // NOLINT(misc-include-cleaner)
+#include <nanobind/stl/string.h>  // NOLINT(misc-include-cleaner): Converts the statistics representation.
 #include <nanobind/stl/vector.h>  // NOLINT(misc-include-cleaner)
 
 namespace pyfiction

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/design_gates.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/design_gates.cpp
@@ -30,6 +30,11 @@
 namespace pyfiction
 {
 
+/**
+ * @brief Registers SiDB gate design, its parameters, and statistics.
+ *
+ * @param m Python module.
+ */
 void design_gates(nanobind::module_& m)
 {
     namespace py = nanobind;
@@ -86,14 +91,28 @@ void design_gates(nanobind::module_& m)
                 DOC(fiction_sidb_generators_design_gates_params_number_of_canvas_sidbs))
         .def_rw("maximal_random_design_attempts", &design_gates_params::maximal_random_design_attempts,
                 DOC(fiction_sidb_generators_design_gates_params_maximal_random_design_attempts))
+        .def_rw("timeout", &design_gates_params::timeout, DOC(fiction_sidb_generators_design_gates_params_timeout))
         .def_rw("termination_cond", &design_gates_params::termination_cond,
                 DOC(fiction_sidb_generators_design_gates_params_termination_condition));
 
     m.def(
         "design_sidb_gates",
-        [](const layout& skeleton, const std::vector<py_tt>& spec, const design_gates_params& params,
+        [](const layout skeleton, const std::vector<py_tt> spec, const design_gates_params params,
            design_gates_stats* stats)
-        { return fiction::sidb::generators::design_gates(skeleton, spec, params, stats); },
+        {
+            // Copy Python-owned inputs before releasing the GIL; publish statistics after reacquiring it.
+            design_gates_stats  local_stats{};
+            std::vector<layout> result{};
+            {
+                const py::gil_scoped_release release{};
+                result = fiction::sidb::generators::design_gates(skeleton, spec, params, &local_stats);
+            }
+            if (stats != nullptr)
+            {
+                *stats = local_stats;
+            }
+            return result;
+        },
         py::arg("skeleton"), py::arg("spec"), py::arg("params") = design_gates_params{}, py::arg("stats") = nullptr,
         DOC(fiction_sidb_generators_design_gates));
 }

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/on_the_fly_circuit_design.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/generators/on_the_fly_circuit_design.cpp
@@ -76,6 +76,8 @@ void on_the_fly_circuit_design(nanobind::module_& m)
     py::class_<circuit_params>(m, "on_the_fly_sidb_circuit_design_params",
                                DOC(fiction_sidb_generators_on_the_fly_circuit_design_params))
         .def(py::init<>(), "Default constructor.")
+        .def_rw("timeout", &circuit_params::timeout,
+                DOC(fiction_sidb_generators_on_the_fly_circuit_design_params_timeout))
         .def_rw("sidb_on_the_fly_gate_library_parameters", &circuit_params::sidb_on_the_fly_gate_library_parameters,
                 DOC(fiction_sidb_generators_on_the_fly_circuit_design_params_sidb_on_the_fly_gate_library_parameters));
 
@@ -107,7 +109,8 @@ void on_the_fly_circuit_design(nanobind::module_& m)
 
 The layout and parameters are copied before releasing the GIL. The input layout is not modified.
 This function does not perform placement and routing or accept a defective surface.
-The search has no timeout; use a separate process when cancellation is required.
+The optional timeout bounds the whole circuit search in milliseconds. Deadline checks are cooperative;
+use a separate process when an exact cutoff is required. A timeout never returns a partial circuit.
 
 Args:
     layout: A hexagonal gate-level layout with supported Bestagon port orientations.
@@ -117,6 +120,7 @@ Returns:
     An SiDB layout that can be exported with write_sqd_layout or write_sidb_layout_svg.
 
 Raises:
+    TimeoutError: The circuit or an individual gate exceeds its timeout.
     RuntimeError: A gate cannot be designed with the supplied parameters.
     ValueError: A gate type or orientation is unsupported, or gate parameters are invalid.
 )doc");

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/lattice.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/lattice.cpp
@@ -79,8 +79,11 @@ void lattice(nanobind::module_& m)
 
     m.def("row_of", &fiction::sidb::row_of, py::arg("site"), DOC(fiction_sidb_row_of));
     m.def("site_at_row", &fiction::sidb::site_at_row, py::arg("x"), py::arg("row"), DOC(fiction_sidb_site_at_row));
-    m.def("sites_in_area", &fiction::sidb::sites_in_area, py::arg("first_corner"), py::arg("second_corner"),
-          DOC(fiction_sidb_sites_in_area));
+    m.def(
+        "sites_in_area",
+        [](const fiction::sidb::lattice_site& first_corner, const fiction::sidb::lattice_site& second_corner)
+        { return fiction::sidb::sites_in_area(first_corner, second_corner); }, py::arg("first_corner"),
+        py::arg("second_corner"), DOC(fiction_sidb_sites_in_area));
 
     py::class_<fiction::sidb::lattice>(m, "lattice", DOC(fiction_sidb_lattice))
         .def(py::init<>(), "Default constructor.")

--- a/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/simulation/engines/exhaustive_ground_state_simulation.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/technology/sidb/simulation/engines/exhaustive_ground_state_simulation.cpp
@@ -19,27 +19,27 @@
 #include <fiction/technology/sidb/layout.hpp>
 #include <fiction/technology/sidb/model/simulation_parameters.hpp>
 #include <fiction/technology/sidb/simulation/engines/exhaustive_ground_state_simulation.hpp>
-#include <fiction/technology/sidb/simulation/result.hpp>
 
 #include <nanobind/nanobind.h>
-#include <nanobind/stl/unordered_map.h>  // NOLINT(misc-include-cleaner)
-#include <nanobind/stl/vector.h>         // NOLINT(misc-include-cleaner)
 
 namespace pyfiction
 {
 
+/**
+ * @brief Registers exhaustive ground-state simulation without an internal deadline argument.
+ *
+ * @param m Python module.
+ */
 void exhaustive_ground_state_simulation(nanobind::module_& m)
 {
     namespace py = nanobind;
 
-    // NOLINTNEXTLINE(misc-const-correctness)
-    fiction::sidb::simulation::result (*const exgs_pointer)(const fiction::sidb::layout&,
-                                                            const fiction::sidb::model::simulation_parameters&) =
-        &fiction::sidb::simulation::engines::exhaustive_ground_state_simulation;
-
-    m.def("exhaustive_ground_state_simulation", exgs_pointer, py::arg("lyt"),
-          py::arg("params") = fiction::sidb::model::simulation_parameters{},
-          DOC(fiction_sidb_simulation_engines_exhaustive_ground_state_simulation));
+    m.def(
+        "exhaustive_ground_state_simulation",
+        [](const fiction::sidb::layout& layout, const fiction::sidb::model::simulation_parameters& params)
+        { return fiction::sidb::simulation::engines::exhaustive_ground_state_simulation(layout, params); },
+        py::arg("lyt"), py::arg("params") = fiction::sidb::model::simulation_parameters{},
+        DOC(fiction_sidb_simulation_engines_exhaustive_ground_state_simulation));
 }
 
 }  // namespace pyfiction

--- a/bindings/mnt/pyfiction/src/pyfiction/utils/execution_timeout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/utils/execution_timeout.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 - 2023 Marcel Walter
+ * Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/**
+ * @file
+ * @brief Maps execution timeouts to Python's built-in TimeoutError.
+ * @author Simon Hofmann (simon1hofmann)
+ */
+
+#include <fiction/utils/execution_timeout.hpp>
+
+#include <exception>
+
+#include <nanobind/nanobind.h>
+
+namespace pyfiction
+{
+
+/**
+ * @brief Registers the Python translator for execution timeouts.
+ *
+ * @param m Python module.
+ */
+void execution_timeout(nanobind::module_& /* m */)
+{
+    nanobind::register_exception_translator(
+        [](const std::exception_ptr& exception, void* /* unused */)
+        {
+            try
+            {
+                std::rethrow_exception(exception);
+            }
+            catch (const fiction::utils::timeout_error& error)
+            {
+                PyErr_SetString(PyExc_TimeoutError, error.what());
+            }
+        });
+}
+
+}  // namespace pyfiction

--- a/bindings/mnt/pyfiction/src/pyfiction/utils/execution_timeout.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/utils/execution_timeout.cpp
@@ -19,6 +19,7 @@
 #include <exception>
 
 #include <nanobind/nanobind.h>
+#include <pyerrors.h>
 
 namespace pyfiction
 {

--- a/bindings/mnt/pyfiction/src/pyfiction/utils/register_utils.cpp
+++ b/bindings/mnt/pyfiction/src/pyfiction/utils/register_utils.cpp
@@ -21,8 +21,21 @@ namespace pyfiction
 
 void version_info(nanobind::module_& m);
 
+/**
+ * @brief Registers the Python translator for execution timeouts.
+ *
+ * @param m Python module.
+ */
+void execution_timeout(nanobind::module_& m);
+
+/**
+ * @brief Registers utility bindings.
+ *
+ * @param m Python module.
+ */
 void register_utils(nanobind::module_& m)
 {
+    execution_timeout(m);
     version_info(m);
 }
 

--- a/bindings/mnt/pyfiction/test/technology/sidb/generators/test_design_gates.py
+++ b/bindings/mnt/pyfiction/test/technology/sidb/generators/test_design_gates.py
@@ -16,6 +16,7 @@ from mnt.pyfiction import (
     design_sidb_gates,
     design_sidb_gates_mode,
     design_sidb_gates_params,
+    design_sidb_gates_stats,
     lattice,
     lattice_site,
     operational_condition,
@@ -95,12 +96,15 @@ def test_siqad_and_gate_skeleton_100():
     assert params.operational_params.simulation_parameters.mu_minus == -0.28
     assert params.number_of_canvas_sidbs == 1
     assert params.maximal_random_design_attempts == 1_000_000
+    assert params.timeout == 2**64 - 1
     assert params.canvas[0] == lattice_site(4, 4, 0)
     assert params.canvas[1] == lattice_site(14, 5, 1)
 
-    designed_gates = design_sidb_gates(layout, [create_and_tt()], params)
+    stats = design_sidb_gates_stats()
+    designed_gates = design_sidb_gates(layout, [create_and_tt()], params, stats)
 
     assert len(designed_gates) == 23
+    assert "total time" in repr(stats)
 
 
 def test_nor_gate_111(nor_gate_skeleton):
@@ -153,3 +157,34 @@ def test_nor_gate_111_quickcell(nor_gate_skeleton):
 
     designed_gates = design_sidb_gates(layout, [create_nor_tt()], params)
     assert len(designed_gates) == 14
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        design_sidb_gates_mode.QUICKCELL,
+        design_sidb_gates_mode.AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER,
+        design_sidb_gates_mode.RANDOM,
+        design_sidb_gates_mode.PRUNING_ONLY,
+    ],
+)
+@pytest.mark.parametrize("timeout", [0, 1])
+def test_gate_design_timeout(nor_gate_skeleton: sidb_layout, mode: design_sidb_gates_mode, timeout: int) -> None:
+    """Every search mode raises TimeoutError without changing its inputs or publishing partial statistics."""
+    params = design_sidb_gates_params()
+    params.timeout = timeout
+    params.design_mode = mode
+    params.canvas = (lattice_site(0, 0, 0), lattice_site(1_000, 1_000, 0))
+    params.number_of_canvas_sidbs = 3
+    params.termination_cond = termination_condition.ALL_COMBINATIONS_ENUMERATED
+    stats = design_sidb_gates_stats()
+    initial_stats = repr(stats)
+    initial_dots = nor_gate_skeleton.sidbs()
+
+    with pytest.raises(TimeoutError):
+        design_sidb_gates(nor_gate_skeleton, [create_nor_tt()], params, stats)
+
+    assert nor_gate_skeleton.sidbs() == initial_dots
+    assert params.timeout == timeout
+    assert params.number_of_canvas_sidbs == 3
+    assert repr(stats) == initial_stats

--- a/bindings/mnt/pyfiction/test/technology/sidb/generators/test_on_the_fly_circuit_design.py
+++ b/bindings/mnt/pyfiction/test/technology/sidb/generators/test_on_the_fly_circuit_design.py
@@ -75,18 +75,17 @@ def test_parameters() -> None:
     assert library.influence_radius_charged_defects == 10
 
 
-@pytest.mark.parametrize("timeout", [0, 1])
 @pytest.mark.parametrize("per_gate", [False, True])
-def test_circuit_timeout(and_circuit: hexagonal_gate_layout, timeout: int, *, per_gate: bool) -> None:
+def test_circuit_timeout(and_circuit: hexagonal_gate_layout, *, per_gate: bool) -> None:
     """Circuit and nested gate budgets raise TimeoutError instead of returning a partial circuit."""
     params = on_the_fly_sidb_circuit_design_params()
     gates = params.sidb_on_the_fly_gate_library_parameters.design_gate_params
     gates.design_mode = design_sidb_gates_mode.QUICKCELL
     gates.number_of_canvas_sidbs = 3
     if per_gate:
-        gates.timeout = timeout
+        gates.timeout = 0
     else:
-        params.timeout = timeout
+        params.timeout = 0
 
     with pytest.raises(TimeoutError):
         on_the_fly_sidb_circuit_design(and_circuit, params)
@@ -94,7 +93,7 @@ def test_circuit_timeout(and_circuit: hexagonal_gate_layout, timeout: int, *, pe
     assert and_circuit.num_pis() == 2
     assert and_circuit.num_pos() == 1
     assert and_circuit.is_and(and_circuit.get_node((1, 1, 0)))
-    assert (gates.timeout if per_gate else params.timeout) == timeout
+    assert (gates.timeout if per_gate else params.timeout) == 0
 
 
 @pytest.mark.parametrize("timeout", [-1, 2**64, 1.5])

--- a/bindings/mnt/pyfiction/test/technology/sidb/generators/test_on_the_fly_circuit_design.py
+++ b/bindings/mnt/pyfiction/test/technology/sidb/generators/test_on_the_fly_circuit_design.py
@@ -49,6 +49,8 @@ def test_parameters() -> None:
     """Circuit parameters retain the native defaults and writable nested fields."""
     params = on_the_fly_sidb_circuit_design_params()
     library = params.sidb_on_the_fly_gate_library_parameters
+    assert params.timeout == 2**64 - 1
+    assert library.design_gate_params.timeout == 2**64 - 1
     assert isinstance(library, sidb_on_the_fly_gate_library_params)
     assert library.design_gate_params.design_mode == design_sidb_gates_mode.AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER
     assert library.design_gate_params.number_of_canvas_sidbs == 1
@@ -71,6 +73,38 @@ def test_parameters() -> None:
         == sidb_complex_gate_design_policy.DESIGN_ON_THE_FLY
     )
     assert library.influence_radius_charged_defects == 10
+
+
+@pytest.mark.parametrize("timeout", [0, 1])
+@pytest.mark.parametrize("per_gate", [False, True])
+def test_circuit_timeout(and_circuit: hexagonal_gate_layout, timeout: int, *, per_gate: bool) -> None:
+    """Circuit and nested gate budgets raise TimeoutError instead of returning a partial circuit."""
+    params = on_the_fly_sidb_circuit_design_params()
+    gates = params.sidb_on_the_fly_gate_library_parameters.design_gate_params
+    gates.design_mode = design_sidb_gates_mode.QUICKCELL
+    gates.number_of_canvas_sidbs = 3
+    if per_gate:
+        gates.timeout = timeout
+    else:
+        params.timeout = timeout
+
+    with pytest.raises(TimeoutError):
+        on_the_fly_sidb_circuit_design(and_circuit, params)
+
+    assert and_circuit.num_pis() == 2
+    assert and_circuit.num_pos() == 1
+    assert and_circuit.is_and(and_circuit.get_node((1, 1, 0)))
+    assert (gates.timeout if per_gate else params.timeout) == timeout
+
+
+@pytest.mark.parametrize("timeout", [-1, 2**64, 1.5])
+def test_invalid_timeout(timeout: float) -> None:
+    """The Python API accepts only unsigned 64-bit millisecond budgets."""
+    params = on_the_fly_sidb_circuit_design_params()
+    with pytest.raises(TypeError):
+        params.timeout = timeout
+    with pytest.raises(TypeError):
+        params.sidb_on_the_fly_gate_library_parameters.design_gate_params.timeout = timeout
 
 
 @pytest.mark.slow

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Algorithms:
 
   - `fcn::area` computes the bounding-box area of a `sidb::layout`, including defects
+  - SiDB gate and circuit design accept cooperative millisecond timeouts; circuit budgets
+    cover all gates and expired searches throw `utils::timeout_error`.
 
 - Code quality:
 
@@ -44,6 +46,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Python bindings:
 
+  - SiDB gate and circuit timeouts raise Python's `TimeoutError`; gate design releases the GIL
+    after copying its inputs.
   - Added directory-based test markers, including `pytest -m simulation`.
   - Marked the SiDB circuit-design integration test as `slow`; `pytest -m 'not slow'` skips it.
   - Exposed `write_location_and_ground_state`, whose binding existed but was never registered

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -391,6 +391,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Python bindings:
 
   - Exposed `missing_required_gates_exception` so callers can catch technology-mapping failures.
+  - `design_sidb_gates_stats.__repr__` now converts the statistics string to Python.
   - Exposed the defect-matrix reader exceptions at the package root.
   - `parameter_point.__getitem__` raises `IndexError` for an out-of-range index instead of
     reading past the parameter vector

--- a/docs/technology/sidb/generators/design_gates.md
+++ b/docs/technology/sidb/generators/design_gates.md
@@ -2,6 +2,11 @@
 
 # SiDB Gate Designer
 
+Set `timeout` to a millisecond budget to limit a gate search. The default, `2**64 - 1`,
+leaves the search unlimited; `0` expires immediately. Deadlines are cooperative, so an
+operation can finish after the deadline before the next check stops the search.
+Finite timeouts support QuickExact, ExGS, and QuickSim; ClusterComplete rejects them.
+
 ::::{tab-set}
 :sync-group: language
 
@@ -9,6 +14,8 @@
 :sync: cpp
 
 **Header:** `fiction/technology/sidb/generators/design_gates.hpp`
+
+An expired deadline throws `fiction::utils::timeout_error` without returning partial results.
 
 ```{doxygenstruct} fiction::sidb::generators::design_gates_stats
 :members:
@@ -26,6 +33,19 @@
 
 :::{tab-item} Python
 :sync: python
+
+The call copies the skeleton, specification, and parameters before releasing the GIL.
+An expired deadline raises the built-in `TimeoutError`; the input skeleton remains unchanged.
+Statistics are published only after a successful search.
+
+```python
+params = design_sidb_gates_params()
+params.timeout = 5_000  # milliseconds
+try:
+    gates = design_sidb_gates(skeleton, specification, params)
+except TimeoutError:
+    print("Gate design exceeded its time budget")
+```
 
 ```{eval-rst}
 .. autoclass:: mnt.pyfiction.design_sidb_gates_stats

--- a/docs/technology/sidb/generators/on_the_fly_circuit_design.md
+++ b/docs/technology/sidb/generators/on_the_fly_circuit_design.md
@@ -11,8 +11,13 @@ Convert Cartesian layouts with {ref}`hexagonalization` before designing the SiDB
 The default search uses exhaustive gate design with one canvas SiDB and stops at the first
 solution. Crossings and double wires use predefined implementations when possible.
 The required number of canvas SiDBs depends on the gates; the example uses three with QuickCell.
-The search has no timeout or cancellation parameter; applications that require cancellation
-must run the call in a separate process. The returned layout can be exported as SVG or SiQAD SQD.
+The returned layout can be exported as SVG or SiQAD SQD.
+
+Set the circuit parameters' `timeout` to a millisecond budget for the entire circuit search,
+including all gate designs. A gate's own `design_gate_params.timeout` can impose a shorter
+per-gate limit. Both default to `2**64 - 1` (unlimited); `0` expires immediately.
+Deadline checks are cooperative; use a separate process when an exact cutoff is required.
+Finite timeouts support QuickExact, ExGS, and QuickSim; ClusterComplete rejects them.
 
 ::::{tab-set}
 :sync-group: language
@@ -21,6 +26,8 @@ must run the call in a separate process. The returned layout can be exported as 
 :sync: cpp
 
 **Header:** `fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp`
+
+An expired deadline throws `fiction::utils::timeout_error` without returning a partial circuit.
 
 ```{doxygenstruct} fiction::sidb::generators::on_the_fly_circuit_design_params
 :members:
@@ -38,7 +45,8 @@ must run the call in a separate process. The returned layout can be exported as 
 The Python call accepts `hexagonal_gate_layout` and returns `sidb_layout`.
 The call leaves its input unchanged and releases the GIL during circuit design.
 An unsupported gate type or orientation raises `ValueError`; an unsuccessful gate search
-raises `RuntimeError`. This interface does not accept defective surfaces or logic networks.
+raises `RuntimeError`. An expired circuit or gate deadline raises the built-in `TimeoutError`.
+This interface does not accept defective surfaces or logic networks.
 
 Choose the gate-search algorithm through `design_gate_params.design_mode`, as shown below.
 The `PRUNING_ONLY` mode skips operational simulation, so it does not verify the designed gates' functionality.
@@ -59,6 +67,7 @@ gate = layout.create_and(a, b, (1, 1, 0))
 layout.create_po(gate, "f", (0, 2, 0))
 
 params = on_the_fly_sidb_circuit_design_params()
+params.timeout = 60_000  # one minute for the whole circuit
 gates = params.sidb_on_the_fly_gate_library_parameters.design_gate_params
 gates.design_mode = design_sidb_gates_mode.QUICKCELL
 gates.number_of_canvas_sidbs = 3

--- a/include/fiction/technology/sidb/generators/design_gates.hpp
+++ b/include/fiction/technology/sidb/generators/design_gates.hpp
@@ -24,6 +24,7 @@
 #include "fiction/technology/sidb/simulation/logic/detect_bdl_wires.hpp"
 #include "fiction/technology/sidb/simulation/logic/is_operational.hpp"
 #include "fiction/technology/sidb/technology.hpp"
+#include "fiction/utils/execution_timeout.hpp"
 #include "fiction/utils/math/combination_utils.hpp"
 #include "fiction/utils/math/math_utils.hpp"
 
@@ -115,6 +116,12 @@ struct design_gates_params
      * When to stop.
      */
     termination_condition termination_cond = termination_condition::AFTER_FIRST_SOLUTION;
+    /**
+     * Timeout in milliseconds, including candidate generation and simulation. The maximum value means unlimited;
+     * zero expires immediately. Checks are cooperative, so allocation and non-interruptible setup can exceed the
+     * budget. Finite budgets support QUICKEXACT, EXGS, and QUICKSIM, but not CLUSTERCOMPLETE.
+     */
+    uint64_t timeout = std::numeric_limits<uint64_t>::max();
 };
 
 /**
@@ -186,18 +193,20 @@ class design_gates_impl
             skeleton_layout{skeleton},
             truth_table{spec},
             params{ps},
-            available_sidbs_in_canvas{[this]
-                                      {
-                                          auto sites = sites_in_area(params.canvas.first, params.canvas.second);
-                                          std::erase_if(sites,
-                                                        [this](const auto& s)
-                                                        {
-                                                            return !skeleton_layout.is_empty_site(s) ||
-                                                                   skeleton_layout.get_defect(s).type !=
-                                                                       model::defect_type::NONE;
-                                                        });
-                                          return sites;
-                                      }()},
+            available_sidbs_in_canvas{
+                [this]
+                {
+                    auto sites =
+                        sites_in_area(params.canvas.first, params.canvas.second, params.operational_params.deadline);
+                    std::erase_if(sites,
+                                  [this](const auto& s)
+                                  {
+                                      utils::check_deadline(params.operational_params.deadline);
+                                      return !skeleton_layout.is_empty_site(s) ||
+                                             skeleton_layout.get_defect(s).type != model::defect_type::NONE;
+                                  });
+                    return sites;
+                }()},
             stats{st},
             input_bdl_wires{simulation::logic::detect_bdl_wires(
                 skeleton_layout, params.operational_params.input_bdl_iterator_params.bdl_wire_params,
@@ -234,7 +243,7 @@ class design_gates_impl
         const mockturtle::stopwatch stop{stats.time_total};
 
         auto all_combinations = utils::math::determine_all_combinations_of_distributing_k_entities_on_n_positions(
-            params.number_of_canvas_sidbs, available_sidbs_in_canvas.size());
+            params.number_of_canvas_sidbs, available_sidbs_in_canvas.size(), params.operational_params.deadline);
 
         std::vector<layout> designed_gate_layouts{};
 
@@ -317,6 +326,7 @@ class design_gates_impl
                         {
                             while (!gate_layout_is_found)
                             {
+                                utils::check_deadline(params.operational_params.deadline);
                                 if (attempt_counter.fetch_add(1, std::memory_order_relaxed) >=
                                     params.maximal_random_design_attempts)
                                 {
@@ -520,6 +530,7 @@ class design_gates_impl
 
         for (std::size_t i = 0; i < num_threads; ++i)
         {
+            utils::check_deadline(params.operational_params.deadline);
             workers.emplace_back(
                 std::async(std::launch::async,
                            [this, i, chunk_size, &items, &fn, &done]
@@ -529,6 +540,7 @@ class design_gates_impl
 
                                for (std::size_t j = start_index; j < end_index; ++j)
                                {
+                                   utils::check_deadline(params.operational_params.deadline);
                                    if (done && params.termination_cond ==
                                                    design_gates_params::termination_condition::AFTER_FIRST_SOLUTION)
                                    {
@@ -579,6 +591,7 @@ class design_gates_impl
 
             for (auto i = 0u; i < truth_table.front().num_bits(); ++i)
             {
+                utils::check_deadline(params.operational_params.deadline);
                 const auto reason = is_operational_impl.is_layout_invalid(i);
 
                 if (!reason.has_value())
@@ -625,13 +638,14 @@ class design_gates_impl
     [[nodiscard]] std::vector<layout> determine_all_possible_canvas_layouts() const
     {
         const auto all_combinations = utils::math::determine_all_combinations_of_distributing_k_entities_on_n_positions(
-            params.number_of_canvas_sidbs, available_sidbs_in_canvas.size());
+            params.number_of_canvas_sidbs, available_sidbs_in_canvas.size(), params.operational_params.deadline);
 
         std::vector<layout> canvas_layouts{};
         canvas_layouts.reserve(all_combinations.size());
 
         for (const auto& combination : all_combinations)
         {
+            utils::check_deadline(params.operational_params.deadline);
             canvas_layouts.push_back(design_canvas_layout(combination));
         }
 
@@ -690,6 +704,8 @@ class design_gates_impl
  * combination of canvas SiDBs, *QuickCell*'s pruning followed by simulation, random placement, and pruning only.
  * Worker exceptions propagate to the caller after all started workers finish.
  * Random placement samples at most `maximal_random_design_attempts` candidates without enumerating canvas layouts.
+ * The timeout covers setup and all search phases. Expiration discards partial results and stops all workers before
+ * throwing. Allocation and non-interruptible setup may exceed the cooperative deadline.
  *
  * *QuickCell* is described in "Towards Fast Automatic Design of Silicon Dangling Bond Logic" by J. Drewniok,
  * M. Walter, S. S. H. Ng, K. Walus, and R. Wille in DATE 2025
@@ -706,12 +722,16 @@ class design_gates_impl
  * @param stats Statistics.
  * @return The designed gates.
  * @throws std::invalid_argument if `spec` is empty or the input wire count differs from the specification.
+ * @throws utils::timeout_error if the gate-design deadline is reached.
  */
 [[nodiscard]] inline std::vector<layout> design_gates(const layout&                                  skeleton,
                                                       const std::vector<kitty::dynamic_truth_table>& spec,
                                                       const design_gates_params&                     params = {},
                                                       design_gates_stats*                            stats  = nullptr)
 {
+    auto timed_params                        = params;
+    timed_params.operational_params.deadline = utils::make_deadline(params.timeout, params.operational_params.deadline);
+    utils::check_deadline(timed_params.operational_params.deadline);
     if (spec.empty())
     {
         throw std::invalid_argument{"spec must not be empty"};
@@ -723,7 +743,7 @@ class design_gates_impl
                                       { return a.num_vars() != b.num_vars(); }) == spec.end());
 
     design_gates_stats        st{};
-    detail::design_gates_impl p{skeleton, spec, params, st};
+    detail::design_gates_impl p{skeleton, spec, timed_params, st};
 
     std::vector<layout> result{};
 
@@ -740,6 +760,7 @@ class design_gates_impl
         result = p.run_quickcell();
     }
 
+    utils::check_deadline(timed_params.operational_params.deadline);
     if (stats != nullptr)
     {
         *stats = st;

--- a/include/fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp
+++ b/include/fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp
@@ -43,7 +43,6 @@
 #include <mockturtle/traits.hpp>
 #include <mockturtle/utils/stopwatch.hpp>
 
-#include <cstdint>
 #include <cstdio>
 #include <optional>
 #include <utility>

--- a/include/fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp
+++ b/include/fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp
@@ -23,7 +23,10 @@
 #include "fiction/technology/sidb/on_the_fly_gate_library.hpp"
 #include "fiction/traits.hpp"
 #include "fiction/types.hpp"
+#include "fiction/utils/execution_timeout.hpp"
 
+#include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -108,6 +111,12 @@ struct on_the_fly_circuit_design_params
      * Parameters for the SiDB on-the-fly gate library.
      */
     sidb::on_the_fly_gate_library_params sidb_on_the_fly_gate_library_parameters = {};
+    /**
+     * Total timeout in milliseconds for all gates and layout conversion. The maximum value means unlimited;
+     * zero expires immediately. Every gate shares the same deadline, including crossings and double wires.
+     * Timeout checks are cooperative; allocation and non-interruptible setup can exceed the budget.
+     */
+    uint64_t timeout = std::numeric_limits<uint64_t>::max();
 };
 
 #if (FICTION_Z3_SOLVER)
@@ -219,6 +228,11 @@ template <typename Ntk, typename GateLyt>
                     break;
                 }
 
+                catch (const utils::timeout_error&)
+                {
+                    throw;
+                }
+
                 catch (...)
                 {
                     fmt::print(stderr, "[e] An unexpected error occurred during gate design.\n");
@@ -257,6 +271,8 @@ template <typename Ntk, typename GateLyt>
  * `on_the_fly_circuit_design_params` object.
  * @return Layout representing the designed SiDB circuit.
  * @throws unsuccessful_gate_design_error if a gate cannot be designed.
+ * @throws utils::timeout_error if the shared circuit budget or an individual gate budget expires. No partial circuit
+ * is returned. Deadline checks are cooperative and do not interrupt allocation or layout conversion.
  */
 template <typename GateLyt>
 [[nodiscard]] layout on_the_fly_circuit_design(const GateLyt&                          gate_lyt,
@@ -264,11 +280,17 @@ template <typename GateLyt>
 {
     static_assert(is_gate_level_layout_v<GateLyt>, "GateLyt is not a gate-level layout");
     static_assert(is_hexagonal_layout_v<GateLyt>, "GateLyt is not a hexagonal");
+    auto  library_params = params.sidb_on_the_fly_gate_library_parameters;
+    auto& deadline       = library_params.design_gate_params.operational_params.deadline;
+    deadline             = utils::make_deadline(params.timeout, deadline);
+    utils::check_deadline(deadline);
     try
     {
-        return to_sidb_layout(
+        auto result = to_sidb_layout(
             physical_design::apply_parameterized_gate_library<sidb_cell_clk_lyt_cube, sidb::on_the_fly_gate_library>(
-                gate_lyt, params.sidb_on_the_fly_gate_library_parameters));
+                gate_lyt, library_params));
+        utils::check_deadline(deadline);
+        return result;
     }
 
     // Report an unsuccessful gate design to the circuit-design caller.

--- a/include/fiction/technology/sidb/lattice.hpp
+++ b/include/fiction/technology/sidb/lattice.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "fiction/utils/execution_timeout.hpp"
+
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -193,12 +195,16 @@ struct lattice_site
  *
  * @param first_corner One corner of the rectangle.
  * @param second_corner The opposite corner.
+ * @param deadline Shared execution deadline; unlimited by default.
  * @return The sites in the rectangle in raster order.
  * @throws std::length_error if the rectangle exceeds the maximum vector size.
+ * @throws utils::timeout_error if the deadline is reached during enumeration.
  */
-[[nodiscard]] inline std::vector<lattice_site> sites_in_area(const lattice_site& first_corner,
-                                                             const lattice_site& second_corner)
+[[nodiscard]] inline std::vector<lattice_site>
+sites_in_area(const lattice_site& first_corner, const lattice_site& second_corner,
+              const std::chrono::steady_clock::time_point deadline = std::chrono::steady_clock::time_point::max())
 {
+    utils::check_deadline(deadline);
     const auto min_x   = std::min(first_corner.x, second_corner.x);
     const auto max_x   = std::max(first_corner.x, second_corner.x);
     const auto min_row = std::min(row_of(first_corner), row_of(second_corner));
@@ -211,16 +217,21 @@ struct lattice_site
     {
         throw std::length_error("Lattice-site rectangle exceeds the maximum vector size");
     }
-    sites.reserve(width * height);
+    if (deadline == std::chrono::steady_clock::time_point::max())
+    {
+        sites.reserve(width * height);
+    }
 
     for (auto row = min_row; row <= max_row; ++row)
     {
         for (int64_t x = min_x; x <= max_x; ++x)
         {
+            utils::check_deadline(deadline);
             sites.push_back(site_at_row(static_cast<int32_t>(x), row));
         }
     }
 
+    utils::check_deadline(deadline);
     return sites;
 }
 /**

--- a/include/fiction/technology/sidb/lattice.hpp
+++ b/include/fiction/technology/sidb/lattice.hpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <compare>
 #include <cstddef>

--- a/include/fiction/technology/sidb/on_the_fly_gate_library.hpp
+++ b/include/fiction/technology/sidb/on_the_fly_gate_library.hpp
@@ -31,6 +31,7 @@
 #include "fiction/technology/sidb/technology.hpp"
 #include "fiction/traits.hpp"
 #include "fiction/types.hpp"
+#include "fiction/utils/execution_timeout.hpp"
 
 #include <kitty/dynamic_truth_table.hpp>
 #include <phmap.h>
@@ -182,12 +183,15 @@ class on_the_fly_gate_library
      * @throws gate_design_exception if no gate can be designed.
      * @throws fcn::unsupported_gate_orientation_exception if the gate orientation is unsupported.
      * @throws fcn::unsupported_gate_type_exception if the gate type is unsupported.
+     * @throws utils::timeout_error if the shared circuit-design deadline is reached.
      */
     template <typename GateLyt, typename Params>
     static gate set_up_gate(const GateLyt& lyt, const tile<GateLyt>& t, const Params& params,
                             const std::optional<layout>& defect_surface = std::nullopt)
     {
         static_assert(is_gate_level_layout_v<GateLyt>, "GateLyt must be a gate-level layout");
+
+        utils::check_deadline(params.design_gate_params.operational_params.deadline);
 
         const auto n = lyt.get_node(t);
         const auto f = lyt.node_function(n);

--- a/include/fiction/technology/sidb/simulation/engines/exhaustive_ground_state_simulation.hpp
+++ b/include/fiction/technology/sidb/simulation/engines/exhaustive_ground_state_simulation.hpp
@@ -24,8 +24,11 @@
 #include "fiction/technology/sidb/simulation/detail/simulation_state.hpp"
 #include "fiction/technology/sidb/simulation/potential_landscape.hpp"
 #include "fiction/technology/sidb/simulation/result.hpp"
+#include "fiction/utils/execution_timeout.hpp"
 
 #include <mockturtle/utils/stopwatch.hpp>
+
+#include <chrono>
 
 namespace fiction::sidb::simulation::engines
 {
@@ -38,13 +41,16 @@ namespace fiction::sidb::simulation::engines
  *
  * @param lyt Layout to simulate.
  * @param params Physical parameters.
+ * @param deadline Shared caller deadline. `time_point::max()` leaves the simulation unlimited.
  * @return The physically valid charge distributions.
  * @throws std::out_of_range if a site has an invalid lattice basis index.
+ * @throws utils::timeout_error if the shared caller deadline expires. No partial result is returned.
  */
-[[nodiscard]] inline result
-exhaustive_ground_state_simulation(const layout&                       lyt,
-                                   const model::simulation_parameters& params = model::simulation_parameters{})
+[[nodiscard]] inline result exhaustive_ground_state_simulation(
+    const layout& lyt, const model::simulation_parameters& params = model::simulation_parameters{},
+    const std::chrono::steady_clock::time_point deadline = std::chrono::steady_clock::time_point::max())
 {
+    utils::check_deadline(deadline);
     result simulation_result{};
     simulation_result.algorithm_name = "ExGS";
     simulation_result.sim_params     = params;
@@ -64,6 +70,7 @@ exhaustive_ground_state_simulation(const layout&                       lyt,
 
         while (state.charge_index() < state.max_charge_index())
         {
+            utils::check_deadline(deadline);
             if (state.is_physically_valid())
             {
                 simulation_result.charge_distributions.push_back(state.snapshot());
@@ -78,6 +85,8 @@ exhaustive_ground_state_simulation(const layout&                       lyt,
         }
     }
     simulation_result.simulation_runtime = time_counter;
+
+    utils::check_deadline(deadline);
 
     return simulation_result;
 }

--- a/include/fiction/technology/sidb/simulation/engines/quickexact.hpp
+++ b/include/fiction/technology/sidb/simulation/engines/quickexact.hpp
@@ -28,11 +28,13 @@
 #include "fiction/technology/sidb/simulation/potential_landscape.hpp"
 #include "fiction/technology/sidb/simulation/result.hpp"
 #include "fiction/technology/sidb/technology.hpp"
+#include "fiction/utils/execution_timeout.hpp"
 #include "fiction/utils/math/gray_code_iterator.hpp"
 
 #include <mockturtle/utils/stopwatch.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <unordered_map>
@@ -79,6 +81,10 @@ struct quickexact_params
      * Global external electrostatic potential (unit: V). Value is applied on each SiDB.
      */
     double global_potential = 0;
+    /**
+     * Shared caller deadline. `time_point::max()` leaves the simulation unlimited.
+     */
+    std::chrono::steady_clock::time_point deadline{std::chrono::steady_clock::time_point::max()};
 };
 
 namespace detail
@@ -108,6 +114,7 @@ class quickexact_impl
      */
     [[nodiscard]] result run()
     {
+        utils::check_deadline(params.deadline);
         sim_result.algorithm_name = "QuickExact";
         sim_result.sim_params     = params.sim_params;
         sim_result.lyt            = landscape.get_layout();
@@ -153,6 +160,7 @@ class quickexact_impl
                 // charge index is increased and the corresponding charge distribution is checked for physical validity.
                 while (state.charge_index() < state.max_charge_index())
                 {
+                    utils::check_deadline(params.deadline);
                     if (state.is_physically_valid())
                     {
                         sim_result.charge_distributions.push_back(state.snapshot());
@@ -171,6 +179,8 @@ class quickexact_impl
         }
 
         sim_result.simulation_runtime = time_counter;
+
+        utils::check_deadline(params.deadline);
 
         return sim_result;
     }
@@ -230,6 +240,7 @@ class quickexact_impl
 
         for (const auto i : preassigned_negative_sidbs)
         {
+            utils::check_deadline(params.deadline);
             reduced.assign_sidb(sites[i], dot_tag::EMPTY);
             // IMPORTANT: The pre-assigned negatively charged SiDBs (they have to be negatively charged to
             // fulfill the population stability) are considered as negatively charged defects in the layout.
@@ -240,6 +251,7 @@ class quickexact_impl
 
         for (std::size_t i = 0; i < landscape.num_sidbs(); ++i)
         {
+            utils::check_deadline(params.deadline);
             if (!std::ranges::binary_search(preassigned_negative_sidbs, i))
             {
                 free_sidbs.push_back(i);
@@ -309,6 +321,7 @@ class quickexact_impl
 
         for (gci = 0; gci <= reduced_state.max_charge_index(); ++gci)
         {
+            utils::check_deadline(params.deadline);
             reduced_state.assign_charge_index_by_gray_code(
                 *gci, previous_charge_index, simulation::detail::dependent_dot_mode::VARIABLE,
                 simulation::detail::energy_calculation::KEEP_OLD_ENERGY_VALUE,
@@ -339,8 +352,10 @@ class quickexact_impl
 
         while (reduced_state.charge_index() < reduced_state.max_charge_index())
         {
+            utils::check_deadline(params.deadline);
             while (reduced_state.charge_index_of_sub_layout() < reduced_state.max_charge_index_sub_layout())
             {
+                utils::check_deadline(params.deadline);
                 if (reduced_state.is_physically_valid())
                 {
                     record(reduced_state);
@@ -369,6 +384,7 @@ class quickexact_impl
         // charge configurations of the sublayout are iterated
         while (reduced_state.charge_index_of_sub_layout() < reduced_state.max_charge_index_sub_layout())
         {
+            utils::check_deadline(params.deadline);
             if (reduced_state.is_physically_valid())
             {
                 record(reduced_state);
@@ -405,9 +421,11 @@ class quickexact_impl
  * @param params Parameter required for the simulation.
  * @return Simulation result: every physically valid charge distribution of `lyt`.
  * @throws std::out_of_range if a site has an invalid lattice basis index.
+ * @throws utils::timeout_error if the shared caller deadline expires. No partial result is returned.
  */
 [[nodiscard]] inline result quickexact(const layout& lyt, const quickexact_params& params = {})
 {
+    utils::check_deadline(params.deadline);
     detail::quickexact_impl p{lyt, params};
 
     return p.run();

--- a/include/fiction/technology/sidb/simulation/engines/quicksim.hpp
+++ b/include/fiction/technology/sidb/simulation/engines/quicksim.hpp
@@ -24,6 +24,7 @@
 #include "fiction/technology/sidb/simulation/detail/simulation_state.hpp"
 #include "fiction/technology/sidb/simulation/potential_landscape.hpp"
 #include "fiction/technology/sidb/simulation/result.hpp"
+#include "fiction/utils/execution_timeout.hpp"
 
 #include <mockturtle/utils/stopwatch.hpp>
 
@@ -67,6 +68,11 @@ struct quicksim_params
      * Timeout limit (in ms).
      */
     uint64_t timeout = std::numeric_limits<uint64_t>::max();
+    /**
+     * Shared caller deadline. Expiration throws instead of returning an incomplete simulation.
+     * `time_point::max()` leaves the caller budget unlimited; `timeout` still applies.
+     */
+    std::chrono::steady_clock::time_point deadline{std::chrono::steady_clock::time_point::max()};
 };
 
 /**
@@ -82,9 +88,11 @@ struct quicksim_params
  * @return The physically valid charge distributions found, or `std::nullopt` if the layout is empty, holds charged
  * defects, the iteration count is zero, the timeout was hit, or no valid distribution was found.
  * @throws std::out_of_range if a site has an invalid lattice basis index.
+ * @throws utils::timeout_error if the shared caller deadline expires. No partial result is returned.
  */
 [[nodiscard]] inline std::optional<result> quicksim(const layout& lyt, const quicksim_params& ps = quicksim_params{})
 {
+    utils::check_deadline(ps.deadline);
     if (ps.iteration_steps == 0 || lyt.num_dots() == 0 || lyt.num_charged_defects() > 0)
     {
         return std::nullopt;
@@ -117,6 +125,8 @@ struct quicksim_params
         simulation::detail::simulation_state state{land, model::charge_state::NEGATIVE,
                                                    simulation::detail::simulation_state::energy_model::INTERNAL_ONLY};
 
+        utils::check_deadline(ps.deadline);
+
         const auto predefined_negative_sidb_indices = state.negative_sidb_detection();
 
         // Check that the layout with all SiDBs negatively charged is physically valid.
@@ -141,6 +151,7 @@ struct quicksim_params
 
         for (std::size_t i = 0; i < state.num_sidbs(); ++i)
         {
+            utils::check_deadline(ps.deadline);
             // no execution policy: predefined_negative_sidb_indices holds a handful of entries, where the dispatch
             // costs an order of magnitude more than the search itself
             if (std::ranges::find(predefined_negative_sidb_indices, i) == predefined_negative_sidb_indices.cend())
@@ -155,6 +166,7 @@ struct quicksim_params
         }
 
         state.update_after_charge_change();
+        utils::check_deadline(ps.deadline);
         if (state.is_physically_valid())
         {
             st.charge_distributions.push_back(state.snapshot());
@@ -189,9 +201,19 @@ struct quicksim_params
 
                     for (uint64_t l = 0ul; l < iter_per_thread; ++l)
                     {
+                        if (ps.deadline != std::chrono::steady_clock::time_point::max() &&
+                            std::chrono::steady_clock::now() >= ps.deadline)
+                        {
+                            return;
+                        }
                         for (const auto sidb_index_with_unknown_charge_state :
                              all_sidb_indices_with_unknown_charge_state)
                         {
+                            if (ps.deadline != std::chrono::steady_clock::time_point::max() &&
+                                std::chrono::steady_clock::now() >= ps.deadline)
+                            {
+                                return;
+                            }
                             // Check if the timeout has been reached before starting the iterations
                             const auto current_time = std::chrono::high_resolution_clock::now();
                             const auto elapsed_time =
@@ -230,6 +252,11 @@ struct quicksim_params
 
                             for (uint64_t num = 0ul; num < upper_limit; num++)
                             {
+                                if (ps.deadline != std::chrono::steady_clock::time_point::max() &&
+                                    std::chrono::steady_clock::now() >= ps.deadline)
+                                {
+                                    return;
+                                }
                                 worker_state.adjacent_search(ps.alpha, negative_sidbs_indices);
                                 worker_state.validity_check();
 
@@ -251,6 +278,9 @@ struct quicksim_params
     }
 
     st.simulation_runtime = time_counter;
+
+    // Throw only after every worker has joined; exceptions cannot escape a worker thread.
+    utils::check_deadline(ps.deadline);
 
     if (timeout_limit_reached.load(std::memory_order_relaxed) || st.charge_distributions.empty())
     {

--- a/include/fiction/technology/sidb/simulation/logic/is_operational.hpp
+++ b/include/fiction/technology/sidb/simulation/logic/is_operational.hpp
@@ -39,6 +39,7 @@
 #include "fiction/technology/sidb/simulation/potential_landscape.hpp"
 #include "fiction/technology/sidb/simulation/result.hpp"
 #include "fiction/technology/sidb/technology.hpp"
+#include "fiction/utils/execution_timeout.hpp"
 #include "fiction/utils/math/math_utils.hpp"
 
 #include <fmt/format.h>
@@ -47,6 +48,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -155,10 +157,35 @@ struct is_operational_params
      */
     operational_analysis_strategy strategy_to_analyze_operational_status{
         operational_analysis_strategy::SIMULATION_ONLY};
+    /**
+     * Shared caller deadline for pruning and simulation. `time_point::max()` leaves the check unlimited.
+     * Finite deadlines support QuickExact, ExGS, and QuickSim; ClusterComplete is unsupported.
+     */
+    std::chrono::steady_clock::time_point deadline{std::chrono::steady_clock::time_point::max()};
 };
 
 namespace detail
 {
+
+/**
+ * Validates the shared deadline before setting up an operational check.
+ *
+ * @param params Operational parameters.
+ * @return The validated parameters.
+ * @throws utils::timeout_error if the deadline expires.
+ * @throws std::invalid_argument if ClusterComplete is selected with a finite deadline.
+ */
+[[nodiscard]] inline const is_operational_params& checked_parameters(const is_operational_params& params)
+{
+    utils::check_deadline(params.deadline);
+#if (FICTION_ALGLIB_ENABLED)
+    if (params.deadline != std::chrono::steady_clock::time_point::max() && params.sim_engine == engine::CLUSTERCOMPLETE)
+    {
+        throw std::invalid_argument("ClusterComplete does not support a shared deadline");
+    }
+#endif  // FICTION_ALGLIB_ENABLED
+    return params;
+}
 
 /**
  * Reasons why a layout is not operational.
@@ -223,7 +250,7 @@ class is_operational_impl
                         const is_operational_params& params) :
             sidb_layout{lyt},
             truth_table{spec},
-            parameters{params},
+            parameters{checked_parameters(params)},
             output_bdl_pairs{detect_bdl_pairs(lyt, dot_tag::OUTPUT,
                                               params.input_bdl_iterator_params.bdl_wire_params.bdl_pairs_params)},
             bii{lyt, params.input_bdl_iterator_params},
@@ -248,7 +275,7 @@ class is_operational_impl
                         const std::vector<bdl_wire>& output_wires, const bool initialize_bii = true) :
             sidb_layout{lyt},
             truth_table{spec},
-            parameters{params},
+            parameters{checked_parameters(params)},
             output_bdl_pairs{detect_bdl_pairs(lyt, dot_tag::OUTPUT,
                                               params.input_bdl_iterator_params.bdl_wire_params.bdl_pairs_params)},
             bii{initialize_bii ? bdl_input_iterator{lyt, params.input_bdl_iterator_params, input_wires} :
@@ -271,7 +298,7 @@ class is_operational_impl
                         const std::vector<bdl_wire>& output_wires, layout c_lyt) :
             sidb_layout{lyt},
             truth_table{spec},
-            parameters{params},
+            parameters{checked_parameters(params)},
             output_bdl_pairs{detect_bdl_pairs(lyt, dot_tag::OUTPUT,
                                               params.input_bdl_iterator_params.bdl_wire_params.bdl_pairs_params)},
             bii{lyt, params.input_bdl_iterator_params, input_wires},
@@ -291,7 +318,7 @@ class is_operational_impl
                         const is_operational_params& params, layout c_lyt) :
             sidb_layout{lyt},
             truth_table{spec},
-            parameters{params},
+            parameters{checked_parameters(params)},
             output_bdl_pairs{detect_bdl_pairs(lyt, dot_tag::OUTPUT,
                                               params.input_bdl_iterator_params.bdl_wire_params.bdl_pairs_params)},
             bii{lyt, params.input_bdl_iterator_params},
@@ -316,7 +343,7 @@ class is_operational_impl
                         const std::vector<bdl_wire>& input_wires, const std::vector<bdl_wire>& output_wires,
                         layout c_lyt) :
             truth_table{spec},
-            parameters{params},
+            parameters{checked_parameters(params)},
             output_bdl_pairs{detect_bdl_pairs(input_pattern_lyts.front(), dot_tag::OUTPUT,
                                               params.input_bdl_iterator_params.bdl_wire_params.bdl_pairs_params)},
             // the input pattern layouts make the iterator redundant
@@ -335,6 +362,7 @@ class is_operational_impl
      */
     [[nodiscard]] std::optional<layout_invalidity_reason> is_layout_invalid(const uint64_t input_pattern)
     {
+        utils::check_deadline(parameters.deadline);
         if (!has_valid_bdl_configuration())
         {
             return layout_invalidity_reason::IO_INSTABILITY;
@@ -344,8 +372,11 @@ class is_operational_impl
 
         const potential_landscape land{lyt_with_input_pattern, parameters.sim_params};
 
+        utils::check_deadline(parameters.deadline);
+
         if (parameters.sim_params.base == 2 && analysis::can_positive_charges_occur(land))
         {
+            utils::check_deadline(parameters.deadline);
             return layout_invalidity_reason::POTENTIAL_POSITIVE_CHARGES;
         }
 
@@ -365,6 +396,7 @@ class is_operational_impl
             return std::nullopt;
         }
 
+        utils::check_deadline(parameters.deadline);
         return layout_invalidity_reason::PHYSICAL_INFEASIBILITY;
     }
     /**
@@ -374,6 +406,7 @@ class is_operational_impl
      */
     [[nodiscard]] std::pair<operational_status, non_operationality_reason> run()
     {
+        utils::check_deadline(parameters.deadline);
         if (parameters.sim_engine == engine::QUICKSIM && sidb_layout.num_charged_defects() > 0)
         {
             throw std::invalid_argument("QuickSim does not support charged defects");
@@ -387,6 +420,7 @@ class is_operational_impl
         {
             for (auto i = 0u; i < truth_table.front().num_bits(); ++i)
             {
+                utils::check_deadline(parameters.deadline);
                 if (is_layout_invalid(i))
                 {
                     return {operational_status::NON_OPERATIONAL, non_operationality_reason::LOGIC_MISMATCH};
@@ -400,6 +434,7 @@ class is_operational_impl
                 is_operational_params::operational_analysis_strategy::FILTER_ONLY &&
             canvas_filtering_applicable)
         {
+            utils::check_deadline(parameters.deadline);
             return {operational_status::OPERATIONAL, non_operationality_reason::NONE};
         }
 
@@ -411,12 +446,14 @@ class is_operational_impl
         {
             for (auto i = 0u; i < truth_table.front().num_bits(); ++i)
             {
+                utils::check_deadline(parameters.deadline);
                 const auto& lyt_with_input_pattern = layout_with_input_pattern(i);
 
                 // if positively charged SiDBs can occur, the SiDB layout is considered non-operational
                 if (parameters.sim_params.base == 2 &&
                     analysis::can_positive_charges_occur(lyt_with_input_pattern, parameters.sim_params))
                 {
+                    utils::check_deadline(parameters.deadline);
                     return {operational_status::NON_OPERATIONAL, non_operationality_reason::POTENTIAL_POSITIVE_CHARGES};
                 }
 
@@ -432,7 +469,10 @@ class is_operational_impl
 
                 for (const auto& gs : simulation_results.groundstates())
                 {
+                    utils::check_deadline(parameters.deadline);
                     const auto [op_status, non_op_reason] = verify_logic_match_of_cd(gs, i);
+
+                    utils::check_deadline(parameters.deadline);
 
                     if (op_status == operational_status::NON_OPERATIONAL &&
                         non_op_reason == non_operationality_reason::LOGIC_MISMATCH)
@@ -449,6 +489,7 @@ class is_operational_impl
             }
         }
 
+        utils::check_deadline(parameters.deadline);
         return {operational_status::OPERATIONAL, non_operationality_reason::NONE};
     }
     /**
@@ -515,12 +556,14 @@ class is_operational_impl
     [[nodiscard]] std::vector<std::pair<uint64_t, non_operationality_reason>>
     determine_non_operational_input_patterns_and_non_operationality_reason()
     {
+        utils::check_deadline(parameters.deadline);
         std::vector<std::pair<uint64_t, non_operationality_reason>> non_operational{};
 
         if (!has_valid_bdl_configuration())
         {
             for (uint64_t i = 0; i < truth_table.front().num_bits(); ++i)
             {
+                utils::check_deadline(parameters.deadline);
                 non_operational.emplace_back(i, non_operationality_reason::LOGIC_MISMATCH);
             }
 
@@ -529,6 +572,7 @@ class is_operational_impl
 
         for (auto i = 0u; i < truth_table.front().num_bits(); ++i)
         {
+            utils::check_deadline(parameters.deadline);
             ++simulator_invocations;
 
             const auto& lyt_with_input_pattern = layout_with_input_pattern(i);
@@ -549,6 +593,7 @@ class is_operational_impl
 
             for (const auto& gs : simulation_results.groundstates())
             {
+                utils::check_deadline(parameters.deadline);
                 const auto [op_status, non_op_reason] = verify_logic_match_of_cd(gs, i);
 
                 if (op_status == operational_status::NON_OPERATIONAL)
@@ -558,6 +603,7 @@ class is_operational_impl
             }
         }
 
+        utils::check_deadline(parameters.deadline);
         return non_operational;
     }
     /**
@@ -579,6 +625,7 @@ class is_operational_impl
      */
     [[nodiscard]] std::optional<double> is_physical_validity_feasible(simulation::detail::simulation_state& state)
     {
+        utils::check_deadline(parameters.deadline);
         assert(!canvas_lyt.is_empty() && "The canvas layout must not be empty.");
 
         const auto& lyt = state.landscape().get_layout();
@@ -606,6 +653,7 @@ class is_operational_impl
 
         for (uint64_t canvas_index = 0;; ++canvas_index)
         {
+            utils::check_deadline(parameters.deadline);
             for (std::size_t j = 0; j < num_free; ++j)
             {
                 state.assign_charge_state_by_index(canvas[j + 1],
@@ -634,6 +682,7 @@ class is_operational_impl
             }
         }
 
+        utils::check_deadline(parameters.deadline);
         if (std::isinf(min_energy))
         {
             return std::nullopt;
@@ -741,6 +790,7 @@ class is_operational_impl
         {
             for (uint64_t output_wire_index = 0; output_wire_index < max_output_pattern_index; ++output_wire_index)
             {
+                utils::check_deadline(parameters.deadline);
                 if (output_wire_index == logical_correct_output_pattern && kink_states_input == input_pattern)
                 {
                     continue;
@@ -758,6 +808,7 @@ class is_operational_impl
             }
         }
 
+        utils::check_deadline(parameters.deadline);
         return false;
     }
 
@@ -864,15 +915,18 @@ class is_operational_impl
      */
     [[nodiscard]] result physical_simulation_of_layout(const layout& lyt_with_input_pattern) const
     {
+        utils::check_deadline(parameters.deadline);
         if (parameters.sim_engine == engine::EXGS)
         {
-            return engines::exhaustive_ground_state_simulation(lyt_with_input_pattern, parameters.sim_params);
+            return engines::exhaustive_ground_state_simulation(lyt_with_input_pattern, parameters.sim_params,
+                                                               parameters.deadline);
         }
         if (parameters.sim_engine == engine::QUICKEXACT)
         {
             const engines::quickexact_params qe_params{
                 .sim_params            = parameters.sim_params,
-                .base_number_detection = engines::quickexact_params::automatic_base_number_detection::OFF};
+                .base_number_detection = engines::quickexact_params::automatic_base_number_detection::OFF,
+                .deadline              = parameters.deadline};
 
             return engines::quickexact(lyt_with_input_pattern, qe_params);
         }
@@ -890,7 +944,8 @@ class is_operational_impl
 
             const engines::quicksim_params qs_params{.sim_params      = parameters.sim_params,
                                                      .iteration_steps = 500,
-                                                     .alpha           = 0.6};
+                                                     .alpha           = 0.6,
+                                                     .deadline        = parameters.deadline};
 
             if (const auto qs_result = engines::quicksim(lyt_with_input_pattern, qs_params); qs_result.has_value())
             {

--- a/include/fiction/technology/sidb/simulation/logic/is_operational.hpp
+++ b/include/fiction/technology/sidb/simulation/logic/is_operational.hpp
@@ -175,7 +175,7 @@ namespace detail
  * @throws utils::timeout_error if the deadline expires.
  * @throws std::invalid_argument if ClusterComplete is selected with a finite deadline.
  */
-[[nodiscard]] inline const is_operational_params& checked_parameters(const is_operational_params& params)
+[[nodiscard]] inline is_operational_params checked_parameters(const is_operational_params& params)
 {
     utils::check_deadline(params.deadline);
 #if (FICTION_ALGLIB_ENABLED)
@@ -824,7 +824,7 @@ class is_operational_impl
     /**
      * Parameters.
      */
-    const is_operational_params& parameters;
+    const is_operational_params parameters;
     /**
      * The output BDL pairs.
      */

--- a/include/fiction/utils/execution_timeout.hpp
+++ b/include/fiction/utils/execution_timeout.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 - 2023 Marcel Walter
+ * Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/**
+ * @file
+ * @brief Shared monotonic deadlines for nested algorithms.
+ * @author Simon Hofmann (simon1hofmann)
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace fiction::utils
+{
+
+/**
+ * An algorithm reached its execution deadline without producing a complete result.
+ */
+class timeout_error : public std::runtime_error
+{
+  public:
+    /**
+     * @brief Constructs an execution-timeout error.
+     */
+    timeout_error() : std::runtime_error{"Execution deadline exceeded"} {}
+};
+
+/**
+ * @brief Starts a millisecond budget without extending an enclosing deadline.
+ *
+ * @param timeout Milliseconds from now; the maximum value means unlimited.
+ * @param enclosing Deadline shared with an enclosing algorithm.
+ * @return The earlier deadline, saturated at the clock's maximum time point.
+ */
+[[nodiscard]] inline std::chrono::steady_clock::time_point
+make_deadline(const uint64_t                              timeout,
+              const std::chrono::steady_clock::time_point enclosing = std::chrono::steady_clock::time_point::max())
+{
+    if (timeout == std::numeric_limits<uint64_t>::max())
+    {
+        return enclosing;
+    }
+    const auto maximum =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::duration::max());
+    if (std::cmp_greater(timeout, maximum.count()))
+    {
+        return enclosing;
+    }
+    const auto budget =
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::milliseconds{timeout});
+    const auto now = std::chrono::steady_clock::now();
+    if (now > std::chrono::steady_clock::time_point::max() - budget)
+    {
+        return enclosing;
+    }
+    return std::min(enclosing, now + budget);
+}
+
+/**
+ * @brief Checks a shared monotonic deadline.
+ *
+ * @param deadline Expiration time; the maximum time point means unlimited.
+ * @throws timeout_error if the deadline has been reached.
+ */
+inline void check_deadline(const std::chrono::steady_clock::time_point deadline)
+{
+    if (deadline != std::chrono::steady_clock::time_point::max() && std::chrono::steady_clock::now() >= deadline)
+    {
+        throw timeout_error{};
+    }
+}
+
+}  // namespace fiction::utils

--- a/include/fiction/utils/math/combination_utils.hpp
+++ b/include/fiction/utils/math/combination_utils.hpp
@@ -17,8 +17,10 @@
 
 #pragma once
 
+#include "fiction/utils/execution_timeout.hpp"
 #include "fiction/utils/math/math_utils.hpp"
 
+#include <chrono>
 #include <cstddef>
 #include <numeric>
 #include <stdexcept>
@@ -36,13 +38,18 @@ namespace fiction::utils::math
  *
  * @param k The number of entities to distribute.
  * @param n The number of positions available for distribution.
+ * @param deadline Shared execution deadline; unlimited by default.
  * @return A vector of vectors representing all possible combinations of
  *         distributing k entities on n positions.
  * @throws std::length_error if the number of combinations exceeds the vector's capacity.
+ * @throws timeout_error if the deadline is reached during enumeration.
  */
 [[nodiscard]] inline std::vector<std::vector<std::size_t>>
-determine_all_combinations_of_distributing_k_entities_on_n_positions(const std::size_t k, const std::size_t n)
+determine_all_combinations_of_distributing_k_entities_on_n_positions(
+    const std::size_t k, const std::size_t n,
+    const std::chrono::steady_clock::time_point deadline = std::chrono::steady_clock::time_point::max())
 {
+    check_deadline(deadline);
     // Handle a special case
     if (k > n)
     {
@@ -61,15 +68,20 @@ determine_all_combinations_of_distributing_k_entities_on_n_positions(const std::
     {
         throw std::length_error{"number of combinations exceeds vector capacity"};
     }
-    all_combinations.reserve(static_cast<std::size_t>(number_of_combinations));
+    // A bounded search grows on demand instead of allocating the full search space before its deadline checks.
+    if (deadline == std::chrono::steady_clock::time_point::max())
+    {
+        all_combinations.reserve(static_cast<std::size_t>(number_of_combinations));
+    }
 
     std::vector<std::size_t> numbers(n);
     std::iota(numbers.begin(), numbers.end(), 0);
 
     combinations::for_each_combination(
         numbers.begin(), numbers.begin() + static_cast<std::vector<std::size_t>::difference_type>(k), numbers.end(),
-        [&k, &all_combinations](const auto begin, const auto end)
+        [&k, &all_combinations, deadline](const auto begin, const auto end)
         {
+            check_deadline(deadline);
             std::vector<std::size_t> combination{};
             combination.reserve(k);
 
@@ -83,6 +95,7 @@ determine_all_combinations_of_distributing_k_entities_on_n_positions(const std::
             return false;  // keep looping
         });
 
+    check_deadline(deadline);
     return all_combinations;
 }
 

--- a/test/technology/sidb/generators/test_design_gates.cpp
+++ b/test/technology/sidb/generators/test_design_gates.cpp
@@ -33,9 +33,11 @@
 #include <fiction/technology/sidb/simulation/logic/is_operational.hpp>
 #include <fiction/technology/sidb/technology.hpp>
 #include <fiction/types.hpp>
+#include <fiction/utils/execution_timeout.hpp>
 
 #include <mockturtle/utils/stopwatch.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <stdexcept>
 #include <thread>
@@ -76,6 +78,36 @@ TEST_CASE("Gate design propagates worker failures", "[design-sidb-gates]")
 TEST_CASE("Reject an empty gate specification", "[design-sidb-gates]")
 {
     CHECK_THROWS_AS(design_gates(layout{}, std::vector<tt>{}), std::invalid_argument);
+}
+
+TEST_CASE("Gate-design timeouts cover every search mode", "[design-sidb-gates]")
+{
+    const auto lyt = blueprints::two_input_one_output_skeleton_west_west();
+
+    design_gates_params params{};
+
+    SECTION("Zero expires immediately")
+    {
+        params.timeout = 0;
+    }
+    SECTION("A positive budget covers canvas enumeration")
+    {
+        params.timeout                = 1;
+        params.canvas                 = {site_at_row(0, 0), site_at_row(1'000, 1'000)};
+        params.number_of_canvas_sidbs = 0;
+    }
+
+    for (const auto mode :
+         {design_gates_params::design_gates_mode::QUICKCELL,
+          design_gates_params::design_gates_mode::AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER,
+          design_gates_params::design_gates_mode::RANDOM, design_gates_params::design_gates_mode::PRUNING_ONLY})
+    {
+        CAPTURE(mode);
+        params.design_mode = mode;
+        const auto start   = std::chrono::steady_clock::now();
+        CHECK_THROWS_AS(design_gates(lyt, std::vector{create_and_tt()}, params), utils::timeout_error);
+        CHECK(std::chrono::steady_clock::now() - start < std::chrono::seconds{10});
+    }
 }
 
 TEST_CASE("Design AND gate with skeleton, where one input wire and the output wire are orientated to the east.",

--- a/test/technology/sidb/generators/test_design_gates.cpp
+++ b/test/technology/sidb/generators/test_design_gates.cpp
@@ -17,6 +17,7 @@
  * @author Benjamin Hien (hibenj)
  */
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "utils/blueprints/layout_blueprints.hpp"

--- a/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
+++ b/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
@@ -18,11 +18,16 @@
 
 #include <fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp>
 #include <fiction/types.hpp>
+#include <fiction/utils/execution_timeout.hpp>
 
 #include <array>
+#include <chrono>
+#include <cstdint>
+#include <limits>
 #include <string_view>
 
 using namespace fiction;
+using namespace fiction::sidb;
 using namespace fiction::sidb::generators;
 
 TEST_CASE("Circuit design deduces the gate layout type", "[on-the-fly-circuit-design]")
@@ -34,6 +39,43 @@ TEST_CASE("Circuit design deduces the gate layout type", "[on-the-fly-circuit-de
     params.sidb_on_the_fly_gate_library_parameters.design_gate_params.number_of_canvas_sidbs = 0;
 
     CHECK_THROWS_AS(on_the_fly_circuit_design(gate_layout, params), unsuccessful_gate_design_error);
+}
+
+TEST_CASE("Circuit design honors both circuit and gate timeouts", "[on-the-fly-circuit-design]")
+{
+    hex_even_row_gate_clk_lyt gate_layout{{2, 2}};
+    const auto                first  = gate_layout.create_pi("a", {0, 0});
+    const auto                second = gate_layout.create_pi("b", {1, 0});
+    const auto                gate   = gate_layout.create_and(first, second, {1, 1});
+    gate_layout.create_po(gate, "f", {0, 2});
+
+    on_the_fly_circuit_design_params params{};
+    auto&                            gates = params.sidb_on_the_fly_gate_library_parameters.design_gate_params;
+    CHECK(params.timeout == std::numeric_limits<uint64_t>::max());
+    CHECK(gates.timeout == std::numeric_limits<uint64_t>::max());
+
+    SECTION("Zero circuit budget expires with unlimited gate budgets")
+    {
+        params.timeout = 0;
+    }
+    SECTION("Zero gate budget expires within a positive circuit budget")
+    {
+        params.timeout = 10'000;
+        gates.timeout  = 0;
+    }
+    SECTION("Unlimited gate budgets cannot override a finite circuit budget")
+    {
+        params.timeout               = 1;
+        gates.canvas                 = {site_at_row(0, 0), site_at_row(1'000, 1'000)};
+        gates.number_of_canvas_sidbs = 0;
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    CHECK_THROWS_AS(on_the_fly_circuit_design(gate_layout, params), utils::timeout_error);
+    CHECK(std::chrono::steady_clock::now() - start < std::chrono::seconds{10});
+    CHECK(gate_layout.num_pis() == 2);
+    CHECK(gate_layout.num_pos() == 1);
+    CHECK(gate_layout.is_and(gate_layout.get_node({1, 1})));
 }
 
 TEMPLATE_TEST_CASE("Circuit-design exceptions copy the supplied message view", "[on-the-fly-circuit-design]",

--- a/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
+++ b/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
@@ -97,8 +97,8 @@ TEST_CASE("Defect-aware circuit design propagates gate timeouts", "[on-the-fly-c
 
     on_the_fly_circuit_design_on_defective_surface_params params{};
     params.exact_design_parameters.scheme                                     = "Row";
-    params.exact_design_parameters.upper_bound_x                              = 2;
-    params.exact_design_parameters.upper_bound_y                              = 2;
+    params.exact_design_parameters.upper_bound_x                              = 3;
+    params.exact_design_parameters.upper_bound_y                              = 3;
     params.exact_design_parameters.fixed_size                                 = true;
     params.exact_design_parameters.timeout                                    = 10'000;
     params.sidb_on_the_fly_gate_library_parameters.design_gate_params.timeout = 0;

--- a/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
+++ b/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
@@ -11,6 +11,8 @@
 /**
  * @file
  * @brief Tests for SiDB circuit design and bounded exception messages.
+ * @author Marcel Walter (marcelwa)
+ * @author Simon Hofmann (simon1hofmann)
  */
 
 #include <catch2/catch_template_test_macros.hpp>
@@ -18,6 +20,8 @@
 
 #include <fiction/layouts/clocking_scheme.hpp>
 #include <fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp>
+#include <fiction/technology/sidb/lattice.hpp>
+#include <fiction/technology/sidb/layout.hpp>
 #include <fiction/types.hpp>
 #include <fiction/utils/execution_timeout.hpp>
 

--- a/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
+++ b/test/technology/sidb/generators/test_on_the_fly_circuit_design.cpp
@@ -16,6 +16,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <fiction/layouts/clocking_scheme.hpp>
 #include <fiction/technology/sidb/generators/on_the_fly_circuit_design.hpp>
 #include <fiction/types.hpp>
 #include <fiction/utils/execution_timeout.hpp>
@@ -26,7 +27,12 @@
 #include <limits>
 #include <string_view>
 
+#if (FICTION_Z3_SOLVER)
+#include <mockturtle/networks/aig.hpp>
+#endif
+
 using namespace fiction;
+using namespace fiction::layouts;
 using namespace fiction::sidb;
 using namespace fiction::sidb::generators;
 
@@ -43,7 +49,7 @@ TEST_CASE("Circuit design deduces the gate layout type", "[on-the-fly-circuit-de
 
 TEST_CASE("Circuit design honors both circuit and gate timeouts", "[on-the-fly-circuit-design]")
 {
-    hex_even_row_gate_clk_lyt gate_layout{{2, 2}};
+    hex_even_row_gate_clk_lyt gate_layout{{2, 2}, clocking::row<hex_even_row_gate_clk_lyt>()};
     const auto                first  = gate_layout.create_pi("a", {0, 0});
     const auto                second = gate_layout.create_pi("b", {1, 0});
     const auto                gate   = gate_layout.create_and(first, second, {1, 1});
@@ -77,6 +83,30 @@ TEST_CASE("Circuit design honors both circuit and gate timeouts", "[on-the-fly-c
     CHECK(gate_layout.num_pos() == 1);
     CHECK(gate_layout.is_and(gate_layout.get_node({1, 1})));
 }
+
+#if (FICTION_Z3_SOLVER)
+TEST_CASE("Defect-aware circuit design propagates gate timeouts", "[on-the-fly-circuit-design]")
+{
+    mockturtle::aig_network network{};
+    const auto              first  = network.create_pi();
+    const auto              second = network.create_pi();
+    network.create_po(network.create_and(first, second));
+
+    const hex_even_row_gate_clk_lyt tiling{{2, 2}, clocking::row<hex_even_row_gate_clk_lyt>()};
+    const sidb::layout              surface{};
+
+    on_the_fly_circuit_design_on_defective_surface_params params{};
+    params.exact_design_parameters.scheme                                     = "Row";
+    params.exact_design_parameters.upper_bound_x                              = 2;
+    params.exact_design_parameters.upper_bound_y                              = 2;
+    params.exact_design_parameters.fixed_size                                 = true;
+    params.exact_design_parameters.timeout                                    = 10'000;
+    params.sidb_on_the_fly_gate_library_parameters.design_gate_params.timeout = 0;
+
+    CHECK_THROWS_AS(on_the_fly_circuit_design_on_defective_surface(network, tiling, surface, params),
+                    utils::timeout_error);
+}
+#endif
 
 TEMPLATE_TEST_CASE("Circuit-design exceptions copy the supplied message view", "[on-the-fly-circuit-design]",
                    unsuccessful_pr_error, unsuccessful_gate_design_error)

--- a/test/technology/sidb/simulation/engines/test_exhaustive_ground_state_simulation.cpp
+++ b/test/technology/sidb/simulation/engines/test_exhaustive_ground_state_simulation.cpp
@@ -28,13 +28,36 @@
 #include <fiction/technology/sidb/model/simulation_parameters.hpp>
 #include <fiction/technology/sidb/simulation/engines/exhaustive_ground_state_simulation.hpp>
 #include <fiction/technology/sidb/technology.hpp>
+#include <fiction/utils/execution_timeout.hpp>
 #include <fiction/utils/math/math_utils.hpp>
+
+#include <chrono>
+#include <cstdint>
 
 using namespace fiction;
 using namespace fiction::sidb;
 using namespace fiction::sidb::model;
 using namespace fiction::sidb::simulation::engines;
 using namespace fiction::utils::math;
+
+TEST_CASE("ExGS rejects incomplete simulations after the caller deadline", "[exhaustive-ground-state-simulation]")
+{
+    layout lyt{};
+    auto   deadline = std::chrono::steady_clock::now();
+
+    SECTION("Already expired") {}
+    SECTION("Expires while enumerating")
+    {
+        for (int64_t i = 0; i < 20; ++i)
+        {
+            lyt.assign_sidb({i, 0, 0}, dot_tag::NORMAL);
+        }
+        deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds{1};
+    }
+
+    CHECK_THROWS_AS(exhaustive_ground_state_simulation(lyt, simulation_parameters{2, -0.32}, deadline),
+                    utils::timeout_error);
+}
 
 TEST_CASE("Empty layout ExGS simulation", "[exhaustive-ground-state-simulation]")
 {

--- a/test/technology/sidb/simulation/engines/test_exhaustive_ground_state_simulation.cpp
+++ b/test/technology/sidb/simulation/engines/test_exhaustive_ground_state_simulation.cpp
@@ -43,9 +43,12 @@ using namespace fiction::utils::math;
 TEST_CASE("ExGS rejects incomplete simulations after the caller deadline", "[exhaustive-ground-state-simulation]")
 {
     layout lyt{};
-    auto   deadline = std::chrono::steady_clock::now();
+    auto   deadline = std::chrono::steady_clock::time_point::max();
 
-    SECTION("Already expired") {}
+    SECTION("Already expired")
+    {
+        deadline = std::chrono::steady_clock::now();
+    }
     SECTION("Expires while enumerating")
     {
         for (int32_t i = 0; i < 20; ++i)

--- a/test/technology/sidb/simulation/engines/test_exhaustive_ground_state_simulation.cpp
+++ b/test/technology/sidb/simulation/engines/test_exhaustive_ground_state_simulation.cpp
@@ -48,7 +48,7 @@ TEST_CASE("ExGS rejects incomplete simulations after the caller deadline", "[exh
     SECTION("Already expired") {}
     SECTION("Expires while enumerating")
     {
-        for (int64_t i = 0; i < 20; ++i)
+        for (int32_t i = 0; i < 20; ++i)
         {
             lyt.assign_sidb({i, 0, 0}, dot_tag::NORMAL);
         }

--- a/test/technology/sidb/simulation/engines/test_quickexact.cpp
+++ b/test/technology/sidb/simulation/engines/test_quickexact.cpp
@@ -60,7 +60,7 @@ TEST_CASE("QuickExact rejects incomplete simulations after the caller deadline",
     }
     SECTION("Expires while enumerating")
     {
-        for (int64_t i = 0; i < 20; ++i)
+        for (int32_t i = 0; i < 20; ++i)
         {
             lyt.assign_sidb({i, 0, 0}, dot_tag::NORMAL);
         }

--- a/test/technology/sidb/simulation/engines/test_quickexact.cpp
+++ b/test/technology/sidb/simulation/engines/test_quickexact.cpp
@@ -31,10 +31,12 @@
 #include <fiction/technology/sidb/simulation/engines/quickexact.hpp>
 #include <fiction/technology/sidb/simulation/result.hpp>
 #include <fiction/technology/sidb/technology.hpp>
+#include <fiction/utils/execution_timeout.hpp>
 #include <fiction/utils/math/math_utils.hpp>
 
 #include <algorithm>
 #include <any>
+#include <chrono>
 #include <cstdint>
 #include <set>
 #include <stdexcept>
@@ -45,6 +47,28 @@ using namespace fiction::sidb::model;
 using namespace fiction::sidb::simulation;
 using namespace fiction::sidb::simulation::engines;
 using namespace fiction::utils::math;
+
+TEST_CASE("QuickExact rejects incomplete simulations after the caller deadline", "[quickexact]")
+{
+    layout            lyt{};
+    quickexact_params params{.sim_params            = simulation_parameters{2, -0.32},
+                             .base_number_detection = quickexact_params::automatic_base_number_detection::OFF};
+
+    SECTION("Already expired")
+    {
+        params.deadline = std::chrono::steady_clock::now();
+    }
+    SECTION("Expires while enumerating")
+    {
+        for (int64_t i = 0; i < 20; ++i)
+        {
+            lyt.assign_sidb({i, 0, 0}, dot_tag::NORMAL);
+        }
+        params.deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds{1};
+    }
+
+    CHECK_THROWS_AS(quickexact(lyt, params), utils::timeout_error);
+}
 
 TEST_CASE("Empty layout QuickExact simulation", "[quickexact]")
 {

--- a/test/technology/sidb/simulation/engines/test_quicksim.cpp
+++ b/test/technology/sidb/simulation/engines/test_quicksim.cpp
@@ -28,8 +28,10 @@
 #include <fiction/technology/sidb/simulation/engines/quicksim.hpp>
 #include <fiction/technology/sidb/simulation/result.hpp>
 #include <fiction/technology/sidb/technology.hpp>
+#include <fiction/utils/execution_timeout.hpp>
 #include <fiction/utils/math/math_utils.hpp>
 
+#include <chrono>
 #include <optional>
 #include <stdexcept>
 
@@ -40,6 +42,26 @@ using namespace fiction::sidb::simulation;
 using namespace fiction::sidb::simulation::analysis;
 using namespace fiction::sidb::simulation::engines;
 using namespace fiction::utils::math;
+
+TEST_CASE("QuickSim joins its workers before reporting the caller deadline", "[quicksim]")
+{
+    layout lyt{};
+    lyt.assign_sidb({0, 0, 0}, dot_tag::NORMAL);
+    lyt.assign_sidb({1, 0, 0}, dot_tag::NORMAL);
+    lyt.assign_sidb({2, 0, 0}, dot_tag::NORMAL);
+    quicksim_params params{.iteration_steps = 1'000'000, .number_threads = 2, .timeout = 1000};
+
+    SECTION("Already expired")
+    {
+        params.deadline = std::chrono::steady_clock::now();
+    }
+    SECTION("Expires while workers search")
+    {
+        params.deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds{1};
+    }
+
+    CHECK_THROWS_AS(quicksim(lyt, params), utils::timeout_error);
+}
 
 /**
  * @brief Returns the result contained in a successful QuickSim invocation.

--- a/test/technology/sidb/simulation/logic/test_is_operational.cpp
+++ b/test/technology/sidb/simulation/logic/test_is_operational.cpp
@@ -34,7 +34,9 @@
 #include <fiction/technology/sidb/simulation/potential_landscape.hpp>
 #include <fiction/technology/sidb/technology.hpp>
 #include <fiction/types.hpp>
+#include <fiction/utils/execution_timeout.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <set>
@@ -47,6 +49,25 @@ using namespace fiction::sidb::model;
 using namespace fiction::sidb::simulation;
 using namespace fiction::sidb::simulation::logic;
 using namespace fiction::synthesis;
+
+TEST_CASE("Operational checks honor a shared caller deadline", "[is-operational]")
+{
+    const auto lyt = blueprints::siqad_or_gate();
+
+    for (const auto sim_engine : {engine::QUICKEXACT, engine::EXGS, engine::QUICKSIM})
+    {
+        const is_operational_params params{.sim_params = simulation_parameters{2, -0.32},
+                                           .sim_engine = sim_engine,
+                                           .deadline   = std::chrono::steady_clock::now()};
+        CHECK_THROWS_AS(is_operational(lyt, {create_or_tt()}, params), utils::timeout_error);
+    }
+
+#if (FICTION_ALGLIB_ENABLED)
+    const is_operational_params params{.sim_engine = engine::CLUSTERCOMPLETE,
+                                       .deadline   = std::chrono::steady_clock::now() + std::chrono::hours{1}};
+    CHECK_THROWS_AS(is_operational(lyt, {create_or_tt()}, params), std::invalid_argument);
+#endif  // FICTION_ALGLIB_ENABLED
+}
 
 TEST_CASE("SiQAD OR gate", "[is-operational]")
 {

--- a/test/technology/sidb/simulation/logic/test_is_operational.cpp
+++ b/test/technology/sidb/simulation/logic/test_is_operational.cpp
@@ -183,13 +183,14 @@ TEST_CASE("Incomplete BDL wire set is non-operational", "[is-operational]")
 TEST_CASE("Canvas filtering rejects SiDBs outside the simulation state", "[is-operational]")
 {
     const auto                  lyt = blueprints::siqad_or_gate();
+    const std::vector<tt>       spec{create_or_tt()};
     const is_operational_params params{};
     layout                      canvas{};
     canvas.assign_sidb({1000, 0, 0}, dot_tag::LOGIC);
 
     const potential_landscape                            landscape{lyt, params.sim_params};
     sidb::simulation::detail::simulation_state           state{landscape, charge_state::NEGATIVE};
-    sidb::simulation::logic::detail::is_operational_impl implementation{lyt, {create_or_tt()}, params, canvas};
+    sidb::simulation::logic::detail::is_operational_impl implementation{lyt, spec, params, canvas};
 
     CHECK_THROWS_AS(implementation.is_physical_validity_feasible(state), std::invalid_argument);
 }

--- a/test/technology/sidb/simulation/logic/test_is_operational.cpp
+++ b/test/technology/sidb/simulation/logic/test_is_operational.cpp
@@ -14,6 +14,7 @@
  * @author Jan Drewniok (Drewniok)
  * @author Willem Lambooy (wlambooy)
  * @author Marcel Walter (marcelwa)
+ * @author Simon Hofmann (simon1hofmann)
  */
 
 #include <catch2/catch_test_macros.hpp>
@@ -67,6 +68,17 @@ TEST_CASE("Operational checks honor a shared caller deadline", "[is-operational]
                                        .deadline   = std::chrono::steady_clock::now() + std::chrono::hours{1}};
     CHECK_THROWS_AS(is_operational(lyt, {create_or_tt()}, params), std::invalid_argument);
 #endif  // FICTION_ALGLIB_ENABLED
+}
+
+TEST_CASE("Operational checks retain their validated parameters", "[is-operational]")
+{
+    const auto                                           lyt = blueprints::siqad_or_gate();
+    const std::vector<tt>                                spec{create_or_tt()};
+    is_operational_params                                params{.sim_params = simulation_parameters{2, -0.32}};
+    sidb::simulation::logic::detail::is_operational_impl implementation{lyt, spec, params};
+
+    params.deadline = std::chrono::steady_clock::now();
+    CHECK_NOTHROW(implementation.run());
 }
 
 TEST_CASE("SiQAD OR gate", "[is-operational]")

--- a/test/utils/test_execution_timeout.cpp
+++ b/test/utils/test_execution_timeout.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 - 2023 Marcel Walter
+ * Copyright (c) 2023 - present Chair for Design Automation, Technical University of Munich
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+/**
+ * @file
+ * @brief Tests shared execution deadlines and overflow-safe millisecond budgets.
+ * @author Simon Hofmann (simon1hofmann)
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <fiction/utils/execution_timeout.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <limits>
+
+using namespace fiction;
+using namespace fiction::utils;
+
+TEST_CASE("Execution deadlines preserve enclosing budgets", "[execution-timeout]")
+{
+    const auto unlimited = std::numeric_limits<uint64_t>::max();
+    const auto distant   = std::chrono::steady_clock::time_point::max();
+    CHECK(make_deadline(unlimited) == distant);
+    CHECK(make_deadline(unlimited - 1) == distant);
+    CHECK_NOTHROW(check_deadline(distant));
+
+    const auto expired = std::chrono::steady_clock::now();
+    CHECK(make_deadline(unlimited, expired) == expired);
+    CHECK(make_deadline(unlimited - 1, expired) == expired);
+    CHECK(make_deadline(1000, expired) == expired);
+    CHECK_THROWS_AS(check_deadline(expired), timeout_error);
+    CHECK_THROWS_AS(check_deadline(make_deadline(0)), timeout_error);
+
+    const auto start    = std::chrono::steady_clock::now();
+    const auto deadline = make_deadline(1000);
+    CHECK(deadline >= start + std::chrono::milliseconds{1000});
+    CHECK(deadline <= std::chrono::steady_clock::now() + std::chrono::milliseconds{1000});
+}


### PR DESCRIPTION
## Description

SiDB gate and circuit design need a shared time budget so a long search can stop without returning an incomplete layout. This adds optional millisecond timeouts with unlimited defaults, raises Python's built-in `TimeoutError`, and keeps one deadline across every circuit gate. Cancellation is cooperative; finite budgets support QuickExact, ExGS, and QuickSim, but not ClusterComplete, so applications should retain a process-level hard cutoff.

Local validation: all 360 Python tests, seven targeted C++ test executables, and `prek run -a` pass.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have added a changelog entry.
- [x] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.

Implemented and drafted with AI assistance (GPT-5 via Codex); validation was run by the agent. Human review is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable cooperative timeouts for SiDB gate design, circuit design, simulation, and operational checks.
  * Python users can set millisecond timeouts; expired operations raise `TimeoutError`.
  * Timed-out operations do not return partial circuits, layouts, statistics, or simulation results.
  * Circuit-wide and per-gate budgets are supported, with invalid values rejected.
  * Gate design releases the Python GIL during execution.

* **Documentation**
  * Documented timeout behavior, supported algorithms, defaults, exceptions, and usage examples.

* **Bug Fixes**
  * Improved Python statistics handling.
  * Fixed ClangCL test builds affected by precompiled headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
